### PR TITLE
REFACTOR: Apply move method to increase the incapsulation of CouponBundl...

### DIFF
--- a/src/Elcodi/CouponBundle/Entity/Coupon.php
+++ b/src/Elcodi/CouponBundle/Entity/Coupon.php
@@ -404,4 +404,18 @@ class Coupon extends AbstractEntity implements CouponInterface
     {
         return $this->getName();
     }
+
+
+    public function incrementUsages()
+    {
+        $this->used++;
+
+        if ($this->count <= $this->used) {
+            $this->enabled = false;
+        }
+        return $this;
+    }
+
+
+
 }

--- a/src/Elcodi/CouponBundle/EventListener/CouponEventListener.php
+++ b/src/Elcodi/CouponBundle/EventListener/CouponEventListener.php
@@ -23,7 +23,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 /**
  * Class CouponEventListener
  */
-class CouponEventListene
+class CouponEventListener
 {
     /**
      * @var ObjectManager
@@ -55,17 +55,7 @@ class CouponEventListene
     public function onCouponUsedEvent(CouponOnUsedEvent $event)
     {
         $coupon = $event->getCoupon();
-        $count = $coupon->getCount();
-        $used = $coupon->getUsed();
-
-        $used++;
-        $coupon->setUsed($used);
-
-        if ($count <= $used) {
-
-            $coupon->setEnabled(false);
-        }
-
+        $coupon->incrementUsages();
         $this->couponObjectManager->flush($coupon);
     }
 }


### PR DESCRIPTION
When an object brings a property from another object, transforms it and sets it back again, it is a bad smell which indicates that the manipulated class incapsulation is being violated.

By moving that code from the listener to the `Coupon` class, we obtain several benefits:
- The responsibility in the listener is significantly reduced.
- The listener knows less about the implementation details of the coupon class. By decoupling it, it will be more robust to change.
- The business rules are contained in the class they apply to, reducing the spreading of knowledge.
- By putting logic in the Coupon class, we allow other coupons to be added to the system that can extend the behaviour - i.e. using polymorphism -.
