### PR TITLE
Add support for Page templating

### DIFF
--- a/src/Elcodi/Bundle/BambooBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/BambooBundle/DependencyInjection/Configuration.php
@@ -53,39 +53,54 @@ class Configuration extends AbstractConfiguration
                     ->prototype('scalar')
                     ->end()
                 ->end()
-                ->arrayNode('emails')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->arrayNode('defaults')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('layout')
-                                    ->defaultValue('ElcodiBambooBundle:emails:layout.html.twig')
-                                ->end()
-                                ->scalarNode('sender_email')
-                                    ->defaultValue('no-reply@elcodi.com')
-                                ->end()
-                            ->end()
-                        ->end()
 
-                        ->append($this->addEmailNode(
-                            'customer_password_remember',
-                            false,
-                            'ElcodiBambooBundle:emails:customer_password_remember.html.twig'
-                        ))
-
-                        ->append($this->addEmailNode(
-                            'customer_password_recover',
-                            false,
-                            'ElcodiBambooBundle:emails:customer_password_recover.html.twig'
-                        ))
-                    ->end()
-                ->end()
+                ->append($this->createEmailConfiguration())
             ->end();
     }
 
     /**
-     * Add a mapping node into configuration
+     * Creates configuration for email sending
+     *
+     * @return ArrayNodeDefinition|NodeDefinition
+     */
+    protected function createEmailConfiguration()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('emails');
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('defaults')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('layout')
+                            ->defaultValue('ElcodiBambooBundle:emails:layout.html.twig')
+                        ->end()
+                        ->scalarNode('sender_email')
+                            ->defaultValue('no-reply@elcodi.com')
+                        ->end()
+                    ->end()
+                ->end()
+
+                ->append($this->addEmailNode(
+                    'customer_password_remember',
+                    false,
+                    'ElcodiBambooBundle:emails:customer_password_remember.html.twig'
+                ))
+
+                ->append($this->addEmailNode(
+                    'customer_password_recover',
+                    false,
+                    'ElcodiBambooBundle:emails:customer_password_recover.html.twig'
+                ))
+            ->end();
+
+        return $node;
+    }
+
+    /**
+     * Add configuration for email template
      *
      * @param string  $nodeName    Node name
      * @param boolean $enabled     The email is enabled by default
@@ -121,8 +136,7 @@ class Configuration extends AbstractConfiguration
                 ->scalarNode('sender_email')
                     ->defaultValue($senderEmail)
                 ->end()
-            ->end()
-        ->end();
+            ->end();
 
         return $node;
     }

--- a/src/Elcodi/Bundle/BambooBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/BambooBundle/DependencyInjection/Configuration.php
@@ -55,6 +55,8 @@ class Configuration extends AbstractConfiguration
                 ->end()
 
                 ->append($this->createEmailConfiguration())
+
+                ->append($this->createPagesConfiguration())
             ->end();
     }
 
@@ -140,4 +142,26 @@ class Configuration extends AbstractConfiguration
 
         return $node;
     }
+
+    /**
+     * Creates configuration for page rendering
+     *
+     * @return ArrayNodeDefinition|NodeDefinition
+     */
+    protected function createPagesConfiguration()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('pages');
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('default_template')
+                    ->defaultValue('ElcodiBambooBundle:pages:basic_layout.html.twig')
+                ->end()
+            ->end();
+
+        return $node;
+    }
+
 }

--- a/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
+++ b/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
@@ -94,6 +94,8 @@ class ElcodiBambooExtension extends AbstractExtension
             "elcodi.core.bamboo.emails.customer_password_recover.template"      => $config['emails']['customer_password_recover']['template'],
             "elcodi.core.bamboo.emails.customer_password_recover.layout"        => $config['emails']['customer_password_recover']['layout'],
             "elcodi.core.bamboo.emails.customer_password_recover.sender_email"  => $config['emails']['customer_password_recover']['sender_email'],
+
+            "elcodi.core.bamboo.page.default_template"                          => $config['pages']['default_template'],
         ];
     }
 

--- a/src/Elcodi/Bundle/BambooBundle/Entity/Page.php
+++ b/src/Elcodi/Bundle/BambooBundle/Entity/Page.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\BambooBundle\Entity;
+
+use Elcodi\Component\Page\Entity\Page as BasePage;
+
+/**
+ * Class Page
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class Page extends BasePage
+{
+    /**
+     * @var string
+     *
+     * Path for the layout template to render the page
+     */
+    protected $template;
+
+    /**
+     * Get current template
+     *
+     * @return string
+     */
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+
+    /**
+     * Set current template
+     *
+     * @param string $template
+     *
+     * @return $this Self object
+     */
+    public function setTemplate($template)
+    {
+        $this->template = $template;
+
+        return $this;
+    }
+}

--- a/src/Elcodi/Bundle/BambooBundle/Renderer/TemplateRenderer.php
+++ b/src/Elcodi/Bundle/BambooBundle/Renderer/TemplateRenderer.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Bundle\BambooBundle\Renderer;
+
+use Symfony\Component\Templating\EngineInterface;
+
+use Elcodi\Bundle\BambooBundle\Entity\Page as BambooPage;
+use Elcodi\Component\Page\Entity\Interfaces\PageInterface;
+use Elcodi\Component\Page\Renderer\Interfaces\PageRendererInterface;
+
+/**
+ * Class TemplateRenderer
+ *
+ * Add layout rendering
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class TemplateRenderer implements PageRendererInterface
+{
+    /**
+     * @var EngineInterface
+     *
+     * Render engine
+     */
+    protected $engine;
+
+    /**
+     * @var string
+     *
+     * Default template
+     */
+    protected $defaultTemplate;
+
+    /**
+     * @param EngineInterface $engine          Render engine
+     * @param string          $defaultTemplate Default template
+     */
+    public function __construct(EngineInterface $engine, $defaultTemplate)
+    {
+        $this->engine = $engine;
+        $this->defaultTemplate = (string) $defaultTemplate;
+    }
+
+    /**
+     * Render a page
+     *
+     * @param PageInterface $page Page to render
+     *
+     * @return string Rendered content
+     */
+    public function render(PageInterface $page)
+    {
+        return $this->engine->render(
+            $this->getTemplate($page),
+            array(
+                'page' => $page,
+            )
+        );
+    }
+
+    /**
+     * Check for render support of a page
+     *
+     * @param PageInterface $page Page to check support
+     *
+     * @return bool
+     */
+    public function supports(PageInterface $page)
+    {
+        return $page instanceof BambooPage;
+    }
+
+    /**
+     * Get template to render
+     *
+     * @param BambooPage $page Page to get current template
+     *
+     * @return string
+     */
+    protected function getTemplate(BambooPage $page)
+    {
+        $template = $page->getTemplate();
+        if (!empty($template)) {
+
+            return $template;
+        }
+
+        return $this->defaultTemplate;
+    }
+}

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/doctrine/Page.orm.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/doctrine/Page.orm.yml
@@ -1,0 +1,57 @@
+Elcodi\Bundle\BambooBundle\Entity\Page:
+    type: entity
+    repositoryClass: Elcodi\Component\Page\Repository\PageRepository
+    table: page
+    id:
+        id:
+            type: integer
+            generator:
+                strategy: AUTO
+    fields:
+        title:
+            column: title
+            type: string
+            length: 255
+            nullable: false
+        content:
+            column: content
+            type: text
+            nullable: false
+        path:
+            column: path
+            type: string
+            length: 255
+            nullable: false
+        template:
+            column: template
+            type: string
+            length: 255
+            nullable: true
+        metaTitle:
+            column: meta_title
+            type: string
+            length: 255
+            nullable: true
+        metaDescription:
+            column: meta_description
+            type: string
+            length: 255
+            nullable: true
+        metaKeywords:
+            column: meta_keywords
+            type: string
+            length: 255
+            nullable: true
+        createdAt:
+            column: created_at
+            type: datetime
+        updatedAt:
+            column: updated_at
+            type: datetime
+        enabled:
+            column: enabled
+            type: boolean
+
+    lifecycleCallbacks:
+        preUpdate: [loadUpdateAt]
+        prePersist: [loadUpdateAt]

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/mapping.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/mapping.yml
@@ -1,0 +1,8 @@
+#
+# Overloads Page component
+#
+elcodi_page:
+    mapping:
+        page:
+            class: Elcodi\Bundle\BambooBundle\Entity\Page
+            mapping_file: @ElcodiBambooBundle/Resources/config/doctrine/Page.orm.yml

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/page.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/page.yml
@@ -1,0 +1,6 @@
+#
+# Page renderers
+#
+elcodi_page:
+    renderers:
+        - bamboo.page.renderer.template_renderer

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/services.yml
@@ -8,3 +8,12 @@ services:
         arguments:
             kernel: @kernel
             configuration_manager: @?elcodi.configuration_manager
+
+    #
+    # Page renderer
+    #
+    bamboo.page.renderer.template_renderer:
+        class: Elcodi\Bundle\BambooBundle\Renderer\TemplateRenderer
+        arguments:
+            - @templating.engine.twig
+            - %elcodi.core.bamboo.page.default_template%

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/services.yml
@@ -15,5 +15,5 @@ services:
     bamboo.page.renderer.template_renderer:
         class: Elcodi\Bundle\BambooBundle\Renderer\TemplateRenderer
         arguments:
-            - @templating.engine.twig
+            - @?templating.engine.twig
             - %elcodi.core.bamboo.page.default_template%

--- a/src/Elcodi/Bundle/BambooBundle/Resources/views/pages/basic_layout.html.twig
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/views/pages/basic_layout.html.twig
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="{{ app.request.locale }}">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>{{ page.metatitle }}</title>
+    <meta name="description" content="{{ page.metadescription }}">
+    <meta name="keywords" content="{{ page.metakeywords }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+    <h1>{{ page.title }}</h1>
+    {{ page.content|raw }}
+</body>
+</html>

--- a/src/Elcodi/Bundle/BambooBundle/Resources/views/pages/extensible_layout.html.twig
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/views/pages/extensible_layout.html.twig
@@ -1,0 +1,32 @@
+{%- block doctype -%}
+<!DOCTYPE html>
+{% endblock %}
+{%- block html_header -%}
+<html lang="{{ app.request.locale }}">
+{% endblock %}
+<head>
+    {% block head %}
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        {% block metadata %}
+            <title>{{ page.metatitle }}</title>
+            <meta name="description" content="{{ page.metadescription }}">
+            <meta name="keywords" content="{{ page.metakeywords }}">
+        {% endblock %}
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% endblock %}
+</head>
+{% block body_header %}
+<body>
+{% endblock %}
+{% block body %}
+    {% block title %}
+        <h1>{{ page.title }}</h1>
+    {% endblock %}
+
+    {% block content %}
+        {{ page.content|raw }}
+    {% endblock %}
+{% endblock %}
+</body>
+</html>

--- a/src/Elcodi/Bundle/BambooBundle/Services/TemplateLoader.php
+++ b/src/Elcodi/Bundle/BambooBundle/Services/TemplateLoader.php
@@ -87,7 +87,7 @@ class TemplateLoader
                 $bundleName = $bundle->getName();
                 $templates->set($bundleName, [
                     'bundle' => $bundleName,
-                    'name'   => $bundle->getTemplateName()
+                    'name'   => $bundle->getTemplateName(),
                 ]);
             }
         }

--- a/src/Elcodi/Bundle/PageBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/PageBundle/DependencyInjection/Configuration.php
@@ -71,6 +71,10 @@ class Configuration extends AbstractConfiguration implements ConfigurationInterf
                         ->end()
                     ->end()
                 ->end()
+
+                ->arrayNode('renderers')
+                    ->prototype('scalar')->end()
+                ->end()
             ->end()
         ;
     }

--- a/src/Elcodi/Bundle/PageBundle/DependencyInjection/ElcodiPageExtension.php
+++ b/src/Elcodi/Bundle/PageBundle/DependencyInjection/ElcodiPageExtension.php
@@ -90,6 +90,7 @@ class ElcodiPageExtension extends AbstractExtension implements EntitiesOverridab
                 $config['routing']['enabled']
             ],
             'objectManagers',
+            'renderers',
             'repositories',
         ];
     }

--- a/src/Elcodi/Bundle/PageBundle/DependencyInjection/ElcodiPageExtension.php
+++ b/src/Elcodi/Bundle/PageBundle/DependencyInjection/ElcodiPageExtension.php
@@ -18,6 +18,7 @@ namespace Elcodi\Bundle\PageBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractExtension;
 use Elcodi\Bundle\CoreBundle\DependencyInjection\Interfaces\EntitiesOverridableExtensionInterface;
@@ -164,6 +165,19 @@ class ElcodiPageExtension extends AbstractExtension implements EntitiesOverridab
             $loaderDefinition = $container->findDefinition($loaderId);
             $loaderDefinition->addTag('routing.loader');
             $container->setAlias('elcodi.core.page.router', $loaderId);
+        }
+
+        if (!empty($config['renderers'])) {
+
+            $rendererReferences = [];
+            foreach ($config['renderers'] as $rendererId) {
+
+                $rendererReferences[] = new Reference($rendererId);
+            }
+
+            $controllerId = 'elcodi.core.page.chain_renderer';
+            $controllerDefinition = $container->findDefinition($controllerId);
+            $controllerDefinition->addArgument($rendererReferences);
         }
     }
 }

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/classes.yml
@@ -19,3 +19,8 @@ parameters:
     # Loaders
     #
     elcodi.core.page.router.simple_loader.class: Elcodi\Component\Page\Router\PageRouterSimpleLoader
+
+    #
+    # Renderers
+    #
+    elcodi.core.page.chain_renderer.class: Elcodi\Component\Page\Renderer\ChainPageRenderer

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/controllers.yml
@@ -8,3 +8,4 @@ services:
         arguments:
             page_repository: @elcodi.repository.page
             request_stack: @request_stack
+            renderer: @elcodi.core.page.chain_renderer

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/renderers.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/renderers.yml
@@ -1,0 +1,7 @@
+services:
+
+    #
+    # Page renderers
+    #
+    elcodi.core.page.chain_renderer:
+        class: %elcodi.core.page.chain_renderer.class%

--- a/src/Elcodi/Component/Page/Controller/PageController.php
+++ b/src/Elcodi/Component/Page/Controller/PageController.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 use Elcodi\Component\Page\Entity\Interfaces\PageInterface;
+use Elcodi\Component\Page\Renderer\Interfaces\PageRendererInterface;
 use Elcodi\Component\Page\Repository\Interfaces\PageRepositoryInterface;
 
 /**
@@ -45,18 +46,26 @@ class PageController
     protected $requestStack;
 
     /**
+     * @var PageRendererInterface
+     */
+    protected $pageRenderer;
+
+    /**
      * Constructor
      *
      * @param PageRepositoryInterface $repository   Page repository
      * @param RequestStack            $requestStack Request stack
+     * @param PageRendererInterface   $pageRenderer Content renderer
      */
     public function __construct(
         PageRepositoryInterface $repository,
-        RequestStack $requestStack
+        RequestStack $requestStack,
+        PageRendererInterface $pageRenderer = null
     )
     {
         $this->repository = $repository;
         $this->requestStack = $requestStack;
+        $this->pageRenderer = $pageRenderer;
     }
 
     /**
@@ -119,6 +128,10 @@ class PageController
      */
     protected function renderPage(PageInterface $page)
     {
+        if ($this->pageRenderer && $this->pageRenderer->supports($page)) {
+            return $this->pageRenderer->render($page);
+        }
+
         return $page->getContent();
     }
 }

--- a/src/Elcodi/Component/Page/Entity/Page.php
+++ b/src/Elcodi/Component/Page/Entity/Page.php
@@ -39,23 +39,23 @@ class Page implements PageInterface
         EnabledTrait;
 
     /**
-     * The path
-     *
      * @var string
+     *
+     * Path from which this page would be accessed
      */
     protected $path;
 
     /**
-     * The title
-     *
      * @var string
+     *
+     * Title of the page
      */
     protected $title;
 
     /**
-     * The content
-     *
      * @var string
+     *
+     * Content of the page
      */
     protected $content;
 

--- a/src/Elcodi/Component/Page/Renderer/ChainPageRenderer.php
+++ b/src/Elcodi/Component/Page/Renderer/ChainPageRenderer.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Page\Renderer;
+
+use Elcodi\Component\Page\Entity\Interfaces\PageInterface;
+use Elcodi\Component\Page\Renderer\Interfaces\PageRendererInterface;
+
+/**
+ * Class ChainPageRenderer
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class ChainPageRenderer implements PageRendererInterface
+{
+    /**
+     * @var PageRendererInterface[]
+     *
+     * Multiple page renderers to select
+     */
+    protected $renderers;
+
+    /**
+     * @param PageRendererInterface[] $renderers
+     */
+    public function __construct(array $renderers = [])
+    {
+        $this->renderers = $renderers;
+    }
+
+    /**
+     * Adds a new renderer
+     *
+     * @param PageRendererInterface $renderer
+     *
+     * @return $this Self object
+     */
+    public function addRenderer(PageRendererInterface $renderer)
+    {
+        $this->renderers[] = $renderer;
+
+        return $this;
+    }
+
+    /**
+     * Render a page
+     *
+     * @param PageInterface $page Page to render
+     *
+     * @return string Rendered content
+     */
+    public function render(PageInterface $page)
+    {
+        foreach ($this->renderers as $renderer) {
+            if (!$renderer->supports($page)) {
+                continue;
+            }
+
+            return $renderer->render($page);
+        }
+
+        return $page->getContent();
+    }
+
+    /**
+     * Supports everything because falls back to `getContent`
+     *
+     * @param PageInterface $page Page to check support
+     *
+     * @return bool
+     */
+    public function supports(PageInterface $page)
+    {
+        return true;
+    }
+}

--- a/src/Elcodi/Component/Page/Renderer/Interfaces/PageRendererInterface.php
+++ b/src/Elcodi/Component/Page/Renderer/Interfaces/PageRendererInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+namespace Elcodi\Component\Page\Renderer\Interfaces;
+
+use Elcodi\Component\Page\Entity\Interfaces\PageInterface;
+
+/**
+ * Interface PageRendererInterface
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+interface PageRendererInterface
+{
+    /**
+     * Render a page
+     *
+     * @param PageInterface $page Page to render
+     *
+     * @return string Rendered content
+     */
+    public function render(PageInterface $page);
+
+    /**
+     * Check for render support of a page
+     *
+     * @param PageInterface $page Page to check support
+     *
+     * @return bool
+     */
+    public function supports(PageInterface $page);
+}


### PR DESCRIPTION
- `PageController` now accepts a `PageRendererInterface` (by default in Bamboo, a `ChainPageRenderer`).
- Overrides `Page` entity with our own in Bamboo.
- Added `template` field to Bamboo's `Page`.
- A `TemplateRenderer` now renders Bamboo's `Page`s.
- Default template in `elcodi_bamboo.pages.default_template`.