### PR TITLE
Setters for Money value object

### DIFF
--- a/src/Elcodi/CurrencyBundle/Entity/Money.php
+++ b/src/Elcodi/CurrencyBundle/Entity/Money.php
@@ -77,6 +77,10 @@ class Money extends StubMoney implements MoneyInterface
      */
     public function setCurrency(CurrencyInterface $currency)
     {
+        $this->wrappedMoney = new WrappedMoney(
+            $this->amount,
+            new WrappedCurrency($currency->getIso())
+        );
         $this->currency = $currency;
 
         return $this;
@@ -101,6 +105,12 @@ class Money extends StubMoney implements MoneyInterface
      */
     public function setAmount($amount)
     {
+        $amount = intval($amount);
+
+        $this->wrappedMoney = new WrappedMoney(
+            $amount,
+            new WrappedCurrency($this->currency->getIso())
+        );
         $this->amount = $amount;
 
         return $this;
@@ -113,6 +123,7 @@ class Money extends StubMoney implements MoneyInterface
      */
     public function getAmount()
     {
+        //var_dump($this->wrappedMoney->getAmount());
         return $this->wrappedMoney->getAmount();
     }
 


### PR DESCRIPTION
Although setters for individual fields should not be allowed
in value objects, it was necessary to implement `setCurrency` and
`setAmount` in order to make the class collaborate with Symfony
form types. Internally, the `Form` component uses setters to "attach" form
data to entity classes, so public setters were needed

See https://github.com/elcodi/bamboo-admin/issues/3
