### PR TITLE
Updated command construction to be compatible with console

### DIFF
--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
@@ -6,11 +6,13 @@ services:
     elcodi.core.currency.command.load_exchange_rates:
         class: %elcodi.core.currency.command.load_exchange_rates.class%
         arguments:
-            currency_repository: @elcodi.repository.currency
+            currency_object_manager: @elcodi.object_manager.currency
+            currency_exchange_rate_object_manager: @elcodi.object_manager.currency_exchange_rate
             currency_exchange_rate_factory: @elcodi.factory.currency_exchange_rate
-            currency_exchange_rate_repository: @elcodi.repository.currency_exchange_rate
             exchange_rates_provider: @elcodi.exchange_rates_provider
-            exchange_rate_object_manager: @elcodi.object_manager.currency_exchange_rate
+            currency_namespace: %elcodi.core.currency.entity.currency.class%
+            currency_namespace: %elcodi.core.currency.entity.currency_exchange_rate.class%
+            currency_exchange_rate_namespace: %elcodi.core.currency.entity.currency_exchange_rate.class%
             default_currency: %elcodi.core.currency.default_currency%
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Component/ReferralProgram/EventListener/ReferralProgramEventListener.php
+++ b/src/Elcodi/Component/ReferralProgram/EventListener/ReferralProgramEventListener.php
@@ -16,11 +16,11 @@
 
 namespace Elcodi\Component\ReferralProgram\EventListener;
 
-use Elcodi\Component\Cart\Event\OrderOnCreatedEvent;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+use Elcodi\Component\Cart\Event\OrderOnCreatedEvent;
 use Elcodi\Component\CartCoupon\Services\OrderCouponManager;
 use Elcodi\Component\ReferralProgram\ElcodiReferralProgramCookie;
 use Elcodi\Component\ReferralProgram\ElcodiReferralProgramRuleTypes;


### PR DESCRIPTION
Related with https://github.com/symfony/symfony/issues/11794 and #252

Instead of removing the command, this has been refactored to work with the FrameworkBundle.
