### PR TITLE
Added configuration option for domain sharding in media

### DIFF
--- a/src/Elcodi/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -51,6 +51,15 @@ class Configuration extends AbstractConfiguration
                     ->addDefaultsIfNotSet()
                     ->children()
 
+                        ->arrayNode('domain_sharding')
+                            ->canBeEnabled()
+                            ->children()
+                                ->arrayNode('base_urls')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+
                         ->arrayNode('view')
                             ->addDefaultsIfNotSet()
                             ->children()
@@ -115,4 +124,5 @@ class Configuration extends AbstractConfiguration
                 ->end()
             ->end();
     }
+
 }

--- a/src/Elcodi/Bundle/MediaBundle/DependencyInjection/ElcodiMediaExtension.php
+++ b/src/Elcodi/Bundle/MediaBundle/DependencyInjection/ElcodiMediaExtension.php
@@ -111,6 +111,9 @@ class ElcodiMediaExtension extends AbstractExtension implements EntitiesOverrida
 
             'elcodi.core.media.filesystem'                             => $config['filesystem'],
 
+            'elcodi.core.media.images.domain_sharding.enabled'         => $config['images']['domain_sharding']['enabled'],
+            'elcodi.core.media.images.domain_sharding.base_urls'       => $config['images']['domain_sharding']['base_urls'],
+
             'elcodi.core.media.image_view_controller_route_name'       => $config['images']['view']['controller_route_name'],
             'elcodi.core.media.image_view_controller_route'            => $config['images']['view']['controller_route'],
             'elcodi.core.media.image_view_max_age'                     => $config['images']['view']['max_age'],

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
@@ -9,5 +9,7 @@ services:
             router: @router
             image_resize_controller_route_name: %elcodi.core.media.image_resize_controller_route_name%
             image_view_controller_route_name: %elcodi.core.media.image_view_controller_route_name%
+            images_domain_sharding_enabled: %elcodi.core.media.images.domain_sharding.enabled%
+            images_domain_sharding_base_urls: %elcodi.core.media.images.domain_sharding.base_urls%
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Component/Media/Twig/ImageExtension.php
+++ b/src/Elcodi/Component/Media/Twig/ImageExtension.php
@@ -49,21 +49,56 @@ class ImageExtension extends Twig_Extension
     protected $imageViewControllerRouteName;
 
     /**
+     * @var boolean
+     *
+     * Enable domain sharding
+     */
+    protected $imageDomainShardingEnabled;
+
+    /**
+     * @var boolean
+     *
+     * Generate absolute or relative path in URLs
+     */
+    protected $generateAbsolutePath;
+
+    /**
+     * @var array
+     *
+     * Base URLs for the resource origin
+     */
+    protected $imageDomainShardingBaseUrls;
+
+    /**
      * Construct method
      *
      * @param UrlGeneratorInterface $router                         Router
      * @param string                $imageResizeControllerRouteName Image resize controller route name
      * @param string                $imageViewControllerRouteName   Image view controller route name
+     * @param boolean               $imageDomainShardingEnabled     If we are using domain sharding or not
+     * @param array                 $imageDomainShardingBaseUrls    Base urls to use in hostnames
      */
     public function __construct(
         UrlGeneratorInterface $router,
         $imageResizeControllerRouteName,
-        $imageViewControllerRouteName
+        $imageViewControllerRouteName,
+        $imageDomainShardingEnabled,
+        $imageDomainShardingBaseUrls
     )
     {
         $this->router = $router;
         $this->imageResizeControllerRouteName = $imageResizeControllerRouteName;
         $this->imageViewControllerRouteName = $imageViewControllerRouteName;
+
+        $this->imageDomainShardingEnabled = $imageDomainShardingEnabled;
+
+        /*
+         * If domain sharding is enabled, we cannot use
+         * absolute URLs, we will manually generate them
+         * as base_url + route_path
+         */
+        $this->generateAbsolutePath = !$imageDomainShardingEnabled;
+        $this->imageDomainShardingBaseUrls = $imageDomainShardingBaseUrls;
     }
 
     /**
@@ -89,7 +124,7 @@ class ImageExtension extends Twig_Extension
      */
     public function resize(ImageInterface $imageMedia, $options)
     {
-        return $this
+        $generatedRoute = $this
             ->router
             ->generate($this->imageResizeControllerRouteName, array(
                 'id'      => (int) $imageMedia->getId(),
@@ -97,7 +132,13 @@ class ImageExtension extends Twig_Extension
                 'width'   => (int) $options['width'],
                 'type'    => (int) $options['type'],
                 '_format' => $imageMedia->getExtension(),
-            ), true);
+            ), $this->generateAbsolutePath);
+
+        /*
+         * Returning generated URL, with or without absolute path
+         */
+
+        return $this->randomizeBaseUrls($generatedRoute);
     }
 
     /**
@@ -109,12 +150,41 @@ class ImageExtension extends Twig_Extension
      */
     public function viewImage(ImageInterface $imageMedia)
     {
-        return $this
+        $generatedRoute = $this
             ->router
             ->generate($this->imageViewControllerRouteName, array(
                 'id'      => (int) $imageMedia->getId(),
                 '_format' => $imageMedia->getExtension(),
-            ), true);
+            ), $this->generateAbsolutePath);
+
+        return $this->randomizeBaseUrls($generatedRoute);
+    }
+
+    /**
+     * Rotates an array of configured origin servers
+     *
+     * This is useful when working with reverse proxies or CDN,
+     * where using different hostnames referring to the same origin
+     * in URLs can optimize browser load times by parallelizing resource
+     * download (domain sharding)
+     *
+     * @link http://www.stevesouders.com/blog/2009/05/12/sharding-dominant-domains/
+     *
+     * @return string
+     */
+    protected function randomizeBaseUrls($path)
+    {
+        if ($this->generateAbsolutePath) return $path;
+
+        $hostNames = $this->imageDomainShardingBaseUrls;
+        /*
+         * Retrieve a pseudo random number between 1 and
+         * the number of origin base url
+         */
+        $random = substr(mt_rand(), 0, 1) % count($hostNames);
+        $hostName = $hostNames[$random];
+
+        return $hostName.$path;
     }
 
     /**


### PR DESCRIPTION
Adding configuration option to make `ImageExtension` work smooth with reverse proxies.
It will work in a similar fashion as [`assets_base_url`](http://symfony.com/doc/current/reference/configuration/framework.html#assets-base-urls) in `FrameWorkBundle`.

Example:

```
elcodi_media:
    images:
        domain_sharding:
            enabled:              true
            base_urls:            [ 'media1.elcodi.com', 'media2.elcodi.com', 'media3.elcodi.com' ]
```

The `resize` and `view` twig functions provided by the `ImageExtension` class will use the sharding configuration to change the hostname for the generated images routes