### PR TITLE
Remove checking `hook_system`

### DIFF
--- a/src/Elcodi/Bundle/PluginBundle/DependencyInjection/ElcodiPluginExtension.php
+++ b/src/Elcodi/Bundle/PluginBundle/DependencyInjection/ElcodiPluginExtension.php
@@ -90,15 +90,6 @@ class ElcodiPluginExtension extends AbstractExtension
     {
         parent::postLoad($config, $container);
 
-        if (!$container->has($config['hook_system'])) {
-
-            throw new InvalidArgumentException(sprintf(
-                'The config "%s.hook_system" has a dependency on a non-existent service "%s".',
-                $this->getAlias(),
-                $config['hook_system']
-            ));
-        }
-
         $container->setAlias('elcodi.hook_system', $config['hook_system']);
     }
 


### PR DESCRIPTION
Removes the check, because the service resolution automatically detects this. (and the current approach was buggy)

Fix #499