### PR TITLE
[Cart] Fix order state event names and methods

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -30,7 +30,7 @@ services:
         arguments:
             order_entity_manager: @elcodi.object_manager.order
         tags:
-            - { name: kernel.event_listener, event: orderstate.onchange, method: onOrderStateOnChangeFlush, priority: 0 }
+            - { name: kernel.event_listener, event: order_state.onchange, method: onOrderStateOnChangeFlush, priority: 0 }
 
     elcodi.core.cart.event_listener.order_line_state:
         class: %elcodi.core.cart.event_listener.order_line_state.class%
@@ -39,8 +39,8 @@ services:
             order_state_event_dispatcher: @elcodi.order_state_event_dispatcher
             order_history_factory: @elcodi.core.cart.factory.order_history
         tags:
-            - { name: kernel.event_listener, event: orderlinestate.onchange, method: onOrderLineStateOnChange, priority: 16 }
-            - { name: kernel.event_listener, event: orderlinestate.onchange, method: onOrderLineStateOnChangeFlush, priority: 0 }
+            - { name: kernel.event_listener, event: order_line_state.onchange, method: onOrderLineStateOnChange, priority: 16 }
+            - { name: kernel.event_listener, event: order_line_state.onchange, method: onOrderLineStateOnChangeFlush, priority: 0 }
 
     elcodi.core.cart.event_listener.cart_session:
         class: %elcodi.core.cart.event_listener.cart_session.class%

--- a/src/Elcodi/Component/Cart/ElcodiCartEvents.php
+++ b/src/Elcodi/Component/Cart/ElcodiCartEvents.php
@@ -112,7 +112,7 @@ class ElcodiCartEvents
     /**
      * This event is dispatched when an orderline is created
      *
-     * event.name : orderline.oncreated
+     * event.name : order_line.oncreated
      * event.class : OrderLineOnCreatedEvent
      */
     const ORDERLINE_ONCREATED = 'order_line.oncreated';
@@ -127,7 +127,7 @@ class ElcodiCartEvents
      * This event has, as first parameter an OrderChangedStatusEvent object
      * having current Order object, last and current OrderHistoryObject
      *
-     * event.name : orderstate.change
+     * event.name : order_state.change
      * event.class : OrderStatePreChangeEvent
      *
      */
@@ -139,7 +139,7 @@ class ElcodiCartEvents
      * This event has, as first parameter an OrderChangedStatusEvent object
      * having current Order object, last and current OrderHistoryObject
      *
-     * event.name : orderstate.onchange
+     * event.name : order_state.onchange
      * event.class : OrderStateOnChangeEvent
      *
      */
@@ -156,7 +156,7 @@ class ElcodiCartEvents
      * object having current OrderLine object, last and current
      * OrderLineHistoryObject and last and current stats
      *
-     * event.name : orderlinestate.prechange
+     * event.name : order_line_state.prechange
      * event.class : OrderLineStatePreChangeEvent
      *
      */
@@ -169,7 +169,7 @@ class ElcodiCartEvents
      * object having current OrderLine object, last and current
      * OrderLineHistoryObject and last and current stats
      *
-     * event.name : orderlinestate.onchange
+     * event.name : order_line_state.onchange
      * event.class : OrderLineStateOnChangeEvent
      *
      */

--- a/src/Elcodi/Component/Cart/EventDispatcher/OrderStateEventDispatcher.php
+++ b/src/Elcodi/Component/Cart/EventDispatcher/OrderStateEventDispatcher.php
@@ -29,9 +29,9 @@ use Elcodi\Component\Core\EventDispatcher\Abstracts\AbstractEventDispatcher;
 class OrderStateEventDispatcher extends AbstractEventDispatcher
 {
     /**
-     * Dispatching "pre" state changed event
+     * Event dispatcher before OrderState changes
      *
-     * This event does not pass wrap new OrderLineHistory into the message,
+     * This event does not pass wrap new OrderHistory into the message,
      * since it has not been created yet.
      *
      * @param OrderInterface        $order            Used Order
@@ -63,9 +63,9 @@ class OrderStateEventDispatcher extends AbstractEventDispatcher
     }
 
     /**
-     * Dispatching "post" state changed event
+     * Event dispatcher when OrderState changes
      *
-     * New OrderLineHistory has been created already
+     * New OrderHistory has been created already
      *
      * @param OrderInterface        $order            Used Order
      * @param OrderHistoryInterface $lastOrderHistory Last OrderHistory
@@ -74,7 +74,7 @@ class OrderStateEventDispatcher extends AbstractEventDispatcher
      *
      * @return $this self Object
      */
-    public function dispatchOrderStatePostChangeEvent(
+    public function dispatchOrderStateOnChangeEvent(
         OrderInterface $order,
         OrderHistoryInterface $lastOrderHistory,
         OrderHistoryInterface $newOrderHistory,
@@ -91,7 +91,7 @@ class OrderStateEventDispatcher extends AbstractEventDispatcher
         $this
             ->eventDispatcher
             ->dispatch(
-                ElcodiCartEvents::ORDER_STATE_POSTCHANGE,
+                ElcodiCartEvents::ORDER_STATE_ONCHANGE,
                 $orderStatePostChangeEvent
             );
 


### PR DESCRIPTION
Some event names were incorrect.

When a new Order or a OrderLine status is added, some events are dispatched, but they were not listened because of this error. 
