### PR TITLE
Moved AbstractPurchasableFactory to Currency

### DIFF
--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/factories.yml
@@ -9,6 +9,7 @@ services:
     #
     elcodi.core.coupon.factory.coupon:
         class: %elcodi.core.coupon.factory.coupon.class%
+        parent: elcodi.core.currency.factory.abstract.purchasable
         calls:
             - [setEntityNamespace, ["%elcodi.core.coupon.entity.coupon.class%"]]
 

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
@@ -17,6 +17,7 @@
 namespace Elcodi\Bundle\CouponBundle\Tests\Functional\Factory;
 
 use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+use Elcodi\Component\Coupon\Entity\Coupon;
 
 /**
  * Class CouponFactoryTest
@@ -30,7 +31,19 @@ class CouponFactoryTest extends WebTestCase
      */
     protected function loadSchema()
     {
-        return false;
+        return true;
+    }
+
+    /**
+     * Load fixtures of these bundles
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected function loadFixturesBundles()
+    {
+        return array(
+            'ElcodiCurrencyBundle'
+        );
     }
 
     /**
@@ -45,4 +58,42 @@ class CouponFactoryTest extends WebTestCase
             'elcodi.factory.coupon',
         ];
     }
+
+    /**
+     * Tests that the Coupon object is factored correctly
+     */
+    public function testCreateCouponFactory()
+    {
+        $this->assertInstanceOf(
+            $this->getParameter('elcodi.core.coupon.entity.coupon.class'),
+            $this->get('elcodi.factory.coupon')->create()
+        );
+    }
+
+    /**
+     * Tests that amounts in the Currency objects are Money value objects
+     */
+    public function testCouponPricesAreMoney()
+    {
+        /**
+         * @var $coupon Coupon
+         */
+        $coupon = $this->get('elcodi.factory.coupon')->create();
+
+        $this->assertInstanceOf(
+            '\Elcodi\Component\Currency\Entity\Money',
+            $coupon->getPrice()
+        );
+
+        $this->assertInstanceOf(
+            '\Elcodi\Component\Currency\Entity\Money',
+            $coupon->getAbsolutePrice()
+        );
+
+        $this->assertInstanceOf(
+            '\Elcodi\Component\Currency\Entity\Money',
+            $coupon->getMinimumPurchase()
+        );
+    }
+
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/classes.yml
@@ -9,6 +9,7 @@ parameters:
     #
     # Factories
     #
+    elcodi.core.currency.factory.abstract.abstract.class: Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory
     elcodi.core.currency.factory.currency.class: Elcodi\Component\Currency\Factory\CurrencyFactory
     elcodi.core.currency.factory.currency_exchange_rate.class: Elcodi\Component\Currency\Factory\CurrencyExchangeRateFactory
 

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
@@ -5,6 +5,15 @@ services:
     #
 
     #
+    # Abstract purchasable factory
+    #
+    elcodi.core.currency.factory.abstract.purchasable:
+        class: %elcodi.core.currency.factory.abstract.abstract.class%
+        abstract: true
+        arguments:
+            currency_wrapper: @elcodi.currency_wrapper
+
+    #
     # Factory for Currency entities
     #
     elcodi.core.currency.factory.currency:

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/classes.yml
@@ -17,7 +17,6 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.product.factory.abstract.abstract.class: Elcodi\Component\Product\Factory\Abstracts\AbstractPurchasableFactory
     elcodi.core.product.factory.product.class: Elcodi\Component\Product\Factory\ProductFactory
     elcodi.core.product.factory.variant.class: Elcodi\Component\Product\Factory\VariantFactory
     elcodi.core.product.factory.manufacturer.class: Elcodi\Component\Product\Factory\ManufacturerFactory

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/factories.yml
@@ -5,20 +5,11 @@ services:
     #
 
     #
-    # Abstract purchasable factory
-    #
-    elcodi.core.product.factory.abstract.purchasable:
-        class: %elcodi.core.product.factory.abstract.abstract.class%
-        abstract: true
-        arguments:
-            currency_wrapper: @elcodi.currency_wrapper
-
-    #
     # Factory for Product entities
     #
     elcodi.core.product.factory.product:
         class: %elcodi.core.product.factory.product.class%
