### PR TITLE
Add entity-translator dependency

### DIFF
--- a/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
@@ -31,6 +31,7 @@
         "mmoreram/simple-doctrine-mapping": "~0.1",
 
         "elcodi/core-bundle": "~0.4.0",
+        "elcodi/entity-translator": "~0.4.0",
         "elcodi/language-bundle": "~0.4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Setting `entity-translator` as a dependency of `entity-translator-bundle`
