### PR TITLE
Some relation changes in doctrine

### DIFF
--- a/src/Elcodi/CartBundle/Resources/config/doctrine/Cart.orm.yml
+++ b/src/Elcodi/CartBundle/Resources/config/doctrine/Cart.orm.yml
@@ -30,6 +30,7 @@ Elcodi\CartBundle\Entity\Cart:
                 name: customer_id
                 referencedColumnName: id
                 nullable: true
+                onDelete: "SET NULL"
 
     oneToMany:
         cartLines:

--- a/src/Elcodi/CartBundle/Resources/config/doctrine/Order.orm.yml
+++ b/src/Elcodi/CartBundle/Resources/config/doctrine/Order.orm.yml
@@ -51,6 +51,7 @@ Elcodi\CartBundle\Entity\Order:
                 name: customer_id
                 referencedColumnName: id
                 nullable: false
+                onDelete: "SET NULL"
         currency:
             targetEntity: Elcodi\CurrencyBundle\Entity\Interfaces\CurrencyInterface
             joinColumn:

--- a/src/Elcodi/UserBundle/Resources/config/doctrine/Customer.orm.yml
+++ b/src/Elcodi/UserBundle/Resources/config/doctrine/Customer.orm.yml
@@ -31,6 +31,8 @@ Elcodi\UserBundle\Entity\Customer:
         orders:
             targetEntity: Elcodi\CartBundle\Entity\Interfaces\OrderInterface
             mappedBy: customer
+            orderBy:
+                createdAt: DESC
             cascade: [ "persist" ]
 
     oneToOne:
@@ -40,6 +42,7 @@ Elcodi\UserBundle\Entity\Customer:
                 name: delivery_address_id
                 referencedColumnName: id
                 nullable: true
+                onDelete: "SET NULL"
             cascade: [ "persist" ]
 
         invoiceAddress:
@@ -48,6 +51,7 @@ Elcodi\UserBundle\Entity\Customer:
                 name: invoice_address_id
                 referencedColumnName: id
                 nullable: true
+                onDelete: "SET NULL"
             cascade: [ "persist" ]
 
     manyToOne:


### PR DESCRIPTION
- When a customer is deleted, both carts and orders customer_id fields are set to null
- Customer orders are ordered by createdAt Desc
- When customer addresses are deleted, deliveryAddressId and invoiceAddressId are set to null
