### PR TITLE
Add analytics tracker ID to the store

### DIFF
--- a/src/Elcodi/Bundle/BambooBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/BambooBundle/DependencyInjection/Configuration.php
@@ -62,6 +62,9 @@ class Configuration extends AbstractConfiguration
                 ->scalarNode('store_under_construction')
                     ->defaultTrue()
                 ->end()
+                ->scalarNode('store_google_analytics_id')
+                    ->defaultValue('')
+                ->end()
 
                 ->append($this->createEmailConfiguration())
             ->end();

--- a/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
+++ b/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
@@ -84,6 +84,7 @@ class ElcodiBambooExtension extends AbstractExtension
             "elcodi.core.bamboo.store_templates"                                => $config['store_templates'],
             "elcodi.core.bamboo.store_enabled"                                  => $config['store_enabled'],
             "elcodi.core.bamboo.store_under_construction"                       => $config['store_under_construction'],
+            "elcodi.core.bamboo.store_google_analytics_id"                      => $config['store_google_analytics_id'],
 
             "elcodi.core.bamboo.emails.layout"                                  => $config['emails']['defaults']['layout'],
             "elcodi.core.bamboo.emails.sender_email"                            => $config['emails']['defaults']['sender_email'],

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/configuration.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/configuration.yml
@@ -3,6 +3,7 @@ elcodi_configuration:
 
         #
         # Store namespace
+        #
         store_name:
             key: name
             name: Store name
@@ -45,6 +46,13 @@ elcodi_configuration:
             namespace: store
             type: boolean
             reference: elcodi.core.bamboo.store_under_construction
+
+        store_google_analytics_id:
+            key: google_analytics_id
+            name: Google analytics tracking ID
+            namespace: store
+            type: string
+            reference: elcodi.core.bamboo.store_google_analytics_id
 
         #
         # Product namespace


### PR DESCRIPTION
New config store_google_analytics_id defined and set empty by default

Ping @elcodi/owners 