### PR TITLE
Transparent NullMoney operations

### DIFF
--- a/src/Elcodi/Component/Currency/Entity/Interfaces/MoneyInterface.php
+++ b/src/Elcodi/Component/Currency/Entity/Interfaces/MoneyInterface.php
@@ -22,29 +22,11 @@ namespace Elcodi\Component\Currency\Entity\Interfaces;
 interface MoneyInterface
 {
     /**
-     * Sets the amount
-     *
-     * @param integer $amount Amount
-     *
-     * @return $this self Object
-     */
-    public function setAmount($amount);
-
-    /**
      * Gets the Money amount
      *
      * @return integer Amount
      */
     public function getAmount();
-
-    /**
-     * Set currency
-     *
-     * @param CurrencyInterface $currency Currency
-     *
-     * @return $this self Object
-     */
-    public function setCurrency(CurrencyInterface $currency);
 
     /**
      * Gets the Currency

--- a/src/Elcodi/Component/Currency/Entity/Money.php
+++ b/src/Elcodi/Component/Currency/Entity/Money.php
@@ -72,24 +72,6 @@ class Money extends StubMoney implements MoneyInterface
     }
 
     /**
-     * Set currency
-     *
-     * @param CurrencyInterface $currency Currency
-     *
-     * @return $this self Object
-     */
-    public function setCurrency(CurrencyInterface $currency)
-    {
-        $this->wrappedMoney = new WrappedMoney(
-            $this->amount,
-            new WrappedCurrency($currency->getIso())
-        );
-        $this->currency = $currency;
-
-        return $this;
-    }
-
-    /**
      * Gets the Money Currency
      *
      * @return CurrencyInterface Currency
@@ -97,26 +79,6 @@ class Money extends StubMoney implements MoneyInterface
     public function getCurrency()
     {
         return $this->currency;
-    }
-
-    /**
-     * Sets the amount
-     *
-     * @param integer $amount Amount
-     *
-     * @return $this self Object
-     */
-    public function setAmount($amount)
-    {
-        $amount = intval($amount);
-
-        $this->wrappedMoney = new WrappedMoney(
-            $amount,
-            new WrappedCurrency($this->currency->getIso())
-        );
-        $this->amount = $amount;
-
-        return $this;
     }
 
     /**

--- a/src/Elcodi/Component/Currency/Entity/NullMoney.php
+++ b/src/Elcodi/Component/Currency/Entity/NullMoney.php
@@ -35,18 +35,6 @@ class NullMoney extends StubMoney implements MoneyInterface
     }
 
     /**
-     * Sets the amount
-     *
-     * @param integer $amount Amount
-     *
-     * @return $this self Object
-     */
-    public function setAmount($amount)
-    {
-        return $this;
-    }
-
-    /**
      * Gets the Money amount
      *
      * @return integer Amount
@@ -54,18 +42,6 @@ class NullMoney extends StubMoney implements MoneyInterface
     public function getAmount()
     {
         return 0;
-    }
-
-    /**
-     * Set currency
-     *
-     * @param CurrencyInterface $currency Currency
-     *
-     * @return $this self Object
-     */
-    public function setCurrency(CurrencyInterface $currency)
-    {
-        return $this;
     }
 
     /**
@@ -93,7 +69,7 @@ class NullMoney extends StubMoney implements MoneyInterface
      */
     public function compareTo(MoneyInterface $other)
     {
-        return null;
+        return $other;
     }
 
     /**
@@ -105,7 +81,7 @@ class NullMoney extends StubMoney implements MoneyInterface
      */
     public function add(MoneyInterface $other)
     {
-        return $this;
+        return $other;
     }
 
     /**
@@ -117,11 +93,12 @@ class NullMoney extends StubMoney implements MoneyInterface
      */
     public function subtract(MoneyInterface $other)
     {
-        return $this;
+        return $other;
     }
 
     /**
-     * Multiplies current Money amount by a factor returns the result as a new Money
+     * Multiplies current Money amount by a factor
+     * and returns the result as a new Money
      *
      * @param float $factor Factor
      *


### PR DESCRIPTION
Operations relative to other MoneyInterfaces objects are now
transparent (they do not return $this, but the comprared Money object).
This avoids that issuing such operations between Money and NullMoney
would return NullMoney instead of Money objects.

Setters were also deleted from MoneyInterface, since objects
implementing this interface will be value objects.

See issue #292 
