### PR TITLE
PluginBundle and Hook support

### DIFF
--- a/src/Elcodi/Bundle/PluginBundle/.editorconfig
+++ b/src/Elcodi/Bundle/PluginBundle/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/src/Elcodi/Bundle/PluginBundle/.gitignore
+++ b/src/Elcodi/Bundle/PluginBundle/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Elcodi/Bundle/PluginBundle/.travis.yml
+++ b/src/Elcodi/Bundle/PluginBundle/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm-nightly
+
+matrix:
+    allow_failures:
+        - php: hhvm-nightly
+
+install:
+    - composer install --prefer-source --no-interaction
+
+script:
+    - phpunit
+
+notifications:
+    email: false

--- a/src/Elcodi/Bundle/PluginBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/PluginBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\PluginBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractConfiguration;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ */
+class Configuration extends AbstractConfiguration
+{
+    /**
+     * Configure the root node
+     *
+     * @param ArrayNodeDefinition $rootNode
+     */
+    protected function setupTree(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->scalarNode('hook_system')
+                    ->defaultValue('elcodi.core.plugin.hook_system.adapter.event_dispatcher')
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Elcodi/Bundle/PluginBundle/DependencyInjection/ElcodiPluginExtension.php
+++ b/src/Elcodi/Bundle/PluginBundle/DependencyInjection/ElcodiPluginExtension.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\PluginBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractExtension;
+
+/**
+ * Class ElcodiPluginExtension
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class ElcodiPluginExtension extends AbstractExtension
+{
+    /**
+     * @var string
+     *
+     * Extension name
+     */
+    const EXTENSION_NAME = 'elcodi_plugin';
+
+    /**
+     * Get the Config file location
+     *
+     * @return string Config file location
+     */
+    public function getConfigFilesLocation()
+    {
+        return __DIR__ . '/../Resources/config';
+    }
+
+    /**
+     * Config files to load
+     *
+     * @param array $config Configuration
+     *
+     * @return array Config files
+     */
+    public function getConfigFiles(array $config)
+    {
+        return [
+            'classes',
+            'services',
+            'twig',
+        ];
+    }
+
+    /**
+     * Return a new Configuration instance.
+     *
+     * If object returned by this method is an instance of
+     * ConfigurationInterface, extension will use the Configuration to read all
+     * bundle config definitions.
+     *
+     * Also will call getParametrizationValues method to load some config values
+     * to internal parameters.
+     *
+     * @return ConfigurationInterface Configuration file
+     */
+    protected function getConfigurationInstance()
+    {
+        return new Configuration($this->getAlias());
+    }
+
+    /**
+     * Hook after load the full container.
+     *
+     * @param array            $config
+     * @param ContainerBuilder $container
+     */
+    public function postLoad(array $config, ContainerBuilder $container)
+    {
+        parent::postLoad($config, $container);
+
+        if (!$container->has($config['hook_system'])) {
+
+            throw new InvalidArgumentException(sprintf(
+                'The config "%s.hook_system" has a dependency on a non-existent service "%s".',
+                $this->getAlias(),
+                $config['hook_system']
+            ));
+        }
+
+        $container->setAlias('elcodi.hook_system', $config['hook_system']);
+    }
+
+    /**
+     * Returns the extension alias, same value as extension name
+     *
+     * @return string The alias
+     */
+    public function getAlias()
+    {
+        return self::EXTENSION_NAME;
+    }
+}

--- a/src/Elcodi/Bundle/PluginBundle/ElcodiPluginBundle.php
+++ b/src/Elcodi/Bundle/PluginBundle/ElcodiPluginBundle.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\PluginBundle;
+
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+use Elcodi\Bundle\PluginBundle\DependencyInjection\ElcodiPluginExtension;
+
+/**
+ * Class ElcodiPluginBundle
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class ElcodiPluginBundle extends Bundle
+{
+    /**
+     * Returns the bundle's container extension.
+     *
+     * @return ExtensionInterface The container extension
+     */
+    public function getContainerExtension()
+    {
+        return new ElcodiPluginExtension();
+    }
+}

--- a/src/Elcodi/Bundle/PluginBundle/LICENSE
+++ b/src/Elcodi/Bundle/PluginBundle/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2012-2014 Room Social Networks S.L.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/Elcodi/Bundle/PluginBundle/README.md
+++ b/src/Elcodi/Bundle/PluginBundle/README.md
@@ -1,0 +1,50 @@
+Elcodi Plugin bundle
+====================
+You can find the last version [here](https://github.com/elcodi/plugin-bundle).
+
+This component is part of [Elcodi project](https://github.com/elcodi).
+
+[Elcodi](http://elcodi.io) is a set of flexible e-commerce components for [Symfony2](http://symfony.com), built as decoupled and isolated repositories and under [MIT license](http://opensource.org/licenses/MIT).
+
+Rationale
+---------
+This bundle integrates `elcodi/plugin` into your Symfony2 application.
+
+Installation
+------------
+1. Open a terminal and use [Composer](https://getcomposer.org/download) to grab the library.
+    ``` bash
+    $ composer require elcodi/plugin-bundle
+    ```
+
+2. Register the `Elcodi\Bundle\PluginBundle\ElcodiPluginBundle` in your application `Kernel`.
+3. Optionally configure the bundle in your `config.yml`.
+
+Configuration
+-------------
+Working default values are provided so you can skip this step.
+
+```yaml
+# Default configuration for extension with alias: "elcodi_plugin"
+elcodi_plugin:
+    # Replace `elcodi.hook_system` by your own service. Should implement HookSystemInterface.
+    hook_system: elcodi.core.plugin.hook_system.adapter.event_dispatcher
+```
+
+Documentation
+-------------
+Check the documentation in [Elcodi Docs](http://docs.elcodi.io). Feel free to propose new recipes, examples or guides; our main goal is to help the developer building their site.
+
+Contributing
+------------
+All issues and Pull Requests should be on the main repository [elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
+
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard) to run code validation.
+
+There is also a policy for contributing to this project. Pull requests must be explained step by step to make the review process easy in order to accept and merge them. New features must come paired with PHPUnit tests.
+
+If you would like to contribute, please read the [Contributing Code][1] in the project documentation. If you are submitting a pull request, please follow the guidelines in the [Submitting a Patch][2] section and use the [Pull Request Template][3].
+
+[1]: http://symfony.com/doc/current/contributing/code/index.html
+[2]: http://symfony.com/doc/current/contributing/code/patches.html#check-list
+[3]: http://symfony.com/doc/current/contributing/code/patches.html#make-a-pull-request

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/classes.yml
@@ -1,0 +1,11 @@
+parameters:
+
+    #
+    # Services
+    #
+    elcodi.core.plugin.hook_system.adapter.event_dispatcher.class: Elcodi\Component\Plugin\Adapter\EventDispatcher\HookSystemAdapter
+
+    #
+    # Twig extensions
+    #
+    elcodi.core.plugin.twig_extension.hook.class: Elcodi\Bundle\PluginBundle\Twig\HookExtension

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
@@ -1,0 +1,9 @@
+services:
+
+    #
+    # Services
+    #
+    elcodi.core.plugin.hook_system.adapter.event_dispatcher:
+        class: %elcodi.core.plugin.hook_system.adapter.event_dispatcher.class%
+        arguments:
+            - @event_dispatcher

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
@@ -1,0 +1,11 @@
+services:
+
+    #
+    # Twig extensions
+    #
+    elcodi.core.plugin.twig_extension.hook:
+        class: %elcodi.core.plugin.twig_extension.hook.class%
+        arguments:
+            - @elcodi.hook_system
+        tags:
+            - { name: twig.extension }

--- a/src/Elcodi/Bundle/PluginBundle/Twig/HookExtension.php
+++ b/src/Elcodi/Bundle/PluginBundle/Twig/HookExtension.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\PluginBundle\Twig;
+
+use Elcodi\Component\Plugin\HookSystemInterface;
+
+/**
+ * Class HookExtension for Twig
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class HookExtension extends \Twig_Extension
+{
+    /**
+     * @var HookSystemInterface $hookSystem
+     *
+     * Where to execute the hooks
+     */
+    protected $hookSystem;
+
+    /**
+     * Construct
+     *
+     * @param HookSystemInterface $hookSystem
+     */
+    public function __construct(HookSystemInterface $hookSystem)
+    {
+        $this->hookSystem = $hookSystem;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction(
+                'elcodi_hook',
+                [$this->hookSystem, 'execute'],
+                [
+                    'is_safe' => ['html'],
+                ]
+            ),
+        ];
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'hook_extension';
+    }
+}

--- a/src/Elcodi/Bundle/PluginBundle/composer.json
+++ b/src/Elcodi/Bundle/PluginBundle/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "elcodi/plugin-bundle",
+    "description": "Elcodi Plugin Bundle",
+    "keywords": ["elcodi", "plugin", "ecommerce"],
+    "homepage": "https://github.com/elcodi/PluginBundle",
+    "type": "symfony-bundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Marc Morera",
+            "email": "yuhu@mmoreram.com"
+        },
+        {
+            "name": "Aldo Chiecchia",
+            "email": "zimage@tiscali.it"
+        },
+        {
+            "name": "Elcodi Community",
+            "homepage": "https://github.com/elcodi/PluginBundle/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.4",
+
+        "symfony/config": "~2.6",
+        "symfony/dependency-injection": "~2.6",
+        "symfony/http-kernel": "~2.6",
+
+        "elcodi/core-bundle": "~0.4.0",
+        "elcodi/plugin": "~0.4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Elcodi\\Bundle\\PluginBundle\\": ""
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.5-dev"
+        }
+    }
+}

