### PR TITLE
Use getClientOriginalExtension insted getExtension to get the image extension

### DIFF
--- a/src/Elcodi/Component/Media/Services/ImageManager.php
+++ b/src/Elcodi/Component/Media/Services/ImageManager.php
@@ -17,6 +17,7 @@
 namespace Elcodi\Component\Media\Services;
 
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 use Elcodi\Component\Media\Adapter\Resizer\Interfaces\ResizeAdapterInterface;
 use Elcodi\Component\Media\ElcodiMediaImageResizeTypes;
@@ -96,6 +97,12 @@ class ImageManager
             throw new InvalidImageException();
         }
 
+        $extension = $file->getExtension();
+
+        if (!$extension && $file instanceof UploadedFile) {
+            $extension = $file->getClientOriginalExtension();
+        }
+
         /**
          * @var ImageInterface $image
          */
@@ -108,7 +115,7 @@ class ImageManager
             ->setHeight($imageSizeData[1])
             ->setContentType($fileMime)
             ->setSize($file->getSize())
-            ->setExtension($file->getExtension())
+            ->setExtension($extension)
             ->setName($name);
 
         return $image;


### PR DESCRIPTION
I thing that `UploadedFile` return empty string using `getExtension`. To get the extension use `getClientOriginalExtension`, one example [OneupUploaderBundle](https://github.com/1up-lab/OneupUploaderBundle/blob/master/Uploader/File/FilesystemFile.php#L13)

**Update**

The problem is the path of the image `/private/var/tmp/phpqtp40p` in the `UploadedFile`, do not have extension.