### PR TITLE
Fix page translation alias

### DIFF
--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/translations.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/translations.yml
@@ -32,7 +32,7 @@ elcodi_entity_translator:
                 metaDescription: ~
                 metaKeywords: ~
         Elcodi\Component\Page\Entity\Interfaces\PageInterface:
-            alias: image
+            alias: page
             fields:
                 title: ~
                 content: ~


### PR DESCRIPTION
`Page` entites were being aliased as `image`.