### PR TITLE
Bundle and Component for dynamic configuration

### DIFF
--- a/src/Elcodi/Bundle/ConfigurationBundle/.editorconfig
+++ b/src/Elcodi/Bundle/ConfigurationBundle/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/src/Elcodi/Bundle/ConfigurationBundle/.gitignore
+++ b/src/Elcodi/Bundle/ConfigurationBundle/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Elcodi/Bundle/ConfigurationBundle/.travis.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm-nightly
+
+matrix:
+    allow_failures:
+        - php: hhvm-nightly
+
+install:
+    - composer install --prefer-source --no-interaction
+
+script:
+    - phpunit
+
+notifications:
+    email: false

--- a/src/Elcodi/Bundle/ConfigurationBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/CompilerPass/MappingCompilerPass.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\CompilerPass;
+
+use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class MappingCompilerPass
+ */
+class MappingCompilerPass extends AbstractMappingCompilerPass
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     *
+     * @api
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this
+            ->addEntityMapping(
+                $container,
+                'elcodi.core.configuration.entity.configuration.manager',
+                'elcodi.core.configuration.entity.configuration.class',
+                'elcodi.core.configuration.entity.configuration.mapping_file',
+                'elcodi.core.configuration.entity.configuration.enabled'
+            );
+    }
+
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/DataFixtures/ORM/ConfigurationData.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/DataFixtures/ORM/ConfigurationData.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\DataFixtures\ORM;
+
+use Doctrine\Common\Persistence\ObjectManager;
+
+use Elcodi\Bundle\CoreBundle\DataFixtures\ORM\Abstracts\AbstractFixture;
+use Elcodi\Component\Configuration\Entity\Configuration;
+
+/**
+ * Class ConfigurationData
+ */
+class ConfigurationData extends AbstractFixture
+{
+
+    /**
+     * Load data fixtures with the passed EntityManager
+     *
+     * @param ObjectManager $manager
+     */
+    public function load(ObjectManager $manager)
+    {
+        /**
+         * @var Configuration $parameter1
+         */
+        $parameter1 = $this
+            ->get('elcodi.factory.configuration')
+            ->create();
+        $parameter1
+            ->setParameter('parameter1')
+            ->setValue('value1')
+            ->setEnabled(true);
+        $manager->persist($parameter1);
+
+        /**
+         * @var Configuration $parameter2
+         */
+        $parameter1 = $this
+            ->get('elcodi.factory.configuration')
+            ->create();
+        $parameter1
+            ->setParameter('parameter2')
+            ->setValue('value2')
+            ->setEnabled(true);
+        $manager->persist($parameter1);
+
+        $manager->flush();
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractConfiguration;
+use Elcodi\Component\Configuration\Adapter\DoctrineConfigurationProvider;
+use Elcodi\Component\Configuration\Adapter\DoctrineCacheConfigurationProvider;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ */
+class Configuration extends AbstractConfiguration implements ConfigurationInterface
+{
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root($this->extensionName);
+
+        $rootNode
+            ->children()
+                ->arrayNode('mapping')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->append($this->addMappingNode(
+                            'configuration',
+                            'Elcodi\Component\Configuration\Entity\Configuration',
+                            '@ElcodiConfigurationBundle/Resources/config/doctrine/Configuration.orm.yml',
+                            'default',
+                            true
+                        ))
+                    ->end()
+                ->end()
+            ->arrayNode('configuration')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('cache_key')
+                        ->defaultValue('configuration')
+                    ->end()
+                    ->enumNode('provider')
+                        ->values([
+                            DoctrineConfigurationProvider::ADAPTER_NAME,
+                            DoctrineCacheConfigurationProvider::ADAPTER_NAME
+                        ])
+                        ->defaultValue(DoctrineConfigurationProvider::ADAPTER_NAME)
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/ElcodiConfigurationExtension.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/ElcodiConfigurationExtension.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractExtension;
+use Elcodi\Bundle\CoreBundle\DependencyInjection\Interfaces\EntitiesOverridableExtensionInterface;
+use Elcodi\Component\Configuration\Adapter\DoctrineCacheConfigurationProvider;
+use Elcodi\Component\Configuration\Adapter\DoctrineConfigurationProvider;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ */
+class ElcodiConfigurationExtension extends AbstractExtension implements EntitiesOverridableExtensionInterface
+{
+    /**
+     * @var string
+     *
+     * Extension name
+     */
+    const EXTENSION_NAME = 'elcodi_configuration';
+
+    /**
+     * Get the Config file location
+     *
+     * @return string Config file location
+     */
+    public function getConfigFilesLocation()
+    {
+        return __DIR__ . '/../Resources/config';
+    }
+
+    /**
+     * Return a new Configuration instance.
+     *
+     * If object returned by this method is an instance of
+     * ConfigurationInterface, extension will use the Configuration to read all
+     * bundle config definitions.
+     *
+     * Also will call getParametrizationValues method to load some config values
+     * to internal parameters.
+     *
+     * @return ConfigurationInterface Configuration file
+     */
+    protected function getConfigurationInstance()
+    {
+        return new Configuration(static::EXTENSION_NAME);
+    }
+
+    /**
+     * Returns extension configuration
+     *
+     * @param array            $config    An array of configuration values
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     *
+     * @return ConfigurationInterface|null The configuration or null
+     */
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return $this->getConfigurationInstance();
+    }
+
+    /**
+     * Load Parametrization definition
+     *
+     * return array(
+     *      'parameter1' => $config['parameter1'],
+     *      'parameter2' => $config['parameter2'],
+     *      ...
+     * );
+     *
+     * @param array $config Bundles config values
+     *
+     * @return array Parametrization values
+     */
+    protected function getParametrizationValues(array $config)
+    {
+        return [
+            "elcodi.core.configuration.entity.configuration.class" => $config['mapping']['configuration']['class'],
+            "elcodi.core.configuration.entity.configuration.mapping_file" => $config['mapping']['configuration']['mapping_file'],
+            "elcodi.core.configuration.entity.configuration.manager" => $config['mapping']['configuration']['manager'],
+            'elcodi.core.configuration.cache_key' => $config['configuration']['cache_key'],
+        ];
+    }
+
+    /**
+     * Config files to load
+     *
+     * @param array $config Config
+     *
+     * @return array Config files
+     */
+    public function getConfigFiles(array $config)
+    {
+        return [
+            'classes',
+            'services',
+            'factories',
+            'repositories',
+            'objectManagers',
+            [
+                'configurationProvider/doctrineConfigurationProvider',
+                $config['configuration']['provider'] === DoctrineConfigurationProvider::ADAPTER_NAME
+            ],
+            [
+                'configurationProvider/doctrineCacheConfigurationProvider',
+                $config['configuration']['provider'] === DoctrineCacheConfigurationProvider::ADAPTER_NAME
+            ],
+            'twig'
+        ];
+    }
+
+    /**
+     * Get entities overrides.
+     *
+     * Result must be an array with:
+     * index: Original Interface
+     * value: Parameter where class is defined.
+     *
+     * @return array Overrides definition
+     */
+    public function getEntitiesOverrides()
+    {
+        return [
+            'Elcodi\Component\Configuration\Entity\Interfaces\ConfigurationInterface' => 'elcodi.core.configuration.entity.configuration.class',
+        ];
+    }
+
+    /**
+     * Returns the recommended alias to use in XML.
+     *
+     * This alias is also the mandatory prefix to use when using YAML.
+     *
+     * This convention is to remove the "Extension" postfix from the class
+     * name and then lowercase and underscore the result. So:
+     *
+     *     AcmeHelloExtension
+     *
+     * becomes
+     *
+     *     acme_hello
+     *
+     * This can be overridden in a sub-class to specify the alias manually.
+     *
+     * @return string The alias
+     */
+    public function getAlias()
+    {
+        return static::EXTENSION_NAME;
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/ElcodiConfigurationBundle.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/ElcodiConfigurationBundle.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+use Elcodi\Bundle\ConfigurationBundle\CompilerPass\MappingCompilerPass;
+use Elcodi\Bundle\ConfigurationBundle\DependencyInjection\ElcodiConfigurationExtension;
+
+/**
+ * ElcodiConfigurationBundle Class
+ */
+class ElcodiConfigurationBundle extends Bundle
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new MappingCompilerPass());
+    }
+
+    /**
+     * Returns the bundle's container extension.
+     *
+     * @return ExtensionInterface The container extension
+     */
+    public function getContainerExtension()
+    {
+        return new ElcodiConfigurationExtension();
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/LICENSE
+++ b/src/Elcodi/Bundle/ConfigurationBundle/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2012-2014 Room Social Networks S.L.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/Elcodi/Bundle/ConfigurationBundle/README.md
+++ b/src/Elcodi/Bundle/ConfigurationBundle/README.md
@@ -1,0 +1,44 @@
+Elcodi Configuration Bundle for Symfony2
+========================================
+
+This bundle is part of [elcodi project](https://github.com/elcodi).
+Elcodi is a set of flexible e-commerce components for Symfony2, built as a
+decoupled and isolated repositories and under
+[MIT](http://opensource.org/licenses/MIT) license.
+
+Documentation
+-------------
+
+Check the documentation in [Elcodi Docs](http://docs.elcodi.io). Feel free to
+propose new recipes, examples or guides; our main goal is to help the developer
+building their site.
+
+Tags
+----
+
+* Use last unstable version ( alias of `dev-master` ) to stay always in last commit
+* Use last stable version tag to stay in a stable release.
+
+Contributing
+------------
+
+All issues and Pull Requests should be on the main repository
+[elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
+
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs
+checks. Read more details about
+[Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
+and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+to run code validation.
+
+There is also a policy for contributing to this project. Pull requests must
+be explained step by step to make the review process easy in order to
+accept and merge them. New features must come paired with PHPUnit tests.
+
+If you would like to contribute, please read the [Contributing Code][1] in the project
+documentation. If you are submitting a pull request, please follow the guidelines
+in the [Submitting a Patch][2] section and use the [Pull Request Template][3].
+
+[1]: http://symfony.com/doc/current/contributing/code/index.html
+[2]: http://symfony.com/doc/current/contributing/code/patches.html#check-list
+[3]: http://symfony.com/doc/current/contributing/code/patches.html#make-a-pull-request

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/classes.yml
@@ -1,0 +1,21 @@
+parameters:
+
+    #
+    # Repositories
+    #
+    elcodi.core.configuration.repository.configuration.class: Elcodi\Component\Configuration\Repository\ConfigurationRepository
+
+    #
+    # Factories
+    #
+    elcodi.core.configuration.factory.configuration.class: Elcodi\Component\Configuration\Factory\ConfigurationFactory
+
+    #
+    # Services
+    #
+    elcodi.core.configuration.service.configuration_manager.class: Elcodi\Component\Configuration\Services\ConfigurationManager
+
+    #
+    # Twig extensions
+    #
+    elcodi.core.configuration.twig_extension.configuration_extension.class: Elcodi\Component\Configuration\Twig\ConfigurationExtension

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/configurationProvider/doctrineCacheConfigurationProvider.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/configurationProvider/doctrineCacheConfigurationProvider.yml
@@ -1,0 +1,19 @@
+parameters:
+
+    #
+    # Doctrine parameter configuration provider
+    #
+    elcodi.core.configuration.adapter.doctrine_cache_configuration_provider.class: Elcodi\Component\Configuration\Adapter\DoctrineCacheConfigurationProvider
+
+services:
+
+    #
+    # Doctrine parameter configuration provider
+    #
+    elcodi.core.configuration.adapter.doctrine_cache_configuration_provider:
+        class: %elcodi.core.configuration.adapter.doctrine_cache_configuration_provider.class%
+        calls:
+            - [setCache, [@doctrine_cache.providers.elcodi_configuration]]
+
+    elcodi.core.configuration.adapter.configuration_provider:
+        alias: elcodi.core.configuration.adapter.doctrine_cache_configuration_provider

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/configurationProvider/doctrineConfigurationProvider.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/configurationProvider/doctrineConfigurationProvider.yml
@@ -1,0 +1,21 @@
+parameters:
+
+    #
+    # Doctrine parameter configuration provider
+    #
+    elcodi.core.configuration.adapter.doctrine_configuration_provider.class: Elcodi\Component\Configuration\Adapter\DoctrineConfigurationProvider
+
+services:
+
+    #
+    # Doctrine parameter configuration provider
+    #
+    elcodi.core.configuration.adapter.doctrine_configuration_provider:
+        class: %elcodi.core.configuration.adapter.doctrine_configuration_provider.class%
+        arguments:
+            object_manager: @elcodi.object_manager.configuration
+            object_repository: @elcodi.repository.configuration
+            configuration_factory: @elcodi.factory.configuration
+
+    elcodi.core.configuration.adapter.configuration_provider:
+        alias: elcodi.core.configuration.adapter.doctrine_configuration_provider

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/doctrine/Configuration.orm.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/doctrine/Configuration.orm.yml
@@ -1,0 +1,45 @@
+Elcodi\Component\Configuration\Entity\Configuration:
+    type: entity
+    repositoryClass: Elcodi\Component\Configuration\Repository\ConfigurationRepository
+    table: configuration
+    indexes:
+        namespace_index:
+            columns: [ namespace ]
+        parameter_index:
+            columns: [ parameter ]
+        namespace_parameter_index:
+            columns: [ namespace, parameter ]
+    id:
+        id:
+            type: integer
+            generator:
+                strategy: AUTO
+    fields:
+        namespace:
+            column: namespace
+            type: string
+            length: 255
+            nullable: true
+        parameter:
+            column: parameter
+            type: string
+            length: 255
+            nullable: false
+        value:
+            column: value
+            type: string
+            length: 255
+            nullable: false
+        createdAt:
+            column: created_at
+            type: datetime
+        updatedAt:
+            column: updated_at
+            type: datetime
+        enabled:
+            column: enabled
+            type: boolean
+
+    lifecycleCallbacks:
+        preUpdate: [loadUpdateAt]
+        prePersist: [loadUpdateAt]

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/factories.yml
@@ -1,0 +1,16 @@
+services:
+
+    #
+    # Factories
+    #
+
+    #
+    # Factory for configuration entity
+    #
+    elcodi.core.configuration.factory.configuration:
+        class: %elcodi.core.configuration.factory.configuration.class%
+        calls:
+            - [setEntityNamespace, ["%elcodi.core.configuration.entity.configuration.class%"]]
+
+    elcodi.factory.configuration:
+        alias: elcodi.core.configuration.factory.configuration

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/objectManagers.yml
@@ -1,0 +1,11 @@
+services:
+
+    #
+    # Object Managers
+    #
+    elcodi.object_manager.configuration:
+        class: Doctrine\Common\Persistence\ObjectManager
+        factory_service: elcodi.manager_provider
+        factory_method: getManagerByEntityNamespace
+        arguments:
+            cart_namespace: %elcodi.core.configuration.entity.configuration.class%

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/repositories.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/repositories.yml
@@ -1,0 +1,18 @@
+services:
+
+    #
+    # Repositories
+    #
+
+    #
+    # Repository for entity configuration
+    #
+    elcodi.core.configuration.repository.configuration:
+        class: %elcodi.core.configuration.repository.configuration.class%
+        factory_service: elcodi.repository_provider
+        factory_method: getRepositoryByEntityNamespace
+        arguments:
+            entity_namespace: %elcodi.core.configuration.entity.configuration.class%
+
+    elcodi.repository.configuration:
+        alias: elcodi.core.configuration.repository.configuration

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
@@ -1,0 +1,12 @@
+services:
+
+    #
+    # Services
+    #
+    elcodi.core.configuration.service.configuration_manager:
+        class: %elcodi.core.configuration.service.configuration_manager.class%
+        arguments:
+            configuration_provider: @elcodi.core.configuration.adapter.configuration_provider
+
+    elcodi.configuration_manager:
+        alias: elcodi.core.configuration.service.configuration_manager

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
@@ -1,0 +1,11 @@
+services:
+
+    #
+    # Twig extensions
+    #
+    elcodi.core.configuration.twig_extension.configuration_extension:
+        class: %elcodi.core.configuration.twig_extension.configuration_extension.class%
+        arguments:
+            configuration_manager: @elcodi.configuration_manager
+        tags:
+            - { name: twig.extension }

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\Tests\Functional\Services;
+
+use Doctrine\ORM\EntityManager;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+use Elcodi\Component\Configuration\Entity\Configuration;
+use Elcodi\Component\Configuration\Services\ConfigurationManager;
+
+/**
+ * Class ConfigurationManagerTest
+ */
+class ConfigurationManagerTest extends WebTestCase
+{
+    /**
+     * @var ConfigurationManager
+     *
+     * Configuration manager
+     */
+    protected $configurationManager;
+
+    /**
+     * Schema must be loaded in all test cases
+     *
+     * @return boolean Load schema
+     */
+    protected function loadSchema()
+    {
+        return true;
+    }
+
+    /**
+     * Returns the callable name of the service
+     *
+     * @return string[] service name
+     */
+    public function getServiceCallableName()
+    {
+        return [
+            'elcodi.core.configuration.service.configuration_manager',
+            'elcodi.configuration_manager'
+        ];
+    }
+
+    /**
+     * Load fixtures of these bundles
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected function loadFixturesBundles()
+    {
+        return array(
+            'ElcodiConfigurationBundle',
+        );
+    }
+
+    /**
+     * Set up
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->configurationManager = $this->get('elcodi.configuration_manager');
+    }
+
+    /**
+     * Skips a test if the configuration provider is not Doctrine
+     *
+     * When using a different storage backend, it is useless to test
+     * doctrine-specific behaviors
+     */
+    protected function skipIfConfigurationProviderIsNotDoctrine()
+    {
+        /*
+         * We will skip the test if the configuration adapter
+         * is not DoctrineConfigurationAdapter
+         */
+        $configurationManager = $this->get('elcodi.configuration_manager');
+        $reflector = new \ReflectionObject($configurationManager);
+        $property = $reflector->getProperty('configurationProvider');
+        $property->setAccessible(true);
+
+        $configurationProviderClass = get_class($property->getValue($configurationManager));
+
+        if ('Elcodi\Component\Configuration\Adapter\DoctrineConfigurationProvider' != $configurationProviderClass) {
+            $this->markTestSkipped('Skipping a doctrine specific test');
+        }
+
+    }
+
+    /**
+     * Test getParameter
+     *
+     * @param $namespace string Namespace of the parameter
+     * @param $param     string Parameter Name
+     * @param $value     string Parameter Value
+     *
+     * @dataProvider dataConfiguration
+     */
+    public function testGetParameter($namespace, $param, $value)
+    {
+        $this->skipIfConfigurationProviderIsNotDoctrine();
+
+        /**
+         * @var EntityManager
+         */
+        $manager = $this->get('elcodi.object_manager.configuration');
+
+        /**
+         * @var Configuration $parameter1
+         */
+        $parameter1 = $this
+            ->get('elcodi.factory.configuration')
+            ->create();
+        $parameter1
+            ->setNamespace($namespace)
+            ->setParameter($param)
+            ->setValue($value)
+            ->setEnabled(true);
+        $manager->persist($parameter1);
+
+        $manager->flush($parameter1);
+
+        $this->assertEquals(
+            $value,
+            $this
+                ->configurationManager
+                ->getParameter($param, $namespace)
+        );
+    }
+
+    /**
+     * @dataProvider dataConfiguration
+     *
+     * @param $namespace string namespace
+     * @param $parameter string parameter name
+     * @param $value     string parameter value
+     */
+    public function testSetParameter($namespace, $parameter, $value)
+    {
+        $this
+            ->configurationManager
+            ->setParameter($parameter, $value, $namespace);
+
+        $this->assertEquals(
+            $value,
+            $this
+                ->configurationManager
+                ->getParameter($parameter, $namespace)
+        );
+    }
+
+    /**
+     * Tests a dynamically set parameter.
+     *
+     * See this test's app/config.yml for service definition
+     *
+     * These test services have their arguments injected via expression language
+     * service() function that ask for elcodi.configuration_manager
+     */
+    public function testDynamicServiceParameter()
+    {
+        $this->skipIfConfigurationProviderIsNotDoctrine();
+
+        /**
+         * @var $serviceTest1 TestService
+         */
+        $serviceTest1 = $this->get('elcodi.configuration.test1');
+
+        /*
+         * Expected 'value1' comes from DataFixtures
+         */
+        $this->assertEquals(
+            $serviceTest1->getParameterValue(),
+            'value1'
+        );
+
+        $serviceTest2 = $this->get('elcodi.configuration.test2');
+
+        $this->assertEquals(
+            $serviceTest2->getParameterValue(),
+            'default'
+        );
+    }
+
+    /**
+     * getParameter data provider
+     */
+    public function dataConfiguration()
+    {
+        return [
+            ['', 'param1', 'value1'],
+            ['namespace2', 'param2', 'value2'],
+            [123, 'param3', 12345]
+        ];
+    }
+
+}
+
+class TestService
+{
+    protected $parameterValue;
+
+    public function __construct($parameterValue)
+    {
+        $this->parameterValue = $parameterValue;
+    }
+
+    public function getParameterValue()
+    {
+        return $this->parameterValue;
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
@@ -171,8 +171,8 @@ class ConfigurationManagerTest extends WebTestCase
      *
      * See this test's app/config.yml for service definition
      *
-     * These test services have their arguments injected via expression language
-     * service() function that ask for elcodi.configuration_manager
+     * These test services have their arguments injected via expression-language's
+     * service() function that asks for elcodi.configuration_manager
      */
     public function testDynamicServiceParameter()
     {

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/AppKernel.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\Tests\Functional\app;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\Abstracts\AbstractElcodiKernel;
+
+/**
+ * Class AppKernel
+ */
+class AppKernel extends AbstractElcodiKernel
+{
+    /**
+     * Register application bundles
+     *
+     * @return array Array of bundles instances
+     */
+    public function registerBundles()
+    {
+        $bundles = array(
+
+            /**
+             * Symfony bundles
+             */
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+
+            /**
+             * Doctrine bundles
+             */
+            new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
+            new \Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
+
+            /**
+             * Elcodi core bundles
+             */
+            new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
+            new \Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle(),
+        );
+
+        return $bundles;
+    }
+
+    /**
+     * Gets the container class.
+     *
+     * @return string The container class
+     */
+    protected function getContainerClass()
+    {
+        return  $this->name .
+                ucfirst($this->environment) .
+                'DebugProjectContainerConfiguration';
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/config.yml
@@ -1,0 +1,48 @@
+imports:
+    - { resource: parameters.yml }
+
+framework:
+    test:            ~
+    session:
+        storage_id: session.storage.mock_file
+    secret:          "%secret%"
+    router:
+        resource: ~
+    form:            true
+    default_locale:  "%locale%"
+    templating:      { engines: ['php'] }
+
+# Doctrine Configuration
+doctrine:
+    dbal:
+        driver:   "%database_driver%"
+        host:     "%database_host%"
+        port:     "%database_port%"
+        dbname:   "%database_name%"
+        user:     "%database_user%"
+        password: "%database_password%"
+        path:     "%database_path%"
+        memory:   "%database_memory%"
+        charset:  UTF8
+    orm:
+        auto_generate_proxy_classes: "%kernel.debug%"
+        metadata_cache_driver: array
+        query_cache_driver: array
+        result_cache_driver: array
+        auto_mapping: false
+
+doctrine_cache:
+   providers:
+      elcodi_configuration:
+         type: array
+
+services:
+    elcodi.configuration.test1:
+        class: Elcodi\Bundle\ConfigurationBundle\Tests\Functional\Services\TestService
+        arguments:
+            parameter_value: @=service('elcodi.configuration_manager').getParameter('parameter1') ?: 'default'
+
+    elcodi.configuration.test2:
+        class: Elcodi\Bundle\ConfigurationBundle\Tests\Functional\Services\TestService
+        arguments:
+            parameter_value: @=service('elcodi.configuration_manager').getParameter('non_existant_parameter') ?: 'default'

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/parameters.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/parameters.yml
@@ -1,0 +1,12 @@
+parameters:
+
+    database_driver: pdo_sqlite
+    database_host: 127.0.0.1
+    database_port: null
+    database_name: elcodi_test
+    database_user: root
+    database_password: root
+    database_path: %kernel.cache_dir%/elcodi.test
+    database_memory: false
+    locale: en
+    secret: keepcalmandengonga

--- a/src/Elcodi/Bundle/ConfigurationBundle/composer.json
+++ b/src/Elcodi/Bundle/ConfigurationBundle/composer.json
@@ -23,6 +23,7 @@
         "php": ">=5.4",
         "doctrine/common": "~2.4",
         "doctrine/orm": "~2.4",
+        "doctrine/doctrine-bundle": "~1.2",
         "doctrine/doctrine-cache-bundle": "~1.0",
 
         "symfony/http-kernel": "~2.4, >2.4.6",
@@ -34,7 +35,10 @@
         "elcodi/configuration": "~0.3.0"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.3.0"
+        "elcodi/test-common-bundle": "~0.3.0",
+        "symfony/expression-language": "~2.4",
+        "doctrine/doctrine-fixtures-bundle": "2.2.*",
+        "doctrine/data-fixtures": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Elcodi/Bundle/ConfigurationBundle/composer.json
+++ b/src/Elcodi/Bundle/ConfigurationBundle/composer.json
@@ -1,0 +1,49 @@
+{
+    "name": "elcodi/configuration-bundle",
+    "description": "Elcodi Configurationm Bundle",
+    "keywords": ["elcodi", "configuration", "ecommerce"],
+    "homepage": "https://github.com/elcodi/ConfigurationBundle",
+    "type": "symfony-bundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Marc Morera",
+            "email": "yuhu@mmoreram.com"
+        },
+        {
+            "name": "Aldo Chiecchia",
+            "email": "zimage@tiscali.it"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://github.com/elcodi/ConfigurationBundle/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.4",
+        "doctrine/common": "~2.4",
+        "doctrine/orm": "~2.4",
+        "doctrine/doctrine-cache-bundle": "~1.0",
+
+        "symfony/http-kernel": "~2.4, >2.4.6",
+        "symfony/config": "~2.4",
+        "symfony/dependency-injection": "~2.4",
+        "mmoreram/simple-doctrine-mapping": "~0.1",
+
+        "elcodi/core-bundle": "~0.3.0",
+        "elcodi/configuration": "~0.3.0"
+    },
+    "require-dev": {
+        "elcodi/test-common-bundle": "~0.3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Elcodi\\Bundle\\ConfigurationBundle\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.4-dev"
+        }
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/phpunit.xml.dist
+++ b/src/Elcodi/Bundle/ConfigurationBundle/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Elcodi bundle package">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./Resources</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Elcodi/Component/Configuration/.editorconfig
+++ b/src/Elcodi/Component/Configuration/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/src/Elcodi/Component/Configuration/.gitignore
+++ b/src/Elcodi/Component/Configuration/.gitignore
@@ -1,0 +1,4 @@
+vendor
+composer.phar
+composer.lock
+phpunit.xml

--- a/src/Elcodi/Component/Configuration/.travis.yml
+++ b/src/Elcodi/Component/Configuration/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm-nightly
+
+matrix:
+    allow_failures:
+        - php: hhvm-nightly
+
+install:
+    - composer install --prefer-source --no-interaction
+
+script:
+    - phpunit
+
+notifications:
+    email: false

--- a/src/Elcodi/Component/Configuration/Adapter/DoctrineCacheConfigurationProvider.php
+++ b/src/Elcodi/Component/Configuration/Adapter/DoctrineCacheConfigurationProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Adapter;
+
+use Elcodi\Component\Configuration\Adapter\Interfaces\ConfigurationProviderInterface;
+use Elcodi\Component\Core\Wrapper\Abstracts\AbstractCacheWrapper;
+
+/**
+ * Class DoctrineCacheConfigurationProvider
+ */
+class DoctrineCacheConfigurationProvider extends AbstractCacheWrapper implements ConfigurationProviderInterface
+{
+    /**
+     * @var string
+     *
+     * Adapter name
+     */
+    const ADAPTER_NAME = 'doctrine_cache';
+
+    /**
+     * Sets a parameter value
+     *
+     * @param $parameter
+     * @param $value
+     *
+     * @return $this self Object
+     */
+    public function setParameter($parameter, $value, $namespace = "")
+    {
+        $namespace = $namespace ? "$namespace." : "";
+
+        $this
+            ->cache
+            ->save($namespace.$parameter, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param $parameter
+     *
+     * @return null|string
+     */
+    public function getParameter($parameter, $namespace = "")
+    {
+        $namespace = $namespace ? "$namespace." : "";
+
+        return $this
+            ->cache
+            ->fetch($namespace.$parameter);
+    }
+}

--- a/src/Elcodi/Component/Configuration/Adapter/DoctrineConfigurationProvider.php
+++ b/src/Elcodi/Component/Configuration/Adapter/DoctrineConfigurationProvider.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Adapter;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+
+use Elcodi\Component\Configuration\Adapter\Interfaces\ConfigurationProviderInterface;
+use Elcodi\Component\Configuration\Entity\Interfaces\ConfigurationInterface;
+use Elcodi\Component\Core\Factory\Abstracts\AbstractFactory;
+
+/**
+ * Class DoctrineConfigurationProvider
+ */
+class DoctrineConfigurationProvider implements ConfigurationProviderInterface
+{
+    /**
+     * @var string
+     *
+     * Adapter name
+     */
+    const ADAPTER_NAME = 'doctrine';
+
+    /**
+     * @var ObjectManager
+     *
+     * Object manager
+     */
+    protected $manager;
+
+    /**
+     * @var ObjectRepository
+     *
+     * Object repository
+     */
+    protected $repository;
+
+    /**
+     * @var AbstractFactory
+     *
+     * Configuration factory
+     */
+    protected $configurationFactory;
+
+    /**
+     * @param ObjectManager    $manager              Object manager
+     * @param ObjectRepository $repository           Object repository
+     * @param AbstractFactory  $configurationFactory Configuration factory
+     */
+    public function __construct(ObjectManager $manager, ObjectRepository $repository, AbstractFactory $configurationFactory)
+    {
+        $this->manager = $manager;
+        $this->repository = $repository;
+        $this->configurationFactory = $configurationFactory;
+    }
+
+    /**
+     * Sets a parameter value
+     *
+     * @param $parameter string parameter name
+     * @param $value     string parameter value
+     * @param $namespace string namespace
+     *
+     * @return $this self Object
+     */
+    public function setParameter($parameter, $value, $namespace = "")
+    {
+        $configuration = $this
+            ->configurationFactory
+            ->create()
+            ->setParameter($parameter)
+            ->setNamespace($namespace)
+            ->setValue($value);
+
+        $this
+            ->manager
+            ->persist($configuration);
+
+        $this
+            ->manager
+            ->flush();
+
+        return $this;
+    }
+
+    /**
+     * Gets a parameter value
+     *
+     * @param $parameter string parameter name
+     * @param $namespace string namespace
+     *
+     * @return string
+     */
+    public function getParameter($parameter, $namespace = "")
+    {
+        /**
+         * @var ConfigurationInterface
+         */
+        $configuration = $this
+            ->repository
+            ->findOneBy(['parameter' => $parameter, 'namespace' => $namespace]);
+
+        return $configuration ? $configuration->getValue() : null;
+    }
+}

--- a/src/Elcodi/Component/Configuration/Adapter/Interfaces/ConfigurationProviderInterface.php
+++ b/src/Elcodi/Component/Configuration/Adapter/Interfaces/ConfigurationProviderInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Adapter\Interfaces;
+
+/**
+ * Interface ConfigurationProviderInterface
+ */
+interface ConfigurationProviderInterface
+{
+    /**
+     * Gets a parameter value
+     *
+     * @param $parameter string parameter name
+     * @param $namespace string namespace
+     *
+     * @return null|string
+     */
+    public function getParameter($parameter, $namespace = "");
+
+    /**
+     * Sets a parameter value
+     *
+     * @param $parameter string parameter name
+     * @param $value     string parameter value
+     * @param $namespace string namespace
+     *
+     * @return $this self Object
+     */
+    public function setParameter($parameter, $value, $namespace = "");
+}

--- a/src/Elcodi/Component/Configuration/Entity/Configuration.php
+++ b/src/Elcodi/Component/Configuration/Entity/Configuration.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Entity;
+
+use Elcodi\Component\Configuration\Entity\Interfaces\ConfigurationInterface;
+use Elcodi\Component\Core\Entity\Traits\DateTimeTrait;
+use Elcodi\Component\Core\Entity\Traits\EnabledTrait;
+
+/**
+ * Class Parameter
+ */
+class Configuration implements ConfigurationInterface
+{
+    use DateTimeTrait, EnabledTrait;
+
+    /**
+     * @var integer
+     *
+     * Entity id
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * Configuration namespace
+     */
+    protected $namespace;
+
+    /**
+     * @var string
+     *
+     * Parameter name
+     */
+    protected $parameter;
+
+    /**
+     * @var string
+     *
+     * Configuration value
+     */
+    protected $value;
+
+    /**
+     * Set id
+     *
+     * @param int $id Entity Id
+     *
+     * @return $this self Object
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get id
+     *
+     * @return int Entity identifier
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Gets parameter name
+     *
+     * @return string
+     */
+    public function getParameter()
+    {
+        return $this->parameter;
+    }
+
+    /**
+     * Sets parameter name
+     *
+     * @param string $name
+     *
+     * @return $this self Object
+     */
+    public function setParameter($name)
+    {
+        $this->parameter = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets configuration value
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets ocnfiguration value
+     *
+     * @param mixed $value
+     *
+     * @return $this self Object
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * Gets configuration namespace
+     *
+     * @return mixed
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Setc configuration namespace
+     *
+     * @param mixed $namespace
+     *
+     * @return $this self Object
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+
+        return $this;
+    }
+}

--- a/src/Elcodi/Component/Configuration/Entity/Interfaces/ConfigurationInterface.php
+++ b/src/Elcodi/Component/Configuration/Entity/Interfaces/ConfigurationInterface.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Entity\Interfaces;
+
+use Elcodi\Component\Core\Entity\Interfaces\DateTimeInterface;
+use Elcodi\Component\Core\Entity\Interfaces\EnabledInterface;
+
+/**
+ * Interface ConfigurationInterface
+ */
+interface ConfigurationInterface extends DateTimeInterface, EnabledInterface
+{
+    /**
+     * Gets parameter name
+     *
+     * @return mixed
+     */
+    public function getParameter();
+
+    /**
+     * Sets parameter name
+     *
+     * @param mixed $name
+     *
+     * @return $this self Object
+     */
+    public function setParameter($name);
+
+    /**
+     * Gets configuration value
+     *
+     * @return mixed
+     */
+    public function getValue();
+
+    /**
+     * Sets configuration value
+     *
+     * @param mixed $value
+     *
+     * @return $this self Object
+     */
+    public function setValue($value);
+
+    /**
+     * Gets configuration namespace
+     *
+     * @return mixed
+     */
+    public function getNamespace();
+
+    /**
+     * Sets configuration namespace
+     *
+     * @param mixed $namespace
+     *
+     * @return $this self Object
+     */
+    public function setNamespace($namespace);
+}

--- a/src/Elcodi/Component/Configuration/Factory/ConfigurationFactory.php
+++ b/src/Elcodi/Component/Configuration/Factory/ConfigurationFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Factory;
+
+use DateTime;
+
+use Elcodi\Component\Configuration\Entity\Configuration;
+use Elcodi\Component\Core\Factory\Abstracts\AbstractFactory;
+
+class ConfigurationFactory extends AbstractFactory
+{
+
+    /**
+     * Creates an instance of an entity.
+     *
+     * Queries should be implemented in a repository class
+     *
+     * This method must always returns an empty instance of the related Entity
+     * and initializes it in a consistent state
+     *
+     * @return Object Empty entity
+     */
+    public function create()
+    {
+        /**
+         * @var Configuration $configuration
+         */
+        $classNamespace = $this->getEntityNamespace();
+        $configuration = new $classNamespace();
+
+        $configuration
+            ->setNamespace('')
+            ->setParameter('')
+            ->setValue('')
+            ->setEnabled(false)
+            ->setCreatedAt(new DateTime());
+
+        return $configuration;
+    }
+}

--- a/src/Elcodi/Component/Configuration/LICENSE
+++ b/src/Elcodi/Component/Configuration/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2012-2014 Room Social Networks S.L.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/Elcodi/Component/Configuration/README.md
+++ b/src/Elcodi/Component/Configuration/README.md
@@ -1,0 +1,44 @@
+Elcodi Configuration component for Symfony2
+===========================================
+
+This bundle is part of [elcodi project](https://github.com/elcodi).
+Elcodi is a set of flexible e-commerce components for Symfony2, built as a
+decoupled and isolated repositories and under
+[MIT](http://opensource.org/licenses/MIT) license.
+
+Documentation
+-------------
+
+Check the documentation in [Elcodi Docs](http://docs.elcodi.io). Feel free to
+propose new recipes, examples or guides; our main goal is to help the developer
+building their site.
+
+Tags
+----
+
+* Use last unstable version ( alias of `dev-master` ) to stay always in last commit
+* Use last stable version tag to stay in a stable release.
+
+Contributing
+------------
+
+All issues and Pull Requests should be on the main repository
+[elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
+
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs
+checks. Read more details about
+[Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
+and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+to run code validation.
+
+There is also a policy for contributing to this project. Pull requests must
+be explained step by step to make the review process easy in order to
+accept and merge them. New features must come paired with PHPUnit tests.
+
+If you would like to contribute, please read the [Contributing Code][1] in the project
+documentation. If you are submitting a pull request, please follow the guidelines
+in the [Submitting a Patch][2] section and use the [Pull Request Template][3].
+
+[1]: http://symfony.com/doc/current/contributing/code/index.html
+[2]: http://symfony.com/doc/current/contributing/code/patches.html#check-list
+[3]: http://symfony.com/doc/current/contributing/code/patches.html#make-a-pull-request

--- a/src/Elcodi/Component/Configuration/Repository/ConfigurationRepository.php
+++ b/src/Elcodi/Component/Configuration/Repository/ConfigurationRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Class ConfigurationRepository
+ */
+class ConfigurationRepository extends EntityRepository
+{
+
+}

--- a/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
+++ b/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Services;
+
+use Elcodi\Component\Configuration\Adapter\Interfaces\ConfigurationProviderInterface;
+use Elcodi\Component\Configuration\Entity\Configuration;
+
+/**
+ * Class ConfigurationManager
+ */
+class ConfigurationManager
+{
+    /**
+     * @var ConfigurationProviderInterface
+     */
+    protected $configurationProvider;
+
+    public function __construct(ConfigurationProviderInterface $configurationProvider)
+    {
+        $this->configurationProvider = $configurationProvider;
+    }
+
+    /**
+     * Sets a parameter name
+     *
+     * @param $parameter string parameter name
+     * @param $value     string parameter value
+     * @param $namespace string namespace
+     *
+     * @return $this self Object
+     */
+    public function setParameter($parameter, $value, $namespace = "")
+    {
+        $this
+            ->configurationProvider
+            ->setParameter($parameter, $value, $namespace);
+
+        return $this;
+    }
+
+    /**
+     * Gets a parameter value
+     *
+     * @param $parameter string parameter name
+     * @param $namespace string namespace
+     *
+     * @return null|string
+     */
+    public function getParameter($parameter, $namespace = "")
+    {
+        /**
+         * @var Configuration $configuration
+         */
+        $configuration  = $this
+            ->configurationProvider
+            ->getParameter($parameter, $namespace);
+
+        return $configuration;
+    }
+}

--- a/src/Elcodi/Component/Configuration/Tests/UnitTest/Services/ConfigurationManagerTest.php
+++ b/src/Elcodi/Component/Configuration/Tests/UnitTest/Services/ConfigurationManagerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Tests\Services;
+
+use PHPUnit_Framework_TestCase;
+
+use Elcodi\Component\Configuration\Adapter\Interfaces\ConfigurationProviderInterface;
+use Elcodi\Component\Configuration\Services\ConfigurationManager;
+
+class ConfigurationManagerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests get Parameter
+     *
+     * @dataProvider dataParameters
+     *
+     * @param $parameter string parameter name
+     * @param $value     string parameter value
+     */
+    public function testGetParameter($parameter, $value)
+    {
+        $testArrayParameters = [
+            'param1' => 'value1',
+            'param2' => 'value2',
+            'param3' => NULL
+        ];
+
+        $configurationManager = new ConfigurationManager(
+            new ArrayConfigurationProvider($testArrayParameters)
+        );
+
+        $this->assertEquals(
+            $value,
+            $configurationManager->getParameter($parameter)
+        );
+    }
+
+    /**
+     * Tests set Parameter
+     *
+     * @dataProvider dataParameters
+     *
+     * @param $parameter string parameter name
+     * @param $value     string parameter value
+     */
+    public function testSetParameter($parameter, $value)
+    {
+        $configurationManager = new ConfigurationManager(
+            new ArrayConfigurationProvider([])
+        );
+
+        $configurationManager->setParameter($parameter, $value);
+
+        $this->assertEquals(
+            $value,
+            $configurationManager->getParameter($parameter)
+        );
+    }
+
+    /**
+     * Tests that a nonexistant parameter returns null
+     */
+    public function testGetNullParameter()
+    {
+        $configurationManager = new ConfigurationManager(
+            new ArrayConfigurationProvider([])
+        );
+
+        $this->assertNull(
+            $configurationManager->getParameter('parameter1')
+        );
+    }
+
+    /**
+     * Data provider for parameter data
+     */
+    public function dataParameters()
+    {
+        return [
+            ['param1', 'value1'],
+            ['param2', 'value2'],
+            ['param3', NULL]
+        ];
+    }
+
+}
+
+class ArrayConfigurationProvider implements ConfigurationProviderInterface
+{
+    private $parameters = [];
+
+    public function __construct(array $parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    public function getParameter($parameter, $namespace = "")
+    {
+        if (!array_key_exists($parameter, $this->parameters)) {
+            return null;
+        }
+
+        return $this->parameters[$parameter];
+    }
+
+    public function setParameter($parameter, $value, $namespace = "")
+    {
+        $this->parameters[$parameter] = $value;
+
+        return $this;
+    }
+}

--- a/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
+++ b/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Configuration\Twig;
+
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+use Elcodi\Component\Configuration\Services\ConfigurationManager;
+
+/**
+ * Class ConfigurationExtension
+ *
+ * Provides a simple twig function to access runtime configuration parameters
+ */
+class ConfigurationExtension extends Twig_Extension
+{
+    /**
+     * @var ConfigurationManager
+     */
+    protected $configurationManager;
+
+    /**
+     * @param ConfigurationManager $configurationManager
+     */
+    public function __construct(ConfigurationManager $configurationManager)
+    {
+        $this->configurationManager = $configurationManager;
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new Twig_SimpleFunction('config_parameter', array($this, 'getParameter'))
+        );
+    }
+
+    /**
+     * Returns a configuration parameter given a parameter name and namespace
+     *
+     * @param $parameter
+     * @param string $namespace
+     *
+     * @return mixed
+     */
+    public function getParameter($parameter, $namespace = "")
+    {
+        return $this
+            ->configurationManager
+            ->getParameter($parameter, $namespace);
+    }
+
+    /**
+     * return extension name
+     *
+     * @return string extension name
+     */
+    public function getName()
+    {
+        return 'configuration_extension';
+    }
+}

--- a/src/Elcodi/Component/Configuration/composer.json
+++ b/src/Elcodi/Component/Configuration/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "elcodi/configuration",
+    "description": "Elcodi Configuration Component",
+    "keywords": ["elcodi", "Configuration", "ecommerce", "component"],
+    "homepage": "https://github.com/elcodi/Configuration",
+
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Marc Morera",
+            "email": "yuhu@mmoreram.com"
+        },
+        {
+            "name": "Aldo Chiecchia",
+            "email": "zimage@tiscali.it"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://github.com/elcodi/Configuration/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.4",
+        "doctrine/common": "~2.4",
+        "doctrine/orm": "~2.4",
+
+        "elcodi/core": "~0.3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Elcodi\\Component\\Configuration\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.4-dev"
+        }
+    }
+}

--- a/src/Elcodi/Component/Configuration/phpunit.xml.dist
+++ b/src/Elcodi/Component/Configuration/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Elcodi component package">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests/</directory>
+                <directory>./vendor/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Initial PR for discussing the component/bundle for dynamic configuration.

At the present state, a simple Entity holds a `Configuration`, which is a simple _key/value_ store. The configuration Entity looks like this:

``` php
protected $namespace = "";
protected $parameter;
protected $value;
```

A default adapter for using such an entity with doctrine `ORM` or `ODM` is proposed.
A second adapter to work with in memory/NOSQL key-value engines (such as `Redis`) is under way and needs to be discussed (Like injecting a specific `Redis` service or a more generic cache, like the [LiipDoctrineCacheBundle](https://github.com/liip/LiipDoctrineCacheBundle)

Some things need to be polished (like role intrefaces)