--- a/src/Elcodi/Bundle/PluginBundle/phpunit.xml.dist
+++ b/src/Elcodi/Bundle/PluginBundle/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Elcodi bundle package">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./Resources</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Elcodi/Component/Plugin/.editorconfig
+++ b/src/Elcodi/Component/Plugin/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/src/Elcodi/Component/Plugin/.gitignore
+++ b/src/Elcodi/Component/Plugin/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Elcodi/Component/Plugin/.travis.yml
+++ b/src/Elcodi/Component/Plugin/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm-nightly
+
+matrix:
+    allow_failures:
+        - php: hhvm-nightly
+
+install:
+    - composer install --prefer-source --no-interaction
+
+script:
+    - phpunit
+
+notifications:
+    email: false

--- a/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/EventAdapter.php
+++ b/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/EventAdapter.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Plugin\Adapter\EventDispatcher;
+
+use Symfony\Component\EventDispatcher\Event;
+
+use Elcodi\Component\Plugin\EventInterface;
+
+/**
+ * Class EventAdapter
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class EventAdapter extends Event implements EventInterface
+{
+    /**
+     * @var array
+     *
+     * Context from the caller
+     */
+    protected $context;
+
+    /**
+     * @var string
+     *
+     * Content to be returned
+     */
+    protected $content;
+
+    /**
+     * Create a new event from context and content
+     *
+     * @param array  $context Caller's context
+     * @param string $content Original content
+     */
+    public function __construct(array $context = array(), $content = '')
+    {
+        $this->content = $content;
+        $this->context = $context;
+    }
+
+    /**
+     * Get a value from the context, with a fallback default
+     *
+     * @param string     $key     Index in the context
+     * @param mixed|null $default Default value if there's no entry
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if (array_key_exists($key, $this->context)) {
+
+            return $this->context[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * Get full context
+     *
+     * @return array
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * Get current content
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        return (string) $this->content;
+    }
+
+    /**
+     * Set current content
+     *
+     * @param  string $content
+     *
+     * @return $this self Object
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+}

--- a/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/HookSystemAdapter.php
+++ b/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/HookSystemAdapter.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Plugin\Adapter\EventDispatcher;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+use Elcodi\Component\Plugin\HookSystemInterface;
+
+/**
+ * Class HookSystemAdapter
+ *
+ * Implements HookSystem over Symfony EventDispatcher component
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class HookSystemAdapter implements HookSystemInterface
+{
+    /**
+     * @var EventDispatcherInterface
+     *
+     * EventDispatcher which will dispatch the events
+     */
+    protected $eventDispatcher;
+
+    /**
+     * Construct
+     *
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Start listening on a specified hook.
+     *
+     * @param string   $hookName Name of the hook to listen
+     * @param callable $callable Function to call on hook execution
+     *
+     * @return $this self Object
+     */
+    public function listen($hookName, $callable)
+    {
+        $this->eventDispatcher->addListener($hookName, $callable);
+
+        return $this;
+    }
+
+    /**
+     * Dispatches all listeners and filters related to a hook.
+     *
+     * @param string $hookName Name of the hook to run
+     * @param array  $context  Context in which the hook should run
+     * @param string $content  Optional original content
+     *
+     * @return mixed Content after transformation
+     */
+    public function execute($hookName, $context = array(), $content = '')
+    {
+        $event = new EventAdapter($context, $content);
+        $this->eventDispatcher->dispatch($hookName, $event);
+
+        return $event->getContent();
+    }
+}

--- a/src/Elcodi/Component/Plugin/EventInterface.php
+++ b/src/Elcodi/Component/Plugin/EventInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Plugin;
+
+/**
+ * Interface Event
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+interface EventInterface
+{
+    /**
+     * Get a value from the context, with a fallback default
+     *
+     * @param string     $key     Index in the context
+     * @param mixed|null $default Default value if there's no entry
+     *
+     * @return array
+     */
+    public function get($key, $default = null);
+
+    /**
+     * Get full context
+     *
+     * @return array
+     */
+    public function getContext();
+
+    /**
+     * Get current content
+     *
+     * @return string
+     */
+    public function getContent();
+
+    /**
+     * Set current content
+     *
+     * @param  string $content
+     *
+     * @return $this self Object
+     */
+    public function setContent($content);
+}

