### PR TITLE
Coupon#used is now defined as boolean

### DIFF
--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
@@ -35,7 +35,7 @@ Elcodi\Component\Coupon\Entity\Coupon:
             nullable: false
         used:
             column: used
-            type: integer
+            type: boolean
             nullable: false
         priority:
             column: priority


### PR DESCRIPTION
Changed ORM definition for `Coupon`. The property `used` is now a `boolean`.
