### PR TITLE
Issue #141 Class hierarchy for Money class

### DIFF
--- a/src/Elcodi/CartBundle/EventListener/CartEventListener.php
+++ b/src/Elcodi/CartBundle/EventListener/CartEventListener.php
@@ -303,8 +303,7 @@ class CartEventListener
         $productPrice = $product->getPrice();
 
         /**
-         * If reducedPrice is defined, found value will be used as real product
-         * price.
+         * If present, reducedPrice will be used as product price in current CartLine.
          */
         if ($product->getReducedPrice() instanceof Money) {
 
@@ -312,9 +311,9 @@ class CartEventListener
         }
 
         /**
-         * Setting amounts for this CartLine.
-         * Line Currency has already be set when factorying CartLine
-         * by CartManager::addProduct
+         * Setting amounts for current CartLine.
+         *
+         * Line Currency was set by CartManager::addProduct when factorying CartLine
          */
         $cartLine->setProductAmount($productPrice->multiply($cartLine->getQuantity()));
         $cartLine->setAmount($cartLine->getProductAmount());

--- a/src/Elcodi/CurrencyBundle/Entity/Interfaces/MoneyInterface.php
+++ b/src/Elcodi/CurrencyBundle/Entity/Interfaces/MoneyInterface.php
@@ -91,6 +91,15 @@ interface MoneyInterface
     public function isGreaterThan(MoneyInterface $other);
 
     /**
+     * Sets the amount
+     *
+     * @param integer $amount Amount
+     *
+     * @return MoneyInterface self Object
+     */
+    public function setAmount($amount);
+
+    /**
      * Gets the Money amount
      *
      * @return int
@@ -98,7 +107,16 @@ interface MoneyInterface
     public function getAmount();
 
     /**
-     * Gets the Money Currency
+     * Set currency
+     *
+     * @param CurrencyInterface $currency Currency
+     *
+     * @return MoneyInterface self Object
+     */
+    public function setCurrency(CurrencyInterface $currency);
+
+    /**
+     * Gets the Currency
      *
      * @return CurrencyInterface
      */

--- a/src/Elcodi/CurrencyBundle/Entity/Money.php
+++ b/src/Elcodi/CurrencyBundle/Entity/Money.php
@@ -31,8 +31,14 @@ use Elcodi\CurrencyBundle\Entity\Interfaces\CurrencyInterface;
  *
  * Useful methods will be exposed as defined in {@see MoneyInterface}
  */
-class Money implements MoneyInterface
+class Money extends StubMoney implements MoneyInterface
 {
+    /**
+     * @var integer
+     *
+     * Money amount
+     */
+    protected $amount;
     /**
      * @var WrappedMoney
      *
@@ -87,7 +93,7 @@ class Money implements MoneyInterface
     }
 
     /**
-     * Set amount
+     * Sets the amount
      *
      * @param integer $amount Amount
      *
@@ -213,7 +219,7 @@ class Money implements MoneyInterface
      *
      * @return WrappedMoney self Object
      */
-    protected function newWrappedMoneyFromMoney(MoneyInterface $money)
+    private function newWrappedMoneyFromMoney(MoneyInterface $money)
     {
         return new WrappedMoney(
             $money->getAmount(),
@@ -223,6 +229,16 @@ class Money implements MoneyInterface
 
     /**
      * Returns a new instance of a Money object
+     *
+     * This factory should be the only process to instantiate a
+     * object implementing MoneyInterface.
+     *
+     * In order to return a proper Money value object, an integer
+     * amount and a Currency object implementing CurrencyInterface
+     * are needed. When the Currency object is invalid, a NullMoney
+     * instance is returned. The NullMoney is an implementation of
+     * a Null Object pattern, a dumb object that will just respond
+     * to MoneyInterface methods but that does nothing.
      *
      * @param integer           $amount   Amount
      * @param CurrencyInterface $currency Currency
@@ -235,7 +251,7 @@ class Money implements MoneyInterface
     )
     {
         return ($currency instanceof CurrencyInterface)
-            ? new self($amount, $currency)
-            : new NullMoney();
+            ? new Money($amount, $currency)
+            : NullMoney::create();
     }
 }

--- a/src/Elcodi/CurrencyBundle/Entity/NullMoney.php
+++ b/src/Elcodi/CurrencyBundle/Entity/NullMoney.php
@@ -21,9 +21,20 @@ use Elcodi\CurrencyBundle\Entity\Interfaces\MoneyInterface;
 
 /**
  * Class NullMoney
+ *
+ * Null Object implementation for a MoneyInterface object
  */
-class NullMoney implements MoneyInterface
+class NullMoney extends StubMoney implements MoneyInterface
 {
+    /**
+     * NullMoney constructor is used only to preserve
+     * the protected accessor
+     */
+    protected function __construct()
+    {
+
+    }
+
     /**
      * Adds a Money and returns the result as a new Money
      *
@@ -115,6 +126,18 @@ class NullMoney implements MoneyInterface
     }
 
     /**
+     * Sets the amount
+     *
+     * @param integer $amount Amount
+     *
+     * @return MoneyInterface self Object
+     */
+    public function setAmount($amount)
+    {
+        return $this;
+    }
+
+    /**
      * Gets the Money amount
      *
      * @return int
@@ -125,7 +148,19 @@ class NullMoney implements MoneyInterface
     }
 
     /**
-     * Gets the Money Currency
+     * Set currency
+     *
+     * @param CurrencyInterface $currency Currency
+     *
+     * @return MoneyInterface self Object
+     */
+    public function setCurrency(CurrencyInterface $currency)
+    {
+        return $this;
+    }
+
+    /**
+     * Gets the Currency
      *
      * @return CurrencyInterface
      */
@@ -133,4 +168,15 @@ class NullMoney implements MoneyInterface
     {
         return null;
     }
+
+    /**
+     * Returns a new instance of a NullMoney object
+     *
+     * @return NullMoney
+     */
+    public static function create()
+    {
+        return new NullMoney();
+    }
+
 }

--- a/src/Elcodi/CurrencyBundle/Entity/StubMoney.php
+++ b/src/Elcodi/CurrencyBundle/Entity/StubMoney.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\CurrencyBundle\Entity;
+
+/**
+ * Class StubMoney
+ *
+ * Base class for Money value objects.
+ */
+class StubMoney
+{
+
+}


### PR DESCRIPTION
We need to implement a simple class hierarchy for `Money` value object class. This is needed because both `Money` and `NullMoney` have to share a common ancestor, to ease the pain when working with Symfony compound forms
