### PR TITLE
Fix currency length

### DIFF
--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/doctrine/Currency.orm.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/doctrine/Currency.orm.yml
@@ -12,13 +12,13 @@ Elcodi\Component\Currency\Entity\Currency:
         name:
             column: name
             type: string
-            length: 25
+            length: 65
             nullable: false
             unique: false
         symbol:
             column: symbol
             type: string
-            length: 25
+            length: 15
             nullable: false
             unique: false
         createdAt:


### PR DESCRIPTION
In Mac there's a problem loading fixtures which exceed the length of the mysql column, and some currency names break easily the limit of 25 characters.
Following [ISO-4217](http://www.xe.com/iso4217.php), the maximum length of the name of a currency is 65 characters.
Also, symbols are three characters long at most and should fit in 15 characters with utf encoding.