### PR TITLE
Fixes #290. Renamed abstract class

### DIFF
--- a/src/Elcodi/Component/User/ElcodiUserEvents.php
+++ b/src/Elcodi/Component/User/ElcodiUserEvents.php
@@ -41,7 +41,7 @@ class ElcodiUserEvents
      * This event is fired when a user is registered
      *
      * event.name : user.register
-     * event.class : AbstractUserRegisterEvent
+     * event.class : UserRegisterEvent
      */
     const ABSTRACTUSER_REGISTER = 'user.register';
 

--- a/src/Elcodi/Component/User/Event/UserRegisterEvent.php
+++ b/src/Elcodi/Component/User/Event/UserRegisterEvent.php
@@ -21,9 +21,9 @@ use Symfony\Component\EventDispatcher\Event;
 use Elcodi\Component\User\Entity\Interfaces\AbstractUserInterface;
 
 /**
- * Class AbstractUserRegisterEvent
+ * Class UserRegisterEvent
  */
-class AbstractUserRegisterEvent extends Event
+class UserRegisterEvent extends Event
 {
     /**
      * @var AbstractUserInterface

--- a/src/Elcodi/Component/User/Services/Abstracts/AbstractUserManager.php
+++ b/src/Elcodi/Component/User/Services/Abstracts/AbstractUserManager.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 
 use Elcodi\Component\User\ElcodiUserEvents;
 use Elcodi\Component\User\Entity\Interfaces\AbstractUserInterface;
-use Elcodi\Component\User\Event\AbstractUserRegisterEvent;
+use Elcodi\Component\User\Event\UserRegisterEvent;
 
 /**
  * Class AbstractUserManager
@@ -82,7 +82,7 @@ abstract class AbstractUserManager
 
         $this->securityContext->setToken($token);
 
-        $event = new AbstractUserRegisterEvent($user);
+        $event = new UserRegisterEvent($user);
         $this->eventDispatcher->dispatch(
             ElcodiUserEvents::ABSTRACTUSER_REGISTER,
             $event


### PR DESCRIPTION
`AbstractUserRegisterEvent` is not an abstract class, it has been renamed to `UserRegisterEvent`
