### PR TITLE
Fixed lazy services dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "symfony/finder": "~2.4",
         "symfony/browser-kit": "~2.4",
         "symfony/routing": "~2.4",
+        "symfony/proxy-manager-bridge": "~2.4",
 
         "doctrine/common": "~2.4",
         "doctrine/orm": "~2.4",
@@ -45,7 +46,6 @@
         "sebastian/money": "~1.3",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "ircmaxell/password-compat": "~1.0",
-        "ocramius/proxy-manager": "~0.5",
         "mmoreram/extractor": "~1.0",
         "goodby/csv": "~1.0"
     },

--- a/src/Elcodi/Bundle/CurrencyBundle/composer.json
+++ b/src/Elcodi/Bundle/CurrencyBundle/composer.json
@@ -32,7 +32,7 @@
         "symfony/config": "~2.4",
         "symfony/dependency-injection": "~2.4",
         "symfony/proxy-manager-bridge": "~2.4",
-        "ocramius/proxy-manager": "~0.5",
+
         "mmoreram/simple-doctrine-mapping": "~0.1",
 
         "elcodi/core-bundle": "~0.3.0",

--- a/src/Elcodi/Bundle/GeoBundle/composer.json
+++ b/src/Elcodi/Bundle/GeoBundle/composer.json
@@ -28,7 +28,6 @@
         "symfony/config": "~2.4",
         "symfony/dependency-injection": "~2.4",
         "symfony/proxy-manager-bridge": "~2.4",
-        "ocramius/proxy-manager": "~0.5",
 
         "mmoreram/simple-doctrine-mapping": "~0.1",
 


### PR DESCRIPTION
- Packages should depend on Symfony Proxy Manager bridge.
- This bridge already depends on ocramius bundle
