### PR TITLE
Fix dependencies for --prefer-lowest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,26 @@
 language: php
 
+env:
+    - COMPOSER_OPTIONS="--prefer-source"
+
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm-nightly
+    - 5.4
+    - 5.5
+    - 5.6
+    - hhvm-nightly
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.4
+          env: COMPOSER_OPTIONS="--prefer-lowest"
 
 before_install:
     - sh -c "sudo mkdir vendor"
     - sh -c "sudo mount -t tmpfs -o size=512M tmpfs vendor"
 
 install:
-    - composer install --prefer-source --no-interaction
+    - composer update --no-interaction ${COMPOSER_OPTIONS}
 
 before_script:
     - sh -c "sudo mkdir /tmp/Elcodi"

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "php": ">=5.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/dependency-injection": "~2.6, >=2.6.3",
         "symfony/config": "~2.6",
         "symfony/yaml": "~2.6",
         "symfony/console": "~2.6",


### PR DESCRIPTION
The `symfony/dependency-injection` was missing in `composer.json`.
This was installing `v2.4.0`, but we need `v2.6.3` at least (for [this issue](https://github.com/symfony/symfony/issues/13267)).