### PR TITLE
Updated framework-bundle lock version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/config": "~2.4",
         "symfony/yaml": "~2.4",
         "symfony/console": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/class-loader": "~2.4",
         "symfony/security": "~2.4",
         "symfony/http-foundation": "~2.4",

--- a/src/Elcodi/AttributeBundle/composer.json
+++ b/src/Elcodi/AttributeBundle/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/BannerBundle/composer.json
+++ b/src/Elcodi/BannerBundle/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/CartBundle/composer.json
+++ b/src/Elcodi/CartBundle/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/CartCouponBundle/composer.json
+++ b/src/Elcodi/CartCouponBundle/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/CoreBundle/composer.json
+++ b/src/Elcodi/CoreBundle/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/CouponBundle/composer.json
+++ b/src/Elcodi/CouponBundle/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/CurrencyBundle/composer.json
+++ b/src/Elcodi/CurrencyBundle/composer.json
@@ -31,7 +31,7 @@
         "symfony/options-resolver": "~2.4",
         "symfony/routing": "~2.4",
         "symfony/http-foundation": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/dependency-injection": "~2.4",
         "symfony/http-kernel": "~2.4",
         "twig/twig": "~1",
@@ -43,7 +43,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/GeoBundle/composer.json
+++ b/src/Elcodi/GeoBundle/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/LanguageBundle/composer.json
+++ b/src/Elcodi/LanguageBundle/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/MediaBundle/composer.json
+++ b/src/Elcodi/MediaBundle/composer.json
@@ -28,7 +28,7 @@
         "symfony/http-foundation": "~2.4",
         "symfony/http-kernel": "~2.4",
         "symfony/dependency-injection": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/process": "~2.4",
         "knplabs/knp-gaufrette-bundle": "v0.1.7",
         "twig/twig": "~1.0",
@@ -38,7 +38,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/MenuBundle/composer.json
+++ b/src/Elcodi/MenuBundle/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/NewsletterBundle/composer.json
+++ b/src/Elcodi/NewsletterBundle/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/ProductBundle/composer.json
+++ b/src/Elcodi/ProductBundle/composer.json
@@ -45,7 +45,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/ReferralProgramBundle/composer.json
+++ b/src/Elcodi/ReferralProgramBundle/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.4",
         "doctrine/common": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/config": "~2.4",
         "symfony/event-dispatcher": "~2.4",
         "symfony/form": "~2.4",
@@ -42,7 +42,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/RuleBundle/composer.json
+++ b/src/Elcodi/RuleBundle/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",

--- a/src/Elcodi/UserBundle/composer.json
+++ b/src/Elcodi/UserBundle/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "symfony/browser-kit": "~2.4",
-        "symfony/framework-bundle": "~2.4",
+        "symfony/framework-bundle": "~2.4, >=2.4.8",
         "symfony/validator": "~2.4",
         "symfony/finder": "~2.4",
         "phpunit/phpunit": ">=4.0",


### PR DESCRIPTION
- Using ~2.4, >=2.4.8 to avoid security issue CVE-2014-4931
- @see http://symfony.com/blog/security-releases-cve-2014-4931-symfony-2-3-18-2-4-8-and-2-5-2-released