-        parent: elcodi.core.product.factory.abstract.purchasable
+        parent: elcodi.core.currency.factory.abstract.purchasable
         calls:
             - [setEntityNamespace, ["%elcodi.core.product.entity.product.class%"]]
 
@@ -30,7 +21,7 @@ services:
     #
     elcodi.core.product.factory.variant:
         class: %elcodi.core.product.factory.variant.class%
-        parent: elcodi.core.product.factory.abstract.purchasable
+        parent: elcodi.core.currency.factory.abstract.purchasable
         calls:
             - [setEntityNamespace, ["%elcodi.core.product.entity.variant.class%"]]
 

--- a/src/Elcodi/Component/Coupon/Factory/CouponFactory.php
+++ b/src/Elcodi/Component/Coupon/Factory/CouponFactory.php
@@ -18,15 +18,15 @@ namespace Elcodi\Component\Coupon\Factory;
 
 use DateTime;
 
-use Elcodi\Component\Core\Factory\Abstracts\AbstractFactory;
 use Elcodi\Component\Coupon\ElcodiCouponTypes;
 use Elcodi\Component\Coupon\Entity\Coupon;
 use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory;
 
 /**
  * Class CouponFactory
  */
-class CouponFactory extends AbstractFactory
+class CouponFactory extends AbstractPurchasableFactory
 {
     /**
      * Creates an instance of a simple coupon.
@@ -37,6 +37,8 @@ class CouponFactory extends AbstractFactory
      */
     public function create()
     {
+        $zeroPrice = $this->createZeroAmountMoney();
+
         /**
          * @var CouponInterface $coupon
          */
@@ -44,8 +46,11 @@ class CouponFactory extends AbstractFactory
         $coupon = new $classNamespace();
         $coupon
             ->setType(ElcodiCouponTypes::TYPE_AMOUNT)
+            ->setPrice($zeroPrice)
+            ->setAbsolutePrice($zeroPrice)
+            ->setMinimumPurchase($zeroPrice)
             ->setEnforcement(ElcodiCouponTypes::ENFORCEMENT_MANUAL)
-            ->setUsed(0)
+            ->setUsed(false)
             ->setPriority(0)
             ->setEnabled(false)
             ->setCreatedAt(new DateTime);

--- a/src/Elcodi/Component/Currency/Factory/Abstracts/AbstractPurchasableFactory.php
+++ b/src/Elcodi/Component/Currency/Factory/Abstracts/AbstractPurchasableFactory.php
@@ -14,7 +14,7 @@
  * @author Aldo Chiecchia <zimage@tiscali.it>
  */
 
-namespace Elcodi\Component\Product\Factory\Abstracts;
+namespace Elcodi\Component\Currency\Factory\Abstracts;
 
 use Elcodi\Component\Core\Factory\Abstracts\AbstractFactory;
 use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;

--- a/src/Elcodi/Component/Product/Factory/ProductFactory.php
+++ b/src/Elcodi/Component/Product/Factory/ProductFactory.php
@@ -21,7 +21,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 use Elcodi\Component\Product\ElcodiProductTypes;
 use Elcodi\Component\Product\Entity\Product;
-use Elcodi\Component\Product\Factory\Abstracts\AbstractPurchasableFactory;
+use Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory;
 
 /**
  * Factory for Product entities

--- a/src/Elcodi/Component/Product/Factory/VariantFactory.php
+++ b/src/Elcodi/Component/Product/Factory/VariantFactory.php
@@ -19,7 +19,7 @@ namespace Elcodi\Component\Product\Factory;
 use Doctrine\Common\Collections\ArrayCollection;
 
 use Elcodi\Component\Product\Entity\Variant;
-use Elcodi\Component\Product\Factory\Abstracts\AbstractPurchasableFactory;
+use Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory;
 
 /**
  * Factory for Variant entities


### PR DESCRIPTION
AbstractPurchasableFactory represents an abstract factory service which
by default is injected with CurrencyWrapper, so that concrete Entity
factories that depend on a valid and consistent Currency can use it to
create new Entities in a stable state (like Product or Variant).

All entities factories whose returned Entity needs a valid Currency object
to be properly initialized should extend AbstractPurchasableFactory.
This is the reason why it has been moved to the Currency component.

CouponFactory has been moved to the AbstractPurchasableFactory hierarchy
