### PR TITLE
Fix travis environment for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
         - php: hhvm-nightly
 
 env:
-    - SYMFONY_VERSION="2.4.*" TWIG_REQUIRED=false
-    - SYMFONY_VERSION="2.4.*" TWIG_REQUIRED=true
+    - SYMFONY_VERSION="2.6.*" TWIG_REQUIRED=false
+    - SYMFONY_VERSION="2.6.*" TWIG_REQUIRED=true
 
 before_install:
     - composer require --no-update symfony/http-kernel:${SYMFONY_VERSION}


### PR DESCRIPTION
Travis configuration is messing with dependencies which weren't updated on previous symfony 2.6 migration.
