### PR TITLE
CurrencyWrapper now loads default currency at service creation time

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/EventListener/CartEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/EventListener/CartEventListenerTest.php
@@ -42,4 +42,16 @@ class CartEventListenerTest extends WebTestCase
     {
         return 'elcodi.core.cart.event_listener.cart';
     }
+
+    /**
+     * Load fixtures of these bundles
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCurrencyBundle',
+        ];
+    }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponEventListenerTest.php
@@ -30,7 +30,7 @@ class CartCouponEventListenerTest extends WebTestCase
      */
     protected function loadSchema()
     {
-        return false;
+        return true;
     }
 
     /**
@@ -42,6 +42,18 @@ class CartCouponEventListenerTest extends WebTestCase
     {
         return [
             'elcodi.core.cart_coupon.event_listener.cart'
+        ];
+    }
+
+    /**
+     * Load fixtures of these bundles
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCurrencyBundle',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/CartCouponManagerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/CartCouponManagerTest.php
@@ -31,7 +31,7 @@ class CartCouponManagerTest extends WebTestCase
      */
     protected function loadSchema()
     {
-        return false;
+        return true;
     }
 
     /**
@@ -71,5 +71,17 @@ class CartCouponManagerTest extends WebTestCase
             ->get('elcodi.cart_coupon_manager')
             ->getCoupons($cart)
         );
+    }
+
+    /**
+     * Load fixtures of these bundles
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCurrencyBundle',
+        ];
     }
 }

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Services/CouponManagerTest.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Services/CouponManagerTest.php
@@ -30,7 +30,7 @@ class CouponManagerTest extends WebTestCase
      */
     protected function loadSchema()
     {
-        return false;
+        return true;
     }
 
     /**
@@ -43,6 +43,18 @@ class CouponManagerTest extends WebTestCase
         return [
             'elcodi.core.coupon.service.coupon_manager',
             'elcodi.coupon_manager',
+        ];
+    }
+
+    /**
+     * Load fixtures of these bundles
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCurrencyBundle',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
@@ -65,6 +65,8 @@ services:
             currency_session_manager: @elcodi.currency_session_manager
             currency_repository: @elcodi.repository.currency
             default_currency: %elcodi.core.currency.default_currency%
+        calls:
+            - [loadCurrency]
 
     elcodi.currency_wrapper:
         alias: elcodi.core.currency.wrapper.currency

--- a/src/Elcodi/Component/Currency/Wrapper/CurrencyWrapper.php
+++ b/src/Elcodi/Component/Currency/Wrapper/CurrencyWrapper.php
@@ -85,9 +85,9 @@ class CurrencyWrapper
     /**
      * Loads Currency from session or repository
      *
-     * @return CurrencyInterface Instance of Customer loaded
+     * @return CurrencyInterface Instance of loaded Currency
      *
-     * @throws CurrencyNotAvailableException Any currency available
+     * @throws CurrencyNotAvailableException No available currencies
      */
     public function loadCurrency()
     {


### PR DESCRIPTION
In order to avoid to call CurrencyWrapper::loadCurrency manually
wherever a currency is needed in the application, the service definition
has been changed so that it gets called automatically.
