### PR TITLE
Avoid global flush on cart load.

### DIFF
--- a/src/Elcodi/Component/Cart/EventListener/CartLoadEventListener.php
+++ b/src/Elcodi/Component/Cart/EventListener/CartLoadEventListener.php
@@ -172,11 +172,11 @@ class CartLoadEventListener
 
         if (!$cart->getCartLines()->isEmpty()) {
             $this->cartObjectManager->persist($cart);
-        }
 
-        $this
-            ->cartObjectManager
-            ->flush();
+            $this
+                ->cartObjectManager
+                ->flush($cart);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed a but that was flushing the entire entity manager at all the store pages when the "loadCart" event was triggered.