### PR TITLE
Changed AbstractUser interface hierarchy

### DIFF
--- a/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
+++ b/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
@@ -17,7 +17,7 @@
 namespace Elcodi\Component\User\Entity\Abstracts;
 
 use DateTime;
-use Symfony\Component\Security\Core\User\UserInterface;
+use Elcodi\Component\User\Entity\Interfaces\AbstractUserInterface;
 
 use Elcodi\Component\Core\Entity\Abstracts\AbstractEntity;
 use Elcodi\Component\Core\Entity\Traits\DateTimeTrait;
@@ -27,7 +27,7 @@ use Elcodi\Component\Core\Entity\Traits\EnabledTrait;
  * AbstractUser is the building block for simple User entities,
  * consisting of username, password, email
  */
-abstract class AbstractUser extends AbstractEntity implements UserInterface
+abstract class AbstractUser extends AbstractEntity implements AbstractUserInterface
 {
     use DateTimeTrait, EnabledTrait;
 

--- a/src/Elcodi/Component/User/Entity/Interfaces/AbstractUserInterface.php
+++ b/src/Elcodi/Component/User/Entity/Interfaces/AbstractUserInterface.php
@@ -17,19 +17,13 @@
 namespace Elcodi\Component\User\Entity\Interfaces;
 
 use DateTime;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Class AbstractUserInterface
  */
-interface AbstractUserInterface
+interface AbstractUserInterface extends UserInterface
 {
-    /**
-     * User roles
-     *
-     * @return string[] Roles
-     */
-    public function getRoles();
-
     /**
      * Set recovery hash
      *
@@ -120,13 +114,6 @@ interface AbstractUserInterface
     public function setUsername($username);
 
     /**
-     * Get username
-     *
-     * @return String Username
-     */
-    public function getUsername();
-
-    /**
      * Get birthday
      *
      * @return DateTime
@@ -157,11 +144,4 @@ interface AbstractUserInterface
      * @return $this self Object
      */
     public function setPassword($password);
-
-    /**
-     * Get password
-     *
-     * @return string Password
-     */
-    public function getPassword();
 }


### PR DESCRIPTION
`AbstractUserInterface` now inherits from symfony `UserInterface`.
Before this change, only `AbstractUser` was implementing `UserInterface`.
`CustomerInterface` and `AdminUserInterface` were extending
`AbstractUserInterface`, making it possible to inject into collaborating
objects a User that does **not** implement `UserInterface`.