--- a/src/Elcodi/Component/Plugin/HookSystemInterface.php
+++ b/src/Elcodi/Component/Plugin/HookSystemInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Plugin;
+
+/**
+ * Interface HookSystemInterface
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+interface HookSystemInterface
+{
+    /**
+     * Start listening on a specified hook.
+     *
+     * @param string   $hookName Name of the hook to listen
+     * @param callable $callable Function to call on hook execution
+     *
+     * @return $this self Object
+     */
+    public function listen($hookName, $callable);
+
+    /**
+     * Dispatches all listeners and filters related to a hook.
+     *
+     * @param string $hookName Name of the hook to run
+     * @param array  $context  Context in which the hook should run
+     * @param string $content  Optional original content
+     *
+     * @return mixed Content after transformation
+     */
+    public function execute($hookName, $context = array(), $content = '');
+}

--- a/src/Elcodi/Component/Plugin/LICENSE
+++ b/src/Elcodi/Component/Plugin/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2012-2014 Room Social Networks S.L.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/Elcodi/Component/Plugin/README.md
+++ b/src/Elcodi/Component/Plugin/README.md
@@ -1,0 +1,44 @@
+Elcodi Plugin component
+=======================
+You can find the last version [here](https://github.com/elcodi/plugin).
+
+This component is part of [Elcodi project](https://github.com/elcodi).
+
+[Elcodi](http://elcodi.io) is a set of flexible e-commerce components for [Symfony2](http://symfony.com), built as decoupled and isolated repositories and under [MIT license](http://opensource.org/licenses/MIT).
+
+Rationale
+---------
+This component adds simple plugin support by a `HookSystem`, where you can define "hooks" and listen to them. 
+
+Installation
+------------
+Open a terminal and use [Composer](https://getcomposer.org/download) to grab the library.
+``` bash
+$ composer require elcodi/plugin
+```
+
+Documentation
+-------------
+All classes are under the `Elcodi\Component\Plugin` namespace.
+
+The basic one is `HookSystemInterface`, which defined how all implementations should behave. You can add listeners 
+with `listen` method, and execute hooks with `execute`. Each listener receives an `EventInterface` with the current 
+context and content passed to the execution.
+
+The basic implemntation is an adapter over `symfony/event-dispatcher`.
+
+Check the documentation in [Elcodi Docs](http://docs.elcodi.io). Feel free to propose new recipes, examples or guides; our main goal is to help the developer building their site.
+
+Contributing
+------------
+All issues and Pull Requests should be on the main repository [elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
+
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard) to run code validation.
+
+There is also a policy for contributing to this project. Pull requests must be explained step by step to make the review process easy in order to accept and merge them. New features must come paired with PHPUnit tests.
+
+If you would like to contribute, please read the [Contributing Code][1] in the project documentation. If you are submitting a pull request, please follow the guidelines in the [Submitting a Patch][2] section and use the [Pull Request Template][3].
+
+[1]: http://symfony.com/doc/current/contributing/code/index.html
+[2]: http://symfony.com/doc/current/contributing/code/patches.html#check-list
+[3]: http://symfony.com/doc/current/contributing/code/patches.html#make-a-pull-request

--- a/src/Elcodi/Component/Plugin/composer.json
+++ b/src/Elcodi/Component/Plugin/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "elcodi/plugin-bundle",
+    "description": "Elcodi Plugin Bundle",
+    "keywords": ["elcodi", "plugin", "ecommerce"],
+    "homepage": "https://github.com/elcodi/PluginBundle",
+    "type": "symfony-bundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Marc Morera",
+            "email": "yuhu@mmoreram.com"
+        },
+        {
+            "name": "Aldo Chiecchia",
+            "email": "zimage@tiscali.it"
+        },
+        {
+            "name": "Elcodi Community",
+            "homepage": "https://github.com/elcodi/Plugin/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.4",
+    },
+    "autoload": {
+        "psr-4": {
+            "Elcodi\\Component\\Plugin\\": ""
+        }
+    },
+    "suggest": {
+        "symfony/dependency-injection": "For EventDispatcher HookSystem adapter"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.5-dev"
+        }
+    }
+}

--- a/src/Elcodi/Component/Plugin/phpunit.xml.dist
+++ b/src/Elcodi/Component/Plugin/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="Elcodi bundle package">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./Resources</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Initial support for simple plugins.
The `HookSystem` allows listening to "hooks", which can be executed via PHP or through a `hook` Twig function.