### PR TITLE
Feature coupons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "ircmaxell/password-compat": "~1.0",
         "guzzlehttp/guzzle": "~5.2",
-        "mmoreram/extractor": "~1.0",
+        "mmoreram/extractor": "~1.0, >=1.1.1",
         "goodby/csv": "~1.0"
     },
     "replace": {

--- a/src/Elcodi/Bundle/AttributeBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/AttributeBundle/Resources/config/classes.yml
@@ -3,5 +3,5 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.attribute.factory.attribute.class: Elcodi\Component\Attribute\Factory\AttributeFactory
-    elcodi.core.attribute.factory.attribute_value.class: Elcodi\Component\Attribute\Factory\ValueFactory
+    elcodi.factory.attribute.class: Elcodi\Component\Attribute\Factory\AttributeFactory
+    elcodi.factory.attribute_value.class: Elcodi\Component\Attribute\Factory\ValueFactory

--- a/src/Elcodi/Bundle/AttributeBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/AttributeBundle/Resources/config/factories.yml
@@ -7,21 +7,15 @@ services:
     #
     # Factory for Attribute entities
     #
-    elcodi.core.attribute.factory.attribute:
-        class: %elcodi.core.attribute.factory.attribute.class%
+    elcodi.factory.attribute:
+        class: %elcodi.factory.attribute.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.attribute.entity.attribute.class%"]]
-
-    elcodi.factory.attribute:
-        alias: elcodi.core.attribute.factory.attribute
 
     #
     # Factory for Value entities
     #
-    elcodi.core.attribute.factory.attribute_value:
-        class: %elcodi.core.attribute.factory.attribute_value.class%
+    elcodi.factory.attribute_value:
+        class: %elcodi.factory.attribute_value.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.attribute.entity.attribute_value.class%"]]
-
-    elcodi.factory.attribute_value:
-        alias: elcodi.core.attribute.factory.attribute_value

--- a/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/Factory/AttributeFactoryTest.php
+++ b/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/Factory/AttributeFactoryTest.php
@@ -42,7 +42,6 @@ class AttributeFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.attribute.factory.attribute',
             'elcodi.factory.attribute',
         ];
     }

--- a/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/Factory/ValueFactoryTest.php
+++ b/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/Factory/ValueFactoryTest.php
@@ -42,7 +42,6 @@ class ValueFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.attribute.factory.attribute_value',
             'elcodi.factory.attribute_value',
         ];
     }

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/services.yml
@@ -13,6 +13,6 @@ services:
     #
     elcodi.store_tracker:
         class: StdClass
-        factory_service: elcodi.configuration_manager
+        factory_service: elcodi.manager.configuration
         factory_method: get
         arguments: ['store.tracker']

--- a/src/Elcodi/Bundle/BannerBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/BannerBundle/Resources/config/classes.yml
@@ -3,10 +3,10 @@ parameters:
     #
     # Services
     #
-    elcodi.core.banner.service.banner_manager.class: Elcodi\Component\Banner\Services\BannerManager
+    elcodi.manager.banner.class: Elcodi\Component\Banner\Services\BannerManager
 
     #
     # Factories
     #
-    elcodi.core.banner.factory.banner.class: Elcodi\Component\Banner\Factory\BannerFactory
-    elcodi.core.banner.factory.banner_zone.class: Elcodi\Component\Banner\Factory\BannerZoneFactory
+    elcodi.factory.banner.class: Elcodi\Component\Banner\Factory\BannerFactory
+    elcodi.factory.banner_zone.class: Elcodi\Component\Banner\Factory\BannerZoneFactory

--- a/src/Elcodi/Bundle/BannerBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/BannerBundle/Resources/config/factories.yml
@@ -7,21 +7,15 @@ services:
     #
     # Factory for entity banner
     #
-    elcodi.core.banner.factory.banner:
-        class: %elcodi.core.banner.factory.banner.class%
+    elcodi.factory.banner:
+        class: %elcodi.factory.banner.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.banner.entity.banner.class%"]]
-
-    elcodi.factory.banner:
-        alias: elcodi.core.banner.factory.banner
 
     #
     # Factory for entity banner_zone
     #
-    elcodi.core.banner.factory.banner_zone:
-        class: %elcodi.core.banner.factory.banner_zone.class%
+    elcodi.factory.banner_zone:
+        class: %elcodi.factory.banner_zone.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.banner.entity.banner_zone.class%"]]
-
-    elcodi.factory.banner_zone:
-        alias: elcodi.core.banner.factory.banner_zone

--- a/src/Elcodi/Bundle/BannerBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/BannerBundle/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
     #
     # Services
     #
-    elcodi.core.banner.service.banner_manager:
-        class: %elcodi.core.banner.service.banner_manager.class%
+    elcodi.manager.banner:
+        class: %elcodi.manager.banner.class%
         arguments:
             banner_repository: @elcodi.repository.banner

--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Factory/BannerFactoryTest.php
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Factory/BannerFactoryTest.php
@@ -42,7 +42,6 @@ class BannerFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.banner.factory.banner',
             'elcodi.factory.banner',
         ];
     }

--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Factory/BannerZoneFactoryTest.php
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Factory/BannerZoneFactoryTest.php
@@ -42,7 +42,6 @@ class BannerZoneFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.banner.factory.banner_zone',
             'elcodi.factory.banner_zone',
         ];
     }

--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Services/BannerManagerTest.php
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Services/BannerManagerTest.php
@@ -54,7 +54,7 @@ class BannerManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.banner.service.banner_manager'];
+        return ['elcodi.manager.banner'];
     }
 
     /**
@@ -69,7 +69,7 @@ class BannerManagerTest extends WebTestCase
             ));
 
         $zones = $this
-            ->get('elcodi.core.banner.service.banner_manager')
+            ->get('elcodi.manager.banner')
             ->getBannersFromBannerZoneCode('bannerzone-code', $language);
 
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $zones);
@@ -82,7 +82,7 @@ class BannerManagerTest extends WebTestCase
     public function testGetBannersFromBannerZoneCodeNoLanguage()
     {
         $zones = $this
-            ->get('elcodi.core.banner.service.banner_manager')
+            ->get('elcodi.manager.banner')
             ->getBannersFromBannerZoneCode('bannerzone-code-nolanguage');
 
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $zones);

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/classes.yml
@@ -11,8 +11,8 @@ parameters:
     #
     # Services
     #
-    elcodi.cart_manager.class: Elcodi\Component\Cart\Services\CartManager
-    elcodi.cart_session_manager.class: Elcodi\Component\Cart\Services\CartSessionManager
+    elcodi.cart.manager.class: Elcodi\Component\Cart\Services\CartManager
+    elcodi.session_manager.cart.class: Elcodi\Component\Cart\Services\CartSessionManager
 
     #
     # Transformers
@@ -40,4 +40,4 @@ parameters:
     #
     # Wrappers
     #
-    elcodi.cart_wrapper.class: Elcodi\Component\Cart\Wrapper\CartWrapper
+    elcodi.wrapper.cart.class: Elcodi\Component\Cart\Wrapper\CartWrapper

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/classes.yml
@@ -27,7 +27,7 @@ parameters:
     elcodi.event_listener.order_creation.class: Elcodi\Component\Cart\EventListener\OrderCreationEventListener
     elcodi.event_listener.order_line_creation.class: Elcodi\Component\Cart\EventListener\OrderLineCreationEventListener
     elcodi.event_listener.cart_session.class: Elcodi\Component\Cart\EventListener\CartSessionEventListener
-
+    elcodi.event_listener.limit_negative_carts.class: Elcodi\Component\Cart\EventListener\LimitNegativeCartsListener
 
     #
     # Factories

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -6,22 +6,22 @@ services:
     elcodi.event_listener.cart_load:
         class: %elcodi.event_listener.cart_load.class%
         arguments:
-            cart_entity_manager: @elcodi.object_manager.cart
-            cart_event_dispatcher: @elcodi.event_dispatcher.cart
-            cart_manager: @elcodi.cart_manager
-            currency_wrapper: @elcodi.currency_wrapper
-            currency_converter: @elcodi.currency_converter
+            - @elcodi.object_manager.cart
+            - @elcodi.event_dispatcher.cart
+            - @elcodi.cart_manager
+            - @elcodi.wrapper.currency
+            - @elcodi.converter.currency
         tags:
             - { name: kernel.event_listener, event: cart.preload, method: checkCartIntegrity, priority: 0 }
             - { name: kernel.event_listener, event: cart.onload, method: loadCartPrices, priority: 16 }
             - { name: kernel.event_listener, event: cart.onload, method: saveCart, priority: 0 }
-            - { name: kernel.event_listener, event: cart.onload, method: loadCartQuantities, priority: -16 }
+            - { name: kernel.event_listener, event: cart.onload, method: loadCartQuantities, priority: 16 }
 
     elcodi.event_listener.order_creation:
         class: %elcodi.event_listener.order_creation.class%
         arguments:
-            order_entity_manager: @elcodi.object_manager.order
-            cart_entity_manager: @elcodi.object_manager.cart
+            - @elcodi.object_manager.order
+            - @elcodi.object_manager.cart
         tags:
             - { name: kernel.event_listener, event: order.oncreated, method: saveOrder, priority: 0}
             - { name: kernel.event_listener, event: order.oncreated, method: setCartAsOrdered, priority: -16 }
@@ -29,14 +29,14 @@ services:
     elcodi.event_listener.order_line_creation:
         class: %elcodi.event_listener.order_line_creation.class%
         arguments:
-            product_object_manager: @elcodi.object_manager.product
-            variant_object_manager: @elcodi.object_manager.product_variant
+            - @elcodi.object_manager.product
+            - @elcodi.object_manager.product_variant
         tags:
             - { name: kernel.event_listener, event: order_line.oncreated, method: updateStock, priority: 0}
 
     elcodi.event_listener.cart_session:
         class: %elcodi.event_listener.cart_session.class%
         arguments:
-            cart_session_manager: @elcodi.cart_session_manager
+            - @elcodi.cart_session_manager
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: saveCartInSession, priority: -2 }

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -17,6 +17,11 @@ services:
             - { name: kernel.event_listener, event: cart.onload, method: saveCart, priority: 0 }
             - { name: kernel.event_listener, event: cart.onload, method: loadCartQuantities, priority: 16 }
 
+    elcodi.event_listener.limit_negative_carts:
+        class: %elcodi.event_listener.limit_negative_carts.class%
+        tags:
+            - { name: kernel.event_listener, event: cart.onload, method: limitCartAmount, priority: -255 }
+
     elcodi.event_listener.order_creation:
         class: %elcodi.event_listener.order_creation.class%
         arguments:

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -8,7 +8,7 @@ services:
         arguments:
             - @elcodi.object_manager.cart
             - @elcodi.event_dispatcher.cart
-            - @elcodi.cart_manager
+            - @elcodi.cart.manager
             - @elcodi.wrapper.currency
             - @elcodi.converter.currency
         tags:
@@ -42,6 +42,6 @@ services:
     elcodi.event_listener.cart_session:
         class: %elcodi.event_listener.cart_session.class%
         arguments:
-            - @elcodi.cart_session_manager
+            - @elcodi.session_manager.cart
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: saveCartInSession, priority: -2 }

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
@@ -3,16 +3,16 @@ services:
     #
     # Services
     #
-    elcodi.cart_manager:
-        class: %elcodi.cart_manager.class%
+    elcodi.cart.manager:
+        class: %elcodi.cart.manager.class%
         arguments:
             cart_event_dispatcher: @elcodi.event_dispatcher.cart
             cart_line_event_dispatcher: @elcodi.event_dispatcher.cart_line
             cart_factory: @elcodi.factory.cart
             cart_line_factory: @elcodi.factory.cart_line
 
-    elcodi.cart_session_manager:
-        class: %elcodi.cart_session_manager.class%
+    elcodi.session_manager.cart:
+        class: %elcodi.session_manager.cart.class%
         arguments:
             session: @session
             session_field_name: %elcodi.core.cart.cart_session_field_name%
@@ -21,11 +21,11 @@ services:
     #
     # Wrappers
     #
-    elcodi.cart_wrapper:
-        class: %elcodi.cart_wrapper.class%
+    elcodi.wrapper.cart:
+        class: %elcodi.wrapper.cart.class%
         arguments:
             cart_event_dispatcher: @elcodi.event_dispatcher.cart
-            cart_session_manager: @elcodi.cart_session_manager
+            cart_session_manager: @elcodi.session_manager.cart
             cart_repository: @elcodi.repository.cart
             cart_factory: @elcodi.factory.cart
-            customer_wrapper: @elcodi.customer_wrapper
+            customer_wrapper: @elcodi.wrapper.customer

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/Abstracts/AbstractCartManagerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/Abstracts/AbstractCartManagerTest.php
@@ -37,7 +37,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.cart_manager'];
+        return ['elcodi.cart.manager'];
     }
 
     /**
@@ -107,7 +107,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testAddLine()
     {
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -152,7 +152,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testRemoveLine()
     {
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -162,7 +162,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->removeLine($this->cart, $line);
 
         $this->assertRemovedLine($line);
@@ -176,7 +176,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testEmptyLines()
     {
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -186,7 +186,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->emptyLines($this->cart);
 
         $this->assertRemovedLine($line);
@@ -200,7 +200,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testEditCartLine()
     {
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -210,7 +210,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->editCartLine($line, $this->purchasable, 2);
 
         $this->assertSame(
@@ -257,7 +257,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $this->cartLine->setQuantity($quantityStart);
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -267,7 +267,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->setCartLineQuantity($line, $quantitySetted);
 
         $this->assertResults($quantityEnd);
@@ -295,7 +295,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->setQuantity($quantityStart);
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct(
                 $this->cart,
                 $line->getProduct(),
@@ -309,7 +309,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         }
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->increaseCartLineQuantity($this->cart->getCartLines()->last(), $quantityAdded);
 
         $this->assertResults($quantityEnd);
@@ -333,7 +333,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $this->cartLine->setQuantity($quantityStart);
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -343,7 +343,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->decreaseCartLineQuantity($line, $quantityRemoved);
 
         $this->assertResults($quantityEnd);
@@ -363,7 +363,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $quantityEnd
     ) {
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct($this->cart, $this->purchasable, $quantitySet);
 
         $this->assertResults($quantityEnd);

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
@@ -144,11 +144,11 @@ class CartManagerVariantTest extends AbstractCartManagerTest
     public function testAddSameVariantTwice()
     {
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct($this->cart, $this->purchasable, 1);
 
         $this
-            ->get('elcodi.cart_manager')
+            ->get('elcodi.cart.manager')
             ->addProduct($this->cart, $this->purchasable, 2);
 
         $this->assertEquals(1, $this->cart->getCartLines()->count());

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Wrapper/CartWrapperTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Wrapper/CartWrapperTest.php
@@ -41,6 +41,6 @@ class CartWrapperTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.cart_wrapper'];
+        return ['elcodi.wrapper.cart'];
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
@@ -9,7 +9,8 @@ parameters:
     #
     # Event Listeners
     #
-    elcodi.event_listener.cart_coupon.refresh_cart.class: Elcodi\Component\CartCoupon\EventListener\CartEventListener
+    elcodi.event_listener.cart_coupon.refresh_coupons.class: Elcodi\Component\CartCoupon\EventListener\RefreshCouponsListener
+    elcodi.event_listener.cart_coupon.coupon_checker.class: Elcodi\Component\CartCoupon\EventListener\CheckCouponListener
     elcodi.event_listener.cart_coupon.check_minimum_price.class: Elcodi\Component\CartCoupon\EventListener\MinimumPriceCouponEventListener
     elcodi.event_listener.cart_coupon.convert_to_order.class: Elcodi\Component\CartCoupon\EventListener\ConvertToOrderCouponsListener
     elcodi.event_listener.cart_coupon.cart_coupon_manager.class: Elcodi\Component\CartCoupon\EventListener\CartCouponManagerListener
@@ -17,6 +18,7 @@ parameters:
     elcodi.event_listener.cart_coupon.order_coupon_manager.class: Elcodi\Component\CartCoupon\EventListener\OrderCouponManagerListener
     elcodi.event_listener.cart_coupon.automatic_coupons.class: Elcodi\Component\CartCoupon\EventListener\AutomaticCouponApplicatorListener
     elcodi.event_listener.cart_coupon.avoid_coupon_duplicates.class: Elcodi\Component\CartCoupon\EventListener\AvoidDuplicatesListener
+    elcodi.event_listener.cart_coupon.cart_coupon_checker.class: Elcodi\Component\CartCoupon\EventListener\CheckCartCouponListener
 
     #
     # Services

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
@@ -11,6 +11,7 @@ parameters:
     #
     elcodi.core.cart_coupon.event_listener.cart.class: Elcodi\Component\CartCoupon\EventListener\CartEventListener
     elcodi.core.cart_coupon.event_listener.order.class: Elcodi\Component\CartCoupon\EventListener\OrderEventListener
+    elcodi.core.cart_coupon.event_listener.check_coupon.class: Elcodi\Component\CartCoupon\EventListener\CheckCouponEventListener
     elcodi.core.cart_coupon.event_listener.cart_coupon.class: Elcodi\Component\CartCoupon\EventListener\CartCouponEventListener
     elcodi.core.cart_coupon.event_listener.cart_coupon_rules.class: Elcodi\Component\CartCoupon\EventListener\CartCouponRulesEventListener
     elcodi.core.cart_coupon.event_listener.order_coupon.class: Elcodi\Component\CartCoupon\EventListener\OrderCouponEventListener

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
@@ -12,6 +12,7 @@ parameters:
     elcodi.core.cart_coupon.event_listener.cart.class: Elcodi\Component\CartCoupon\EventListener\CartEventListener
     elcodi.core.cart_coupon.event_listener.order.class: Elcodi\Component\CartCoupon\EventListener\OrderEventListener
     elcodi.core.cart_coupon.event_listener.check_coupon.class: Elcodi\Component\CartCoupon\EventListener\CheckCouponEventListener
+    elcodi.core.cart_coupon.event_listener.minimum_price.class: Elcodi\Component\CartCoupon\EventListener\MinimumPriceCouponEventListener
     elcodi.core.cart_coupon.event_listener.cart_coupon.class: Elcodi\Component\CartCoupon\EventListener\CartCouponEventListener
     elcodi.core.cart_coupon.event_listener.cart_coupon_rules.class: Elcodi\Component\CartCoupon\EventListener\CartCouponRulesEventListener
     elcodi.core.cart_coupon.event_listener.order_coupon.class: Elcodi\Component\CartCoupon\EventListener\OrderCouponEventListener

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
@@ -11,10 +11,10 @@ parameters:
     #
     elcodi.event_listener.cart_coupon.refresh_coupons.class: Elcodi\Component\CartCoupon\EventListener\RefreshCouponsListener
     elcodi.event_listener.cart_coupon.coupon_checker.class: Elcodi\Component\CartCoupon\EventListener\CheckCouponListener
-    elcodi.event_listener.cart_coupon.check_minimum_price.class: Elcodi\Component\CartCoupon\EventListener\MinimumPriceCouponEventListener
+    elcodi.event_listener.cart_coupon.check_minimum_price.class: Elcodi\Component\CartCoupon\EventListener\MinimumPriceCouponListener
     elcodi.event_listener.cart_coupon.convert_to_order.class: Elcodi\Component\CartCoupon\EventListener\ConvertToOrderCouponsListener
     elcodi.event_listener.cart_coupon.cart_coupon_manager.class: Elcodi\Component\CartCoupon\EventListener\CartCouponManagerListener
-    elcodi.event_listener.cart_coupon.check_rules.class: Elcodi\Component\CartCoupon\EventListener\CartCouponRulesEventListener
+    elcodi.event_listener.cart_coupon.check_rules.class: Elcodi\Component\CartCoupon\EventListener\CheckRulesListener
     elcodi.event_listener.cart_coupon.order_coupon_manager.class: Elcodi\Component\CartCoupon\EventListener\OrderCouponManagerListener
     elcodi.event_listener.cart_coupon.automatic_coupons.class: Elcodi\Component\CartCoupon\EventListener\AutomaticCouponApplicatorListener
     elcodi.event_listener.cart_coupon.avoid_coupon_duplicates.class: Elcodi\Component\CartCoupon\EventListener\AvoidDuplicatesListener

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/classes.yml
@@ -9,22 +9,21 @@ parameters:
     #
     # Event Listeners
     #
-    elcodi.core.cart_coupon.event_listener.cart.class: Elcodi\Component\CartCoupon\EventListener\CartEventListener
-    elcodi.core.cart_coupon.event_listener.order.class: Elcodi\Component\CartCoupon\EventListener\OrderEventListener
-    elcodi.core.cart_coupon.event_listener.check_coupon.class: Elcodi\Component\CartCoupon\EventListener\CheckCouponEventListener
-    elcodi.core.cart_coupon.event_listener.minimum_price.class: Elcodi\Component\CartCoupon\EventListener\MinimumPriceCouponEventListener
-    elcodi.core.cart_coupon.event_listener.cart_coupon.class: Elcodi\Component\CartCoupon\EventListener\CartCouponEventListener
-    elcodi.core.cart_coupon.event_listener.cart_coupon_rules.class: Elcodi\Component\CartCoupon\EventListener\CartCouponRulesEventListener
-    elcodi.core.cart_coupon.event_listener.order_coupon.class: Elcodi\Component\CartCoupon\EventListener\OrderCouponEventListener
-    elcodi.core.cart_coupon.event_listener.automatic_coupons.class: Elcodi\Component\CartCoupon\EventListener\AutomaticCouponApplicatorListener
-    elcodi.core.cart_coupon.event_listener.duplicated_coupons.class: Elcodi\Component\CartCoupon\EventListener\CartCouponDuplicateListener
+    elcodi.event_listener.cart_coupon.refresh_cart.class: Elcodi\Component\CartCoupon\EventListener\CartEventListener
+    elcodi.event_listener.cart_coupon.check_minimum_price.class: Elcodi\Component\CartCoupon\EventListener\MinimumPriceCouponEventListener
+    elcodi.event_listener.cart_coupon.convert_to_order.class: Elcodi\Component\CartCoupon\EventListener\ConvertToOrderCouponsListener
+    elcodi.event_listener.cart_coupon.cart_coupon_manager.class: Elcodi\Component\CartCoupon\EventListener\CartCouponManagerListener
+    elcodi.event_listener.cart_coupon.check_rules.class: Elcodi\Component\CartCoupon\EventListener\CartCouponRulesEventListener
+    elcodi.event_listener.cart_coupon.order_coupon_manager.class: Elcodi\Component\CartCoupon\EventListener\OrderCouponManagerListener
+    elcodi.event_listener.cart_coupon.automatic_coupons.class: Elcodi\Component\CartCoupon\EventListener\AutomaticCouponApplicatorListener
+    elcodi.event_listener.cart_coupon.avoid_coupon_duplicates.class: Elcodi\Component\CartCoupon\EventListener\AvoidDuplicatesListener
 
     #
     # Services
     #
-    elcodi.cart_coupon_manager.class: Elcodi\Component\CartCoupon\Services\CartCouponManager
-    elcodi.cart_coupon_rule_manager.class: Elcodi\Component\CartCoupon\Services\CartCouponRuleManager
-    elcodi.order_coupon_manager.class: Elcodi\Component\CartCoupon\Services\OrderCouponManager
+    elcodi.manager.cart_coupon.class: Elcodi\Component\CartCoupon\Services\CartCouponManager
+    elcodi.manager.cart_coupon_rule.class: Elcodi\Component\CartCoupon\Services\CartCouponRuleManager
+    elcodi.manager.order_coupon.class: Elcodi\Component\CartCoupon\Services\OrderCouponManager
 
     #
     # EventDispatchers

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
@@ -42,6 +42,13 @@ services:
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkCoupon, priority: 32 }
 
+    elcodi.core.cart_coupon.event_listener.minimum_price:
+        class: %elcodi.core.cart_coupon.event_listener.minimum_price.class%
+        arguments:
+            - @elcodi.currency_converter
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkMinimumPrice, priority: 16 }
+
     elcodi.core.cart_coupon.event_listener.cart_coupon_rules:
         class: %elcodi.core.cart_coupon.event_listener.cart_coupon_rules.class%
         arguments:

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
@@ -3,18 +3,69 @@ services:
     #
     # Event Listeners
     #
-    elcodi.event_listener.cart_coupon.refresh_cart:
-        class: %elcodi.event_listener.cart_coupon.refresh_cart.class%
+    elcodi.event_listener.cart_coupon.refresh_coupons:
+        class: %elcodi.event_listener.cart_coupon.refresh_coupons.class%
         arguments:
             - @elcodi.manager.coupon
             - @elcodi.manager.cart_coupon
-            - @elcodi.currency_wrapper
-            - @elcodi.currency_converter
-            - @elcodi.manager.cart_coupon_rule
+            - @elcodi.wrapper.currency
+            - @elcodi.converter.currency
             - @elcodi.event_dispatcher.cart_coupon
         tags:
-            - { name: kernel.event_listener, event: cart.preload, method: onCartPreLoadCoupons, priority: 0 }
-            - { name: kernel.event_listener, event: cart.onload, method: onCartLoadCoupons, priority: -32 }
+            - { name: kernel.event_listener, event: cart.onload, method: refreshCartCoupons, priority: 0 }
+            - { name: kernel.event_listener, event: cart.onload, method: refreshCouponAmount, priority: -32 }
+
+    elcodi.event_listener.cart_coupon.automatic_coupons:
+        class: %elcodi.event_listener.cart_coupon.automatic_coupons.class%
+        arguments:
+            - @elcodi.manager.cart_coupon
+            - @elcodi.repository.coupon
+        tags:
+            - { name: kernel.event_listener, event: cart.onload, method: tryAutomaticCoupons, priority: -16 }
+
+    elcodi.event_listener.cart_coupon.avoid_coupon_duplicates:
+        class: %elcodi.event_listener.cart_coupon.avoid_coupon_duplicates.class%
+        arguments:
+            - @elcodi.repository.cart_coupon
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkDuplicates, priority: 16 }
+
+    elcodi.event_listener.cart_coupon.cart_coupon_checker:
+        class: %elcodi.event_listener.cart_coupon.cart_coupon_checker.class%
+        arguments:
+            - @elcodi.event_dispatcher.cart_coupon
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkCoupon, priority: 16 }
+
+    elcodi.event_listener.cart_coupon.cart_coupon_manager:
+        class: %elcodi.event_listener.cart_coupon.cart_coupon_manager.class%
+        arguments:
+            - @elcodi.object_manager.cart_coupon
+            - @elcodi.factory.cart_coupon
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.onapply, method: onCartCouponApply, priority: 0 }
+            - { name: kernel.event_listener, event: cart_coupon.onremove, method: onCartCouponRemove, priority: 0 }
+
+    elcodi.event_listener.cart_coupon.coupon_checker:
+        class: %elcodi.event_listener.cart_coupon.coupon_checker.class%
+        arguments:
+            - @elcodi.manager.coupon
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.oncheck, method: checkCoupon, priority: 32 }
+
+    elcodi.event_listener.cart_coupon.check_minimum_price:
+        class: %elcodi.event_listener.cart_coupon.check_minimum_price.class%
+        arguments:
+            - @elcodi.converter.currency
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.oncheck, method: checkMinimumPrice, priority: 0 }
+
+    elcodi.event_listener.cart_coupon.check_rules:
+        class: %elcodi.event_listener.cart_coupon.check_rules.class%
+        arguments:
+            - @elcodi.manager.cart_coupon_rule
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.oncheck, method: checkCoupon, priority: -16 }
 
     elcodi.event_listener.cart_coupon.convert_to_order:
         class: %elcodi.event_listener.cart_coupon.convert_to_order.class%
@@ -26,36 +77,6 @@ services:
         tags:
             - { name: kernel.event_listener, event: order.oncreated, method: convertCoupontToOrder, priority: -16 }
 
-    elcodi.event_listener.cart_coupon.cart_coupon_manager:
-        class: %elcodi.event_listener.cart_coupon.cart_coupon_manager.class%
-        arguments:
-            - @elcodi.object_manager.cart_coupon
-            - @elcodi.factory.cart_coupon
-        tags:
-            - { name: kernel.event_listener, event: cart_coupon.onapply, method: onCartCouponApply, priority: 0 }
-            - { name: kernel.event_listener, event: cart_coupon.onremove, method: onCartCouponRemove, priority: 0 }
-
-    elcodi.event_listener.cart_coupon.check_rules:
-        class: %elcodi.event_listener.cart_coupon.check_rules.class%
-        arguments:
-            - @elcodi.manager.coupon
-        tags:
-            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkCoupon, priority: 32 }
-
-    elcodi.event_listener.cart_coupon.check_minimum_price:
-        class: %elcodi.event_listener.cart_coupon.check_minimum_price.class%
-        arguments:
-            - @elcodi.currency_converter
-        tags:
-            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkMinimumPrice, priority: 16 }
-
-    elcodi.event_listener.cart_coupon.avoid_coupon_duplicates:
-        class: %elcodi.event_listener.cart_coupon.avoid_coupon_duplicates.class%
-        arguments:
-            - @elcodi.repository.cart_coupon
-        tags:
-            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkDuplicates, priority: 16 }
-
     elcodi.event_listener.cart_coupon.order_coupon_manager:
         class: %elcodi.event_listener.cart_coupon.order_coupon_manager.class%
         arguments:
@@ -64,11 +85,3 @@ services:
             - @elcodi.factory.order_coupon
         tags:
             - { name: kernel.event_listener, event: order_coupon.onapply, method: convertToOrderCoupons, priority: 0 }
-
-    elcodi.event_listener.cart_coupon.automatic_coupons:
-        class: %elcodi.event_listener.cart_coupon.automatic_coupons.class%
-        arguments:
-            - @elcodi.manager.cart_coupon
-            - @elcodi.repository.coupon
-        tags:
-            - { name: kernel.event_listener, event: cart.onload, method: tryAutomaticCoupons, priority: -16 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
@@ -3,80 +3,72 @@ services:
     #
     # Event Listeners
     #
-    elcodi.core.cart_coupon.event_listener.cart:
-        class: %elcodi.core.cart_coupon.event_listener.cart.class%
+    elcodi.event_listener.cart_coupon.refresh_cart:
+        class: %elcodi.event_listener.cart_coupon.refresh_cart.class%
         arguments:
-            coupon_manager: @elcodi.coupon_manager
-            cart_coupon_manager: @elcodi.cart_coupon_manager
-            currency_wrapper: @elcodi.currency_wrapper
-            currency_converter: @elcodi.currency_converter
-            cart_coupon_rule_manager: @elcodi.cart_coupon_rule_manager
-            cart_coupon_event_dispatcher: @elcodi.event_dispatcher.cart_coupon
+            - @elcodi.manager.coupon
+            - @elcodi.manager.cart_coupon
+            - @elcodi.currency_wrapper
+            - @elcodi.currency_converter
+            - @elcodi.manager.cart_coupon_rule
+            - @elcodi.event_dispatcher.cart_coupon
         tags:
             - { name: kernel.event_listener, event: cart.preload, method: onCartPreLoadCoupons, priority: 0 }
             - { name: kernel.event_listener, event: cart.onload, method: onCartLoadCoupons, priority: -32 }
 
-    elcodi.core.cart_coupon.event_listener.order:
-        class: %elcodi.core.cart_coupon.event_listener.order.class%
+    elcodi.event_listener.cart_coupon.convert_to_order:
+        class: %elcodi.event_listener.cart_coupon.convert_to_order.class%
         arguments:
-            order_coupon_event_dispatcher: @elcodi.event_dispatcher.order_coupon
-            cart_coupon_manager: @elcodi.cart_coupon_manager
-            order_coupon_manager: @elcodi.order_coupon_manager
-            order_coupon_object_manager: @elcodi.object_manager.order_coupon
+            - @elcodi.event_dispatcher.order_coupon
+            - @elcodi.manager.cart_coupon
+            - @elcodi.manager.order_coupon
+            - @elcodi.object_manager.order_coupon
         tags:
-            - { name: kernel.event_listener, event: order.oncreated, method: onOrderOnCreatedEvent, priority: -16 }
+            - { name: kernel.event_listener, event: order.oncreated, method: convertCoupontToOrder, priority: -16 }
 
-    elcodi.core.cart_coupon.event_listener.cart_coupon:
-        class: %elcodi.core.cart_coupon.event_listener.cart_coupon.class%
+    elcodi.event_listener.cart_coupon.cart_coupon_manager:
+        class: %elcodi.event_listener.cart_coupon.cart_coupon_manager.class%
         arguments:
-            cart_coupon_object_manager: @elcodi.object_manager.cart_coupon
-            cart_coupon_factory: @elcodi.factory.cart_coupon
+            - @elcodi.object_manager.cart_coupon
+            - @elcodi.factory.cart_coupon
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: onCartCouponApply, priority: 0 }
             - { name: kernel.event_listener, event: cart_coupon.onremove, method: onCartCouponRemove, priority: 0 }
 
-    elcodi.core.cart_coupon.event_listener.check_coupon:
-        class: %elcodi.core.cart_coupon.event_listener.check_coupon.class%
+    elcodi.event_listener.cart_coupon.check_rules:
+        class: %elcodi.event_listener.cart_coupon.check_rules.class%
         arguments:
-            - @elcodi.coupon_manager
+            - @elcodi.manager.coupon
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkCoupon, priority: 32 }
 
-    elcodi.core.cart_coupon.event_listener.minimum_price:
-        class: %elcodi.core.cart_coupon.event_listener.minimum_price.class%
+    elcodi.event_listener.cart_coupon.check_minimum_price:
+        class: %elcodi.event_listener.cart_coupon.check_minimum_price.class%
         arguments:
             - @elcodi.currency_converter
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkMinimumPrice, priority: 16 }
 
-    elcodi.core.cart_coupon.event_listener.cart_coupon_rules:
-        class: %elcodi.core.cart_coupon.event_listener.cart_coupon_rules.class%
-        arguments:
-            cart_coupon_rule_manager: @elcodi.cart_coupon_rule_manager
-            cart_coupon_event_dispatcher: @elcodi.event_dispatcher.cart_coupon
-        tags:
-            - { name: kernel.event_listener, event: cart_coupon.onapply, method: onCartCouponApply, priority: 16 }
-
-    elcodi.core.cart_coupon.event_listener.duplicated_coupons:
-        class: %elcodi.core.cart_coupon.event_listener.duplicated_coupons.class%
+    elcodi.event_listener.cart_coupon.avoid_coupon_duplicates:
+        class: %elcodi.event_listener.cart_coupon.avoid_coupon_duplicates.class%
         arguments:
             - @elcodi.repository.cart_coupon
         tags:
-            - { name: kernel.event_listener, event: cart_coupon.onapply, method: onCartCouponApply, priority: 16 }
+            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkDuplicates, priority: 16 }
 
-    elcodi.core.cart_coupon.event_listener.order_coupon:
-        class: %elcodi.core.cart_coupon.event_listener.order_coupon.class%
+    elcodi.event_listener.cart_coupon.order_coupon_manager:
+        class: %elcodi.event_listener.cart_coupon.order_coupon_manager.class%
         arguments:
-            order_coupon_object_manager: @elcodi.object_manager.order_coupon
-            coupon_event_dispatcher: @elcodi.event_dispatcher.coupon
-            order_coupon_factory: @elcodi.factory.order_coupon
+            - @elcodi.object_manager.order_coupon
+            - @elcodi.event_dispatcher.coupon
+            - @elcodi.factory.order_coupon
         tags:
-            - { name: kernel.event_listener, event: order_coupon.onapply, method: onOrderCouponApply, priority: 0 }
+            - { name: kernel.event_listener, event: order_coupon.onapply, method: convertToOrderCoupons, priority: 0 }
 
-    elcodi.core.cart_coupon.event_listener.automatic_coupons:
-        class: %elcodi.core.cart_coupon.event_listener.automatic_coupons.class%
+    elcodi.event_listener.cart_coupon.automatic_coupons:
+        class: %elcodi.event_listener.cart_coupon.automatic_coupons.class%
         arguments:
-            - @elcodi.cart_coupon_manager
+            - @elcodi.manager.cart_coupon
             - @elcodi.repository.coupon
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: tryAutomaticCoupons, priority: -16 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
@@ -35,6 +35,13 @@ services:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: onCartCouponApply, priority: 0 }
             - { name: kernel.event_listener, event: cart_coupon.onremove, method: onCartCouponRemove, priority: 0 }
 
+    elcodi.core.cart_coupon.event_listener.check_coupon:
+        class: %elcodi.core.cart_coupon.event_listener.check_coupon.class%
+        arguments:
+            - @elcodi.coupon_manager
+        tags:
+            - { name: kernel.event_listener, event: cart_coupon.onapply, method: checkCoupon, priority: 32 }
+
     elcodi.core.cart_coupon.event_listener.cart_coupon_rules:
         class: %elcodi.core.cart_coupon.event_listener.cart_coupon_rules.class%
         arguments:

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
@@ -19,4 +19,4 @@ services:
     elcodi.manager.cart_coupon_rule:
         class: %elcodi.manager.cart_coupon_rule.class%
         arguments:
-            rule_manager: @elcodi.rule_manager
+            rule_manager: @elcodi.manager.rule

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
@@ -3,20 +3,20 @@ services:
     #
     # Services
     #
-    elcodi.cart_coupon_manager:
-        class: %elcodi.cart_coupon_manager.class%
+    elcodi.manager.cart_coupon:
+        class: %elcodi.manager.cart_coupon.class%
         arguments:
             cart_coupon_event_dispatcher: @elcodi.event_dispatcher.cart_coupon
-            coupon_manager: @elcodi.coupon_manager
+            coupon_manager: @elcodi.manager.coupon
             coupon_repository: @elcodi.repository.coupon
             cart_coupon_repository: @elcodi.repository.cart_coupon
 
-    elcodi.order_coupon_manager:
-        class: %elcodi.order_coupon_manager.class%
+    elcodi.manager.order_coupon:
+        class: %elcodi.manager.order_coupon.class%
         arguments:
             order_coupon_repository: @elcodi.repository.order_coupon
 
-    elcodi.cart_coupon_rule_manager:
-        class: %elcodi.cart_coupon_rule_manager.class%
+    elcodi.manager.cart_coupon_rule:
+        class: %elcodi.manager.cart_coupon_rule.class%
         arguments:
             rule_manager: @elcodi.rule_manager

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponEventListenerTest.php
@@ -42,7 +42,7 @@ class CartCouponEventListenerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.event_listener.cart_coupon.refresh_cart',
+            'elcodi.event_listener.cart_coupon.refresh_coupons',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponEventListenerTest.php
@@ -42,7 +42,7 @@ class CartCouponEventListenerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.cart_coupon.event_listener.cart',
+            'elcodi.event_listener.cart_coupon.refresh_cart',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
@@ -36,7 +36,7 @@ class CartCouponRulesEventListenerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.cart_coupon.event_listener.cart_coupon_rules',
+            'elcodi.event_listener.cart_coupon.check_rules',
         ];
     }
 
@@ -87,7 +87,7 @@ class CartCouponRulesEventListenerTest extends WebTestCase
 
         $coupon->setRule($rule);
 
-        $cartCouponManager = $this->get('elcodi.cart_coupon_manager');
+        $cartCouponManager = $this->get('elcodi.manager.cart_coupon');
 
         try {
             $cartCouponManager->addCoupon(

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartEventListenerTest.php
@@ -45,7 +45,7 @@ class CartEventListenerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.cart_coupon.event_listener.cart',
+            'elcodi.event_listener.cart_coupon.refresh_cart',
         ];
     }
 
@@ -77,7 +77,7 @@ class CartEventListenerTest extends WebTestCase
         $ruleId = $this->loadDefaultTestConfigurationAndReturnRuleId();
 
         $cartCouponManager = $this
-            ->get('elcodi.cart_coupon_manager');
+            ->get('elcodi.manager.cart_coupon');
 
         /**
          * We change rule to false
@@ -115,7 +115,7 @@ class CartEventListenerTest extends WebTestCase
         $this->loadDefaultTestConfigurationAndReturnRuleId();
 
         $cartCouponManager = $this
-            ->get('elcodi.cart_coupon_manager');
+            ->get('elcodi.manager.cart_coupon');
 
         /**
          * We load again same Cart and load it
@@ -159,7 +159,7 @@ class CartEventListenerTest extends WebTestCase
         $coupon->setRule($rule);
 
         $this
-            ->get('elcodi.cart_coupon_manager')
+            ->get('elcodi.manager.cart_coupon')
             ->addCoupon(
                 $cart,
                 $coupon

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderCouponEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderCouponEventListenerTest.php
@@ -39,6 +39,6 @@ class OrderCouponEventListenerTest
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.cart_coupon.event_listener.order_coupon'];
+        return ['elcodi.event_listener.cart_coupon.order_coupon_manager'];
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderEventListenerTest.php
@@ -38,7 +38,7 @@ class OrderEventListenerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.cart_coupon.event_listener.order'];
+        return ['elcodi.event_listener.cart_coupon.convert_to_order'];
     }
 
     /**
@@ -90,11 +90,11 @@ class OrderEventListenerTest extends WebTestCase
         );
 
         $cartCoupons = $this
-            ->get('elcodi.cart_coupon_manager')
+            ->get('elcodi.manager.cart_coupon')
             ->getCartCoupons($cart);
 
         $orderCoupons = $this
-            ->get('elcodi.order_coupon_manager')
+            ->get('elcodi.manager.order_coupon')
             ->getOrderCoupons($order);
 
         $this->assertEquals(

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/CartCouponManagerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/CartCouponManagerTest.php
@@ -42,7 +42,7 @@ class CartCouponManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.cart_coupon_manager'];
+        return ['elcodi.manager.cart_coupon'];
     }
 
     /**
@@ -53,7 +53,7 @@ class CartCouponManagerTest extends WebTestCase
         $cart = new Cart();
 
         $this->assertEmpty($this
-            ->get('elcodi.cart_coupon_manager')
+            ->get('elcodi.manager.cart_coupon')
             ->getCartCoupons($cart)
         );
     }
@@ -66,7 +66,7 @@ class CartCouponManagerTest extends WebTestCase
         $cart = new Cart();
 
         $this->assertEmpty($this
-            ->get('elcodi.cart_coupon_manager')
+            ->get('elcodi.manager.cart_coupon')
             ->getCoupons($cart)
         );
     }

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/CartCouponRuleManagerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/CartCouponRuleManagerTest.php
@@ -41,6 +41,6 @@ class CartCouponRuleManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.cart_coupon_rule_manager'];
+        return ['elcodi.manager.cart_coupon_rule'];
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/OrderCouponManagerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Services/OrderCouponManagerTest.php
@@ -41,6 +41,6 @@ class OrderCouponManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.order_coupon_manager'];
+        return ['elcodi.manager.order_coupon'];
     }
 }

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/classes.yml
@@ -9,10 +9,10 @@ parameters:
     #
     # Services
     #
-    elcodi.comment_manager.class: Elcodi\Component\Comment\Services\CommentManager
+    elcodi.manager.comment.class: Elcodi\Component\Comment\Services\CommentManager
     elcodi.comment_parser.class: Elcodi\Component\Comment\Services\CommentParser
     elcodi.comment_cache.class: Elcodi\Component\Comment\Services\CommentCache
-    elcodi.comment_vote_manager.class: Elcodi\Component\Comment\Services\VoteManager
+    elcodi.manager.comment_vote.class: Elcodi\Component\Comment\Services\VoteManager
 
     #
     # Controllers

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/controllers.yml
@@ -6,6 +6,6 @@ services:
     elcodi.controller.comment:
         class: %elcodi.controller.comment.class%
         arguments:
-            - @elcodi.comment_manager
+            - @elcodi.manager.comment
             - @elcodi.comment_cache
             - @elcodi.repository.comment

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/services.yml
@@ -3,8 +3,8 @@ services:
     #
     # Services
     #
-    elcodi.comment_manager:
-        class: %elcodi.comment_manager.class%
+    elcodi.manager.comment:
+        class: %elcodi.manager.comment.class%
         arguments:
             comment_event_dispatcher: @elcodi.event_dispatcher.comment
             comment_director: @elcodi.director.comment
@@ -23,14 +23,14 @@ services:
         class: %elcodi.comment_cache.class%
         arguments:
             comment_repository: @elcodi.repository.comment
-            comment_vote_manager: @elcodi.comment_vote_manager
+            comment_vote_manager: @elcodi.manager.comment_vote
             cache_key: %elcodi.comment.cache_key%
         calls:
             - [setCache, [@doctrine_cache.providers.elcodi_comments]]
             - [setEncoder, [@elcodi.json_encoder]]
 
-    elcodi.comment_vote_manager:
-        class: %elcodi.comment_vote_manager.class%
+    elcodi.manager.comment_vote:
+        class: %elcodi.manager.comment_vote.class%
         arguments:
             comment_event_dispatcher: @elcodi.event_dispatcher.comment
             vote_director: @elcodi.director.comment_vote

--- a/src/Elcodi/Bundle/CommentBundle/Tests/Functional/Services/CommentCacheTest.php
+++ b/src/Elcodi/Bundle/CommentBundle/Tests/Functional/Services/CommentCacheTest.php
@@ -52,7 +52,7 @@ class CommentCacheTest extends WebTestCase
     public function testLoad()
     {
         $commentCache = $this->get('elcodi.comment_cache');
-        $commentManager = $this->get('elcodi.comment_manager');
+        $commentManager = $this->get('elcodi.manager.comment');
         $source = 'product-1';
         $comment1 = $commentManager->addComment(
             $source,

--- a/src/Elcodi/Bundle/CommentBundle/Tests/Functional/Services/CommentManagerTest.php
+++ b/src/Elcodi/Bundle/CommentBundle/Tests/Functional/Services/CommentManagerTest.php
@@ -42,7 +42,7 @@ class CommentManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.comment_manager',
+            'elcodi.manager.comment',
         ];
     }
 
@@ -51,7 +51,7 @@ class CommentManagerTest extends WebTestCase
      */
     public function testAddComment()
     {
-        $commentManager = $this->get('elcodi.comment_manager');
+        $commentManager = $this->get('elcodi.manager.comment');
         $source = 'http://page.com/product1';
         $commentManager->addComment(
             $source,

--- a/src/Elcodi/Bundle/CommentBundle/Tests/Functional/Services/VoteManagerTest.php
+++ b/src/Elcodi/Bundle/CommentBundle/Tests/Functional/Services/VoteManagerTest.php
@@ -44,7 +44,7 @@ class VoteManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.comment_vote_manager',
+            'elcodi.manager.comment_vote',
         ];
     }
 
@@ -56,7 +56,7 @@ class VoteManagerTest extends WebTestCase
         /**
          * @var VoteManager $voteManager
          */
-        $voteManager = $this->get('elcodi.comment_vote_manager');
+        $voteManager = $this->get('elcodi.manager.comment_vote');
 
         $comment = $this
             ->getFactory('comment')

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/classes.yml
@@ -3,17 +3,17 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.configuration.factory.configuration.class: Elcodi\Component\Configuration\Factory\ConfigurationFactory
+    elcodi.factory.configuration.class: Elcodi\Component\Configuration\Factory\ConfigurationFactory
 
     #
     # Services
     #
-    elcodi.configuration_manager.class: Elcodi\Component\Configuration\Services\ConfigurationManager
+    elcodi.manager.configuration.class: Elcodi\Component\Configuration\Services\ConfigurationManager
 
     #
     # Twig extensions
     #
-    elcodi.core.configuration.twig_extension.configuration_extension.class: Elcodi\Component\Configuration\Twig\ConfigurationExtension
+    elcodi.twig_extension.configuration.class: Elcodi\Component\Configuration\Twig\ConfigurationExtension
 
     #
     # Commands

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/commands.yml
@@ -6,13 +6,13 @@ services:
     elcodi.configuration_set_command:
         class: %elcodi.configuration_set_command.class%
         arguments:
-            template_loader: @elcodi.configuration_manager
+            template_loader: @elcodi.manager.configuration
         tags:
             -  { name: console.command }
 
     elcodi.configuration_get_command:
         class: %elcodi.configuration_get_command.class%
         arguments:
-            template_loader: @elcodi.configuration_manager
+            template_loader: @elcodi.manager.configuration
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/factories.yml
@@ -7,10 +7,7 @@ services:
     #
     # Factory for configuration entity
     #
-    elcodi.core.configuration.factory.configuration:
-        class: %elcodi.core.configuration.factory.configuration.class%
+    elcodi.factory.configuration:
+        class: %elcodi.factory.configuration.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.configuration.entity.configuration.class%"]]
-
-    elcodi.factory.configuration:
-        alias: elcodi.core.configuration.factory.configuration

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
@@ -3,8 +3,8 @@ services:
     #
     # Services
     #
-    elcodi.configuration_manager:
-        class: %elcodi.configuration_manager.class%
+    elcodi.manager.configuration:
+        class: %elcodi.manager.configuration.class%
         lazy: true
         arguments:
             configuration_object_manager: @elcodi.object_manager.configuration

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
@@ -3,9 +3,9 @@ services:
     #
     # Twig extensions
     #
-    elcodi.core.configuration.twig_extension.configuration_extension:
-        class: %elcodi.core.configuration.twig_extension.configuration_extension.class%
+    elcodi.twig_extension.configuration:
+        class: %elcodi.twig_extension.configuration.class%
         arguments:
-            configuration_manager: @elcodi.configuration_manager
+            configuration_manager: @elcodi.manager.configuration
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
@@ -49,7 +49,7 @@ class ConfigurationManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.configuration_manager'];
+        return ['elcodi.manager.configuration'];
     }
 
     /**
@@ -159,7 +159,7 @@ class ConfigurationManagerTest extends WebTestCase
             );
 
         $this
-            ->get('elcodi.configuration_manager')
+            ->get('elcodi.manager.configuration')
             ->set('my_parameter', 'my_new_value');
 
         $this
@@ -202,7 +202,7 @@ class ConfigurationManagerTest extends WebTestCase
             );
 
         $this
-            ->get('elcodi.configuration_manager')
+            ->get('elcodi.manager.configuration')
             ->set('my_immutable_parameter', 'immutable');
 
         $this
@@ -217,7 +217,7 @@ class ConfigurationManagerTest extends WebTestCase
             );
 
         $this
-            ->get('elcodi.configuration_manager')
+            ->get('elcodi.manager.configuration')
             ->set('my_immutable_parameter', 'non-immutable');
     }
 }

--- a/src/Elcodi/Bundle/CoreBundle/Container/Traits/ContainerAccessorTrait.php
+++ b/src/Elcodi/Bundle/CoreBundle/Container/Traits/ContainerAccessorTrait.php
@@ -163,7 +163,7 @@ trait ContainerAccessorTrait
          * @var ObjectManager $objectManager
          */
         $objectManager = $this
-            ->get('elcodi.manager_provider')
+            ->get('elcodi.provider.manager')
             ->getManagerByEntityNamespace(get_class($entity));
 
         $objectManager->persist($entity);
@@ -185,7 +185,7 @@ trait ContainerAccessorTrait
          * @var ObjectManager $objectManager
          */
         $objectManager = $this
-            ->get('elcodi.manager_provider')
+            ->get('elcodi.provider.manager')
             ->getManagerByEntityNamespace(get_class($entity));
 
         $objectManager->clear($entity);

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/classes.yml
@@ -4,8 +4,8 @@ parameters:
     # Providers
     #
     elcodi.container_parameters.class: Symfony\Component\DependencyInjection\ParameterBag\ParameterBag
-    elcodi.manager_provider.class: Elcodi\Component\Core\Services\ManagerProvider
-    elcodi.repository_provider.class: Elcodi\Component\Core\Services\RepositoryProvider
+    elcodi.provider.manager.class: Elcodi\Component\Core\Services\ManagerProvider
+    elcodi.provider.repository.class: Elcodi\Component\Core\Services\RepositoryProvider
     elcodi.mapping_provider.class: Elcodi\Component\Core\Services\MappingProvider
 
     #

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/providers.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/providers.yml
@@ -8,16 +8,16 @@ services:
         factory_service: service_container
         factory_method: getParameterBag
 
-    elcodi.manager_provider:
-        class: %elcodi.manager_provider.class%
+    elcodi.provider.manager:
+        class: %elcodi.provider.manager.class%
         arguments:
             manager: @doctrine
             parameters_bag: @elcodi.container_parameters
 
-    elcodi.repository_provider:
-        class: %elcodi.repository_provider.class%
+    elcodi.provider.repository:
+        class: %elcodi.provider.repository.class%
         arguments:
-            manager_provider: @elcodi.manager_provider
+            manager_provider: @elcodi.provider.manager
             parameters_bag: @elcodi.container_parameters
 
     elcodi.mapping_provider:

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/services.yml
@@ -5,7 +5,7 @@ services:
     #
     elcodi.abstract_manager:
         class: Doctrine\Common\Persistence\ObjectManager
-        factory_service: elcodi.manager_provider
+        factory_service: elcodi.provider.manager
         factory_method: getManagerByEntityNamespace
         abstract: true
 
@@ -14,6 +14,6 @@ services:
     #
     elcodi.abstract_repository:
         class: Doctrine\Common\Persistence\ObjectRepository
-        factory_service: elcodi.repository_provider
+        factory_service: elcodi.provider.repository
         factory_method: getRepositoryByEntityNamespace
         abstract: true

--- a/src/Elcodi/Bundle/CoreBundle/Tests/Functional/Services/ManagerProviderTest.php
+++ b/src/Elcodi/Bundle/CoreBundle/Tests/Functional/Services/ManagerProviderTest.php
@@ -31,6 +31,6 @@ class ManagerProviderTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.manager_provider'];
+        return ['elcodi.provider.manager'];
     }
 }

--- a/src/Elcodi/Bundle/CoreBundle/Tests/Functional/Services/RepositoryProviderTest.php
+++ b/src/Elcodi/Bundle/CoreBundle/Tests/Functional/Services/RepositoryProviderTest.php
@@ -31,6 +31,6 @@ class RepositoryProviderTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.repository_provider'];
+        return ['elcodi.provider.repository'];
     }
 }

--- a/src/Elcodi/Bundle/CouponBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CouponBundle/CompilerPass/MappingCompilerPass.php
@@ -37,10 +37,10 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
         $this
             ->addEntityMapping(
                 $container,
-                'elcodi.core.coupon.entity.coupon.manager',
-                'elcodi.core.coupon.entity.coupon.class',
-                'elcodi.core.coupon.entity.coupon.mapping_file',
-                'elcodi.core.coupon.entity.coupon.enabled'
+                'elcodi.entity.coupon.manager',
+                'elcodi.entity.coupon.class',
+                'elcodi.entity.coupon.mapping_file',
+                'elcodi.entity.coupon.enabled'
             );
     }
 }

--- a/src/Elcodi/Bundle/CouponBundle/DependencyInjection/ElcodiCouponExtension.php
+++ b/src/Elcodi/Bundle/CouponBundle/DependencyInjection/ElcodiCouponExtension.php
@@ -77,10 +77,10 @@ class ElcodiCouponExtension extends AbstractExtension implements EntitiesOverrid
     protected function getParametrizationValues(array $config)
     {
         return [
-            "elcodi.core.coupon.entity.coupon.class" => $config['mapping']['coupon']['class'],
-            "elcodi.core.coupon.entity.coupon.mapping_file" => $config['mapping']['coupon']['mapping_file'],
-            "elcodi.core.coupon.entity.coupon.manager" => $config['mapping']['coupon']['manager'],
-            "elcodi.core.coupon.entity.coupon.enabled" => $config['mapping']['coupon']['enabled'],
+            "elcodi.entity.coupon.class" => $config['mapping']['coupon']['class'],
+            "elcodi.entity.coupon.mapping_file" => $config['mapping']['coupon']['mapping_file'],
+            "elcodi.entity.coupon.manager" => $config['mapping']['coupon']['manager'],
+            "elcodi.entity.coupon.enabled" => $config['mapping']['coupon']['enabled'],
         ];
     }
 
@@ -115,7 +115,7 @@ class ElcodiCouponExtension extends AbstractExtension implements EntitiesOverrid
     public function getEntitiesOverrides()
     {
         return [
-            'Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface' => 'elcodi.core.coupon.entity.coupon.class',
+            'Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface' => 'elcodi.entity.coupon.class',
         ];
     }
 

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/classes.yml
@@ -3,7 +3,7 @@ parameters:
     #
     # Services
     #
-    elcodi.coupon_manager.class: Elcodi\Component\Coupon\Services\CouponManager
+    elcodi.manager.coupon.class: Elcodi\Component\Coupon\Services\CouponManager
 
     #
     # Factories

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
@@ -84,6 +84,7 @@ Elcodi\Component\Coupon\Entity\Coupon:
                  nullable: true
         rule:
             targetEntity: Elcodi\Component\Rule\Entity\Interfaces\RuleInterface
+            fetch: EAGER
             joinColumn:
                 name: rule
                 referencedColumnName: id

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
@@ -39,7 +39,7 @@ Elcodi\Component\Coupon\Entity\Coupon:
             nullable: false
         used:
             column: used
-            type: boolean
+            type: integer
             nullable: false
         priority:
             column: priority

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/factories.yml
@@ -11,4 +11,4 @@ services:
         class: %elcodi.factory.coupon.class%
         parent: elcodi.core.currency.factory.abstract.purchasable
         calls:
-            - [setEntityNamespace, ["%elcodi.core.coupon.entity.coupon.class%"]]
+            - [setEntityNamespace, ["%elcodi.entity.coupon.class%"]]

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/objectManagers.yml
@@ -5,4 +5,4 @@ services:
     #
     elcodi.object_manager.coupon:
         parent: elcodi.abstract_manager
-        arguments: [ %elcodi.core.coupon.entity.coupon.class% ]
+        arguments: [ %elcodi.entity.coupon.class% ]

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/repositories.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/repositories.yml
@@ -9,4 +9,4 @@ services:
     #
     elcodi.repository.coupon:
         parent: elcodi.abstract_repository
-        arguments: [ %elcodi.core.coupon.entity.coupon.class% ]
+        arguments: [ %elcodi.entity.coupon.class% ]

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/services.yml
@@ -3,8 +3,8 @@ services:
     #
     # Services
     #
-    elcodi.coupon_manager:
-        class: %elcodi.coupon_manager.class%
+    elcodi.manager.coupon:
+        class: %elcodi.manager.coupon.class%
         arguments:
             coupon_factory: @elcodi.factory.coupon
             coupon_code_generator: @elcodi.generator.random_string

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
@@ -63,7 +63,7 @@ class CouponFactoryTest extends WebTestCase
     public function testCreateCouponFactory()
     {
         $this->assertInstanceOf(
-            $this->getParameter('elcodi.core.coupon.entity.coupon.class'),
+            $this->getParameter('elcodi.entity.coupon.class'),
             $this->get('elcodi.factory.coupon')->create()
         );
     }

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Services/CouponManagerTest.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Services/CouponManagerTest.php
@@ -41,6 +41,6 @@ class CouponManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.coupon_manager'];
+        return ['elcodi.manager.coupon'];
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
@@ -71,7 +71,7 @@ class Configuration extends AbstractConfiguration
                             ->defaultValue('USD')
                         ->end()
                         ->scalarNode('client')
-                            ->defaultValue('elcodi.currency_exchange_rates_provider_adapter.dummy')
+                            ->defaultValue('elcodi.adapter.currency_exchange_rate.dummy')
                         ->end()
                     ->end()
                     ->append($this->addOpenExchangeRatesParametersNode())

--- a/src/Elcodi/Bundle/CurrencyBundle/DependencyInjection/ElcodiCurrencyExtension.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/DependencyInjection/ElcodiCurrencyExtension.php
@@ -156,7 +156,7 @@ class ElcodiCurrencyExtension extends AbstractExtension implements EntitiesOverr
         parent::postLoad($config, $container);
 
         $ratesProviderId = $config['rates_provider']['client'];
-        $container->setAlias('elcodi.rates_provider_adapter', $ratesProviderId);
+        $container->setAlias('elcodi.adapter.currency_exchange_rate', $ratesProviderId);
     }
 
     /**

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/classes.yml
@@ -3,45 +3,45 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.currency.factory.abstract.abstract.class: Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory
-    elcodi.core.currency.factory.currency.class: Elcodi\Component\Currency\Factory\CurrencyFactory
-    elcodi.core.currency.factory.currency_exchange_rate.class: Elcodi\Component\Currency\Factory\CurrencyExchangeRateFactory
+    elcodi.abstract_factory.purchasable.class: Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory
+    elcodi.factory.currency.class: Elcodi\Component\Currency\Factory\CurrencyFactory
+    elcodi.factory.currency_exchange_rate.class: Elcodi\Component\Currency\Factory\CurrencyExchangeRateFactory
 
     #
     # Services
     #
-    elcodi.core.currency.service.currency_manager.class: Elcodi\Component\Currency\Services\CurrencyManager
-    elcodi.core.currency.service.currency_converter.class: Elcodi\Component\Currency\Services\CurrencyConverter
-    elcodi.core.currency.service.currency_session_manager.class: Elcodi\Component\Currency\Services\CurrencySessionManager
-    elcodi.core.currency.populator.currency_rates_populator.class: Elcodi\Component\Currency\Populator\CurrencyExchangeRatesPopulator
+    elcodi.manager.currency.class: Elcodi\Component\Currency\Services\CurrencyManager
+    elcodi.converter.currency.class: Elcodi\Component\Currency\Services\CurrencyConverter
+    elcodi.session_manager.currency.class: Elcodi\Component\Currency\Services\CurrencySessionManager
+    elcodi.populator.currency_exchange_rate.class: Elcodi\Component\Currency\Populator\CurrencyExchangeRatesPopulator
 
     #
     # Providers
     #
-    elcodi.core.currency.service.currency_exchange_rates_provider.class: Elcodi\Component\Currency\Services\CurrencyExchangeRatesProvider
+    elcodi.provider.currency_exchange_rate.class: Elcodi\Component\Currency\Services\CurrencyExchangeRatesProvider
 
     #
     # Twig extensions
     #
-    elcodi.core.currency.twig_extension.print_money.class: Elcodi\Component\Currency\Twig\PrintMoneyExtension
+    elcodi.twig_extension.print_money.class: Elcodi\Component\Currency\Twig\PrintMoneyExtension
 
     #
     # Wrappers
     #
-    elcodi.core.currency.wrapper.currency.class: Elcodi\Component\Currency\Wrapper\CurrencyWrapper
+    elcodi.wrapper.currency.class: Elcodi\Component\Currency\Wrapper\CurrencyWrapper
 
     #
     # Commands
     #
-    elcodi.core.currency.command.currency_exchange_rates_populate.class: Elcodi\Component\Currency\Command\CurrencyExchangeRatesPopulateCommand
+    elcodi.command.populate_currency_rates.class: Elcodi\Component\Currency\Command\CurrencyExchangeRatesPopulateCommand
 
     #
     # ExchangeRates Adapter
     #
-    elcodi.currency_exchange_rates_provider_adapter.open_exchange_rates.class: Elcodi\Component\Currency\Adapter\CurrencyExchangeRatesProvider\OpenExchangeRatesProviderAdapter
-    elcodi.currency_exchange_rates_provider_adapter.dummy.class: Elcodi\Component\Currency\Adapter\CurrencyExchangeRatesProvider\DummyProviderAdapter
+    elcodi.adapter.currency_exchange_rate.open_exchange.class: Elcodi\Component\Currency\Adapter\CurrencyExchangeRatesProvider\OpenExchangeRatesProviderAdapter
+    elcodi.adapter.currency_exchange_rate.dummy.class: Elcodi\Component\Currency\Adapter\CurrencyExchangeRatesProvider\DummyProviderAdapter
 
     #
     # ExpressionLanguage providers
     #
-    elcodi.core.currency.expression_language.money_provider.class: Elcodi\Component\Currency\ExpressionLanguage\MoneyProvider
+    elcodi.expression_language.money_provider.class: Elcodi\Component\Currency\ExpressionLanguage\MoneyProvider

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
@@ -3,9 +3,9 @@ services:
     #
     # Commands
     #
-    elcodi.core.currency.command.currency_exchange_rates_populate:
-        class: %elcodi.core.currency.command.currency_exchange_rates_populate.class%
+    elcodi.command.populate_currency_rates:
+        class: %elcodi.command.populate_currency_rates.class%
         arguments:
-            currency_rates_populator: @elcodi.currency_rates_populator
+            currency_rates_populator: @elcodi.populator.currency_exchange_rate
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/currencyExchangeRatesProviderAdapters.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/currencyExchangeRatesProviderAdapters.yml
@@ -6,13 +6,13 @@ services:
     elcodi.core.currency.guzzle_client:
         class: GuzzleHttp\Client
 
-    elcodi.currency_exchange_rates_provider_adapter.open_exchange_rates:
-        class: %elcodi.currency_exchange_rates_provider_adapter.open_exchange_rates.class%
+    elcodi.adapter.currency_exchange_rate.open_exchange:
+        class: %elcodi.adapter.currency_exchange_rate.open_exchange.class%
         arguments:
             guzzle_client: @elcodi.core.currency.guzzle_client
             api_id: %elcodi.core.currency.rates_provider_api_id%
             end_point: %elcodi.core.currency.rates_provider_endpoint%
             base_currency: %elcodi.core.currency.rates_provider_currency_base%
 
-    elcodi.currency_exchange_rates_provider_adapter.dummy:
-        class: %elcodi.currency_exchange_rates_provider_adapter.dummy.class%
+    elcodi.adapter.currency_exchange_rate.dummy:
+        class: %elcodi.adapter.currency_exchange_rate.dummy.class%

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/expressionLanguage.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/expressionLanguage.yml
@@ -3,10 +3,10 @@ services:
     #
     # Specific provider for Currency Wrapper
     #
-    elcodi.core.currency.expression_language.money_provider:
-        class: %elcodi.core.currency.expression_language.money_provider.class%
+    elcodi.expression_language.money_provider:
+        class: %elcodi.expression_language.money_provider.class%
         arguments:
-            - @elcodi.currency_wrapper
+            - @elcodi.wrapper.currency
             - @elcodi.repository.currency
         tags:
             - { name: elcodi.rule_configuration }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
@@ -8,29 +8,23 @@ services:
     # Abstract purchasable factory
     #
     elcodi.core.currency.factory.abstract.purchasable:
-        class: %elcodi.core.currency.factory.abstract.abstract.class%
+        class: %elcodi.abstract_factory.purchasable.class%
         abstract: true
         arguments:
-            currency_wrapper: @elcodi.currency_wrapper
+            currency_wrapper: @elcodi.wrapper.currency
 
     #
     # Factory for Currency entities
     #
-    elcodi.core.currency.factory.currency:
-        class: %elcodi.core.currency.factory.currency.class%
+    elcodi.factory.currency:
+        class: %elcodi.factory.currency.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.currency.entity.currency.class%"]]
-
-    elcodi.factory.currency:
-        alias: elcodi.core.currency.factory.currency
 
     #
     # Factory for CurrencyExchangeRate entitites
     #
-    elcodi.core.currency.factory.currency_exchange_rate:
-        class: %elcodi.core.currency.factory.currency_exchange_rate.class%
+    elcodi.factory.currency_exchange_rate:
+        class: %elcodi.factory.currency_exchange_rate.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.currency.entity.currency_exchange_rate.class%"]]
-
-    elcodi.factory.currency_exchange_rate:
-        alias: elcodi.core.currency.factory.currency_exchange_rate

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
@@ -3,68 +3,50 @@ services:
     #
     # Services
     #
-    elcodi.core.currency.service.currency_manager:
-        class: %elcodi.core.currency.service.currency_manager.class%
+    elcodi.manager.currency:
+        class: %elcodi.manager.currency.class%
         arguments:
             currency_repository: @elcodi.repository.currency
             exchange_rates_repository: @elcodi.repository.currency_exchange_rate
             currency_base: %elcodi.core.currency.rates_provider_currency_base%
 
-    elcodi.currency_manager:
-        alias: elcodi.core.currency.service.currency_manager
-
-    elcodi.core.currency.service.currency_session_manager:
-        class: %elcodi.core.currency.service.currency_session_manager.class%
+    elcodi.session_manager.currency:
+        class: %elcodi.session_manager.currency.class%
         arguments:
             session: @session
             session_field_name: %elcodi.core.currency.session_field_name%
 
-    elcodi.currency_session_manager:
-        alias: elcodi.core.currency.service.currency_session_manager
-
-    elcodi.core.currency.service.currency_converter:
-        class: %elcodi.core.currency.service.currency_converter.class%
+    elcodi.converter.currency:
+        class: %elcodi.converter.currency.class%
         arguments:
-            currency_manager: @elcodi.currency_manager
+            currency_manager: @elcodi.manager.currency
             currency_base: %elcodi.core.currency.rates_provider_currency_base%
 
-    elcodi.currency_converter:
-        alias: elcodi.core.currency.service.currency_converter
-
-    elcodi.core.currency.populator.currency_rates_populator:
-        class: %elcodi.core.currency.populator.currency_rates_populator.class%
+    elcodi.populator.currency_exchange_rate:
+        class: %elcodi.populator.currency_exchange_rate.class%
         lazy: true
         arguments:
-            currency_exchange_rate_object_manager: @elcodi.object_manager.currency_exchange_rate
-            currency_repository: @elcodi.repository.currency
-            currency_exchange_rate_repository: @elcodi.repository.currency_exchange_rate
-            currency_exchange_rate_factory: @elcodi.factory.currency_exchange_rate
-            exchange_rates_provider: @elcodi.currency_exchange_rates_provider
-            default_currency: %elcodi.core.currency.default_currency%
-
-    elcodi.currency_rates_populator:
-        alias: elcodi.core.currency.populator.currency_rates_populator
+            - @elcodi.object_manager.currency_exchange_rate
+            - @elcodi.repository.currency
+            - @elcodi.repository.currency_exchange_rate
+            - @elcodi.factory.currency_exchange_rate
+            - @elcodi.provider.currency_exchange_rate
+            - %elcodi.core.currency.default_currency%
 
     #
     # Providers
     #
-    elcodi.core.currency.service.currency_exchange_rates_provider:
-        class: %elcodi.core.currency.service.currency_exchange_rates_provider.class%
+    elcodi.provider.currency_exchange_rate:
+        class: %elcodi.provider.currency_exchange_rate.class%
         arguments:
-            currency_exchange_rates_provider_adapter: @elcodi.rates_provider_adapter
-
-    elcodi.currency_exchange_rates_provider:
-        alias: elcodi.core.currency.service.currency_exchange_rates_provider
+            - @elcodi.adapter.currency_exchange_rate
 
     #
     # Wrappers
     #
-    elcodi.core.currency.wrapper.currency:
-        class: %elcodi.core.currency.wrapper.currency.class%
+    elcodi.wrapper.currency:
+        class: %elcodi.wrapper.currency.class%
         arguments:
-            currency_session_manager: @elcodi.currency_session_manager
-            currency_repository: @elcodi.repository.currency
-            default_currency: %elcodi.core.currency.default_currency%
-
-    elcodi.currency_wrapper:
-        alias: elcodi.core.currency.wrapper.currency
+            - @elcodi.session_manager.currency
+            - @elcodi.repository.currency
+            - %elcodi.core.currency.default_currency%

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/twig.yml
@@ -3,11 +3,11 @@ services:
     #
     # Twig extensions
     #
-    elcodi.core.currency.twig_extension.print_money:
-        class: %elcodi.core.currency.twig_extension.print_money.class%
+    elcodi.twig_extension.print_money:
+        class: %elcodi.twig_extension.print_money.class%
         arguments:
-            currency_manager: @elcodi.currency_converter
-            currency_wrapper: @elcodi.currency_wrapper
-            locale: @elcodi.locale_iso
+            - @elcodi.converter.currency
+            - @elcodi.wrapper.currency
+            - @elcodi.locale_iso
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Command/CurrencyExchangeRatesPopulateCommandTest.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Command/CurrencyExchangeRatesPopulateCommandTest.php
@@ -32,7 +32,7 @@ class CurrencyExchangeRatesPopulateCommandTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.currency.command.currency_exchange_rates_populate',
+            'elcodi.command.populate_currency_rates',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Factory/CurrencyExchangeRateFactoryTest.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Factory/CurrencyExchangeRateFactoryTest.php
@@ -42,7 +42,6 @@ class CurrencyExchangeRateFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.currency.factory.currency_exchange_rate',
             'elcodi.factory.currency_exchange_rate',
         ];
     }

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Factory/CurrencyFactoryTest.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Factory/CurrencyFactoryTest.php
@@ -42,7 +42,6 @@ class CurrencyFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.currency.factory.currency',
             'elcodi.factory.currency',
         ];
     }

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencyConverterTest.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencyConverterTest.php
@@ -42,8 +42,7 @@ class CurrencyConverterTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.currency.service.currency_converter',
-            'elcodi.currency_converter',
+            'elcodi.converter.currency',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencyExchangeRatesProviderTest.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencyExchangeRatesProviderTest.php
@@ -42,8 +42,7 @@ class CurrencyExchangeRatesProviderTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.currency.service.currency_exchange_rates_provider',
-            'elcodi.currency_exchange_rates_provider',
+            'elcodi.provider.currency_exchange_rate',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencyManagerTest.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencyManagerTest.php
@@ -42,8 +42,7 @@ class CurrencyManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.currency.service.currency_manager',
-            'elcodi.currency_manager',
+            'elcodi.manager.currency',
         ];
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencySessionManagerTest.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/Services/CurrencySessionManagerTest.php
@@ -42,8 +42,7 @@ class CurrencySessionManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.currency.service.currency_session_manager',
-            'elcodi.currency_session_manager',
+            'elcodi.session_manager.currency',
         ];
     }
 }

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/classes.yml
@@ -4,20 +4,20 @@ parameters:
     # Factories
     #
     elcodi.core.entity_translator.factory.entity_translator.class: Elcodi\Component\EntityTranslator\Factory\EntityTranslatorFactory
-    elcodi.core.entity_translator.factory.entity_translation.class: Elcodi\Component\EntityTranslator\Factory\EntityTranslationFactory
+    elcodi.factory.entity_translation.class: Elcodi\Component\EntityTranslator\Factory\EntityTranslationFactory
 
     #
     # Repositories
     #
-    elcodi.core.entity_translator.repository.entity_translation.class: Elcodi\Component\EntityTranslator\Repository\EntityTranslationRepository
+    elcodi.repository.entity_translation.class: Elcodi\Component\EntityTranslator\Repository\EntityTranslationRepository
 
     #
     # Services
     #
     elcodi.core.entity_translator.services.cached_entity_translation_provider.class: Elcodi\Component\EntityTranslator\Services\CachedEntityTranslationProvider
     elcodi.core.entity_translator.services.entity_translation_provider.class: Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider
-    elcodi.core.entity_translator.services.entity_translator_builder.class: Elcodi\Component\EntityTranslator\Services\EntityTranslatorBuilder
-    elcodi.core.entity_translator.services.entity_translator.class: Elcodi\Component\EntityTranslator\Services\EntityTranslator
+    elcodi.entity_translator_builder.class: Elcodi\Component\EntityTranslator\Services\EntityTranslatorBuilder
+    elcodi.entity_translator.class: Elcodi\Component\EntityTranslator\Services\EntityTranslator
     elcodi.entity_translator_changes.class: Elcodi\Component\EntityTranslator\Services\EntityTranslationChangesBag
 
     #

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/factories.yml
@@ -7,13 +7,10 @@ services:
     #
     # Factory for entity tax
     #
-    elcodi.core.entity_translator.factory.entity_translation:
-        class: %elcodi.core.entity_translator.factory.entity_translation.class%
+    elcodi.factory.entity_translation:
+        class: %elcodi.factory.entity_translation.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.entity_translator.entity.entity_translation.class%"]]
-
-    elcodi.factory.entity_translation:
-        alias: elcodi.core.entity_translator.factory.entity_translation
 
     #
     # Factory for Translator service
@@ -21,4 +18,4 @@ services:
     elcodi.core.entity_translator.factory.entity_translator:
         class: %elcodi.core.entity_translator.factory.entity_translator.class%
         calls:
-            - [setEntityNamespace, ["%elcodi.core.entity_translator.services.entity_translator.class%"]]
+            - [setEntityNamespace, ["%elcodi.entity_translator.class%"]]

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/repositories.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/repositories.yml
@@ -7,10 +7,7 @@ services:
     #
     # Repository for entity translation
     #
-    elcodi.core.entity_translator.repository.entity_translation:
-        parent: elcodi.abstract_repository
-        class: %elcodi.core.entity_translator.repository.entity_translation.class%
-        arguments: [ %elcodi.core.entity_translator.entity.entity_translation.class% ]
-
     elcodi.repository.entity_translation:
-        alias: elcodi.core.entity_translator.repository.entity_translation
+        parent: elcodi.abstract_repository
+        class: %elcodi.repository.entity_translation.class%
+        arguments: [ %elcodi.core.entity_translator.entity.entity_translation.class% ]

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/services.yml
@@ -25,17 +25,14 @@ services:
     elcodi.entity_translation_provider:
         alias: elcodi.core.entity_translator.services.cached_entity_translation_provider
 
-    elcodi.core.entity_translator.services.entity_translator_builder:
-        class: %elcodi.core.entity_translator.services.entity_translator_builder.class%
+    elcodi.entity_translator_builder:
+        class: %elcodi.entity_translator_builder.class%
         arguments:
             translation_provider: @elcodi.entity_translation_provider
             translator_factory: @elcodi.core.entity_translator.factory.entity_translator
             configuration: %elcodi.core.entity_translator.configuration%
 
-    elcodi.core.entity_translator.services.entity_translator:
-        class: %elcodi.core.entity_translator.services.entity_translator.class%
-        factory_service: elcodi.core.entity_translator.services.entity_translator_builder
-        factory_method: compile
-
     elcodi.entity_translator:
-        alias: elcodi.core.entity_translator.services.entity_translator
+        class: %elcodi.entity_translator.class%
+        factory_service: elcodi.entity_translator_builder
+        factory_method: compile

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/classes.yml
@@ -8,16 +8,16 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.language.factory.language.class: Elcodi\Component\Language\Factory\LanguageFactory
+    elcodi.factory.language.class: Elcodi\Component\Language\Factory\LanguageFactory
 
     #
     # Services
     #
-    elcodi.core.language.service.language_manager.class: Elcodi\Component\Language\Services\LanguageManager
-    elcodi.core.language.service.locale_manager.class: Elcodi\Component\Language\Services\LocaleManager
-    elcodi.core.language.service.locale_provider.class: Elcodi\Component\Language\Services\LocaleProvider
+    elcodi.manager.language.class: Elcodi\Component\Language\Services\LanguageManager
+    elcodi.manager.locale.class: Elcodi\Component\Language\Services\LocaleManager
+    elcodi.provider.locale.class: Elcodi\Component\Language\Services\LocaleProvider
 
     #
     # Twig extensions
     #
-    elcodi.core.language.twig_extension.language_extension.class: Elcodi\Component\Language\Twig\LanguageExtension
+    elcodi.twig_extension.language.class: Elcodi\Component\Language\Twig\LanguageExtension

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/factories.yml
@@ -7,10 +7,7 @@ services:
     #
     # Factory for entity language
     #
-    elcodi.core.language.factory.language:
-        class: %elcodi.core.language.factory.language.class%
+    elcodi.factory.language:
+        class: %elcodi.factory.language.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.language.entity.language.class%"]]
-
-    elcodi.factory.language:
-        alias: elcodi.core.language.factory.language

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/services.yml
@@ -3,54 +3,44 @@ services:
     #
     # Providers
     #
-    elcodi.core.language.service.locale_provider:
-        class: %elcodi.core.language.service.locale_provider.class%
+    elcodi.provider.locale:
+        class: %elcodi.provider.locale.class%
         arguments:
             request_stack: @request_stack
             default_locale: %locale%
 
-    elcodi.locale_provider:
-        alias: elcodi.core.language.service.locale_provider
-
-    elcodi.locale_provider.locale:
+    elcodi.provider.locale.locale:
         class: %elcodi.core.language.entity.locale.class%
-        factory_service: elcodi.locale_provider
+        factory_service: elcodi.provider.locale
         factory_method: getLocale
         public: false
 
     #
     # Services
     #
-    elcodi.core.language.service.language_manager:
-        class: %elcodi.core.language.service.language_manager.class%
+    elcodi.manager.language:
+        class: %elcodi.manager.language.class%
         arguments:
             language_repository: @elcodi.repository.language
 
-    elcodi.language_manager:
-        alias: elcodi.core.language.service.language_manager
-
-
-    elcodi.core.language.service.locale_manager:
-        class: %elcodi.core.language.service.locale_manager.class%
+    elcodi.manager.locale:
+        class: %elcodi.manager.locale.class%
         arguments:
-            locale: @elcodi.locale_provider.locale
+            locale: @elcodi.provider.locale.locale
         calls:
             - [initialize, []]
-
-    elcodi.locale_manager:
-        alias: elcodi.core.language.service.locale_manager
 
     #
     # Environment values
     #
     elcodi.languages:
         class: Doctrine\Common\Collections\Collection
-        factory_service: elcodi.language_manager
+        factory_service: elcodi.manager.language
         factory_method: getLanguages
 
     elcodi.languages_iso:
         class: Doctrine\Common\Collections\Collection
-        factory_service: elcodi.language_manager
+        factory_service: elcodi.manager.language
         factory_method: getLanguagesIso
 
     elcodi.languages_iso_array:
@@ -60,10 +50,10 @@ services:
 
     elcodi.locale:
         class: %elcodi.core.language.entity.locale.class%
-        factory_service: elcodi.locale_manager
+        factory_service: elcodi.manager.locale
         factory_method: getLocale
 
     elcodi.locale_iso:
         class: stdClass
-        factory_service: elcodi.locale_manager
+        factory_service: elcodi.manager.locale
         factory_method: getLocaleIso

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
@@ -3,10 +3,10 @@ services:
     #
     # Twig extensions
     #
-    elcodi.core.language.twig_extension.language_extension:
-        class: %elcodi.core.language.twig_extension.language_extension.class%
+    elcodi.twig_extension.language:
+        class: %elcodi.twig_extension.language.class%
         arguments:
-            language_manager: @elcodi.language_manager
+            language_manager: @elcodi.manager.language
             master_language: @elcodi.locale_iso
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Factory/LanguageFactoryTest.php
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Factory/LanguageFactoryTest.php
@@ -42,7 +42,6 @@ class LanguageFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.language.factory.language',
             'elcodi.factory.language',
         ];
     }

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Services/LanguageManagerTest.php
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Services/LanguageManagerTest.php
@@ -32,8 +32,7 @@ class LanguageManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.language.service.language_manager',
-            'elcodi.language_manager',
+            'elcodi.manager.language',
         ];
     }
 }

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Twig/LanguageExtensionTest.php
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Twig/LanguageExtensionTest.php
@@ -32,7 +32,7 @@ class LanguageExtensionTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.language.twig_extension.language_extension',
+            'elcodi.twig_extension.language',
         ];
     }
 
@@ -56,7 +56,7 @@ class LanguageExtensionTest extends WebTestCase
         $this->assertCount(
             5,
             $this
-                ->get('elcodi.core.language.twig_extension.language_extension')
+                ->get('elcodi.twig_extension.language')
                 ->getLanguages()
         );
     }

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/classes.yml
@@ -3,36 +3,36 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.media.factory.image.class: Elcodi\Component\Media\Factory\ImageFactory
+    elcodi.factory.image.class: Elcodi\Component\Media\Factory\ImageFactory
 
     #
     # Services
     #
     elcodi.core.media.resize.imagemagick.class: Elcodi\Component\Media\Adapter\Resizer\ImageMagickResizeAdapter
-    elcodi.core.media.service.image_manager.class: Elcodi\Component\Media\Services\ImageManager
-    elcodi.core.media.service.file_manager.class: Elcodi\Component\Media\Services\FileManager
-    elcodi.core.media.service.image_uploader.class: Elcodi\Component\Media\Services\ImageUploader
+    elcodi.manager.media_image.class: Elcodi\Component\Media\Services\ImageManager
+    elcodi.manager.media_file.class: Elcodi\Component\Media\Services\FileManager
+    elcodi.image_uploader.class: Elcodi\Component\Media\Services\ImageUploader
 
     #
     # Controllers
     #
-    elcodi.core.media.controller.image_resize.class: Elcodi\Component\Media\Controller\ImageResizeController
-    elcodi.core.media.controller.image_upload.class: Elcodi\Component\Media\Controller\ImageUploadController
+    elcodi.controller.media_image_resize.class: Elcodi\Component\Media\Controller\ImageResizeController
+    elcodi.controller.media_image_upload.class: Elcodi\Component\Media\Controller\ImageUploadController
 
     #
     # Routes
     #
-    elcodi.core.media.routes.image_resize.loader.class: Elcodi\Component\Media\Router\ImageResizeRouterLoader
-    elcodi.core.media.routes.image_view.loader.class: Elcodi\Component\Media\Router\ImageViewRouterLoader
-    elcodi.core.media.routes.image_upload.loader.class: Elcodi\Component\Media\Router\ImageUploadRouterLoader
+    elcodi.router.media_image_resize.class: Elcodi\Component\Media\Router\ImageResizeRouterLoader
+    elcodi.router.media_image_view.class: Elcodi\Component\Media\Router\ImageViewRouterLoader
+    elcodi.router.media_image_upload.class: Elcodi\Component\Media\Router\ImageUploadRouterLoader
 
     #
     # Twig extensions
     #
-    elcodi.core.media.twig_extension.image_extension.class: Elcodi\Component\Media\Twig\ImageExtension
+    elcodi.twig_extension.media_image.class: Elcodi\Component\Media\Twig\ImageExtension
 
     #
     # Transformers
     #
-    elcodi.core.media.transformer.image_etag_transformer.class: Elcodi\Component\Media\Transformer\ImageEtagTransformer
-    elcodi.core.media.transformer.file_identifier_transformer.class: Elcodi\Component\Media\Transformer\FileIdentifierTransformer
+    elcodi.transformer.media_image_etag.class: Elcodi\Component\Media\Transformer\ImageEtagTransformer
+    elcodi.transformer.media_file_identifier.class: Elcodi\Component\Media\Transformer\FileIdentifierTransformer

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/controllers.yml
@@ -3,18 +3,18 @@ services:
     #
     # Controllers
     #
-    elcodi.core.media.controller.image_resize:
-        class: %elcodi.core.media.controller.image_resize.class%
+    elcodi.controller.media_image_resize:
+        class: %elcodi.controller.media_image_resize.class%
         arguments:
             request_stack: @request_stack
             image_repository: @elcodi.repository.image
-            image_manager: @elcodi.core.media.service.image_manager
-            image_etag_transformer: @elcodi.image_etag_transformer
+            image_manager: @elcodi.manager.media_image
+            image_etag_transformer: @elcodi.transformer.media_image_etag
             image_view_max_age: %elcodi.core.media.image_view_max_age%
             image_view_shared_max_age: %elcodi.core.media.image_view_shared_max_age%
 
-    elcodi.core.media.controller.image_upload:
-        class: %elcodi.core.media.controller.image_upload.class%
+    elcodi.controller.media_image_upload:
+        class: %elcodi.controller.media_image_upload.class%
         arguments:
             request_stack: @request_stack
             image_uploader: @elcodi.image_uploader

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/factories.yml
@@ -7,10 +7,7 @@ services:
     #
     # Factory for entity image
     #
-    elcodi.core.media.factory.image:
-        class: %elcodi.core.media.factory.image.class%
+    elcodi.factory.image:
+        class: %elcodi.factory.image.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.media.entity.image.class%"]]
-
-    elcodi.factory.image:
-        alias: elcodi.core.media.factory.image

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/services.yml
@@ -3,34 +3,25 @@ services:
     #
     # Service
     #
-    elcodi.core.media.service.image_manager:
-        class: %elcodi.core.media.service.image_manager.class%
+    elcodi.manager.media_image:
+        class: %elcodi.manager.media_image.class%
         arguments:
-            image_factory: @elcodi.core.media.factory.image
-            file_manager: @elcodi.core.media.service.file_manager
+            image_factory: @elcodi.factory.image
+            file_manager: @elcodi.manager.media_file
             resize_adapter: @elcodi.core.media.resize.default
 
-    elcodi.image_manager:
-        alias: elcodi.core.media.service.image_manager
-
-    elcodi.core.media.service.file_manager:
-        class: %elcodi.core.media.service.file_manager.class%
+    elcodi.manager.media_file:
+        class: %elcodi.manager.media_file.class%
         arguments:
             filesystem: @elcodi.core.media.filesystem.default
-            file_transformer: @elcodi.core.media.transformer.file_identifier_transformer
-
-    elcodi.file_manager:
-        alias: elcodi.core.media.service.file_manager
-
-    elcodi.core.media.service.image_uploader:
-        class: %elcodi.core.media.service.image_uploader.class%
-        arguments:
-            image_object_manager: @elcodi.object_manager.image
-            file_manager: @elcodi.core.media.service.file_manager
-            image_manager: @elcodi.core.media.service.image_manager
+            file_transformer: @elcodi.transformer.media_file_identifier
 
     elcodi.image_uploader:
-        alias: elcodi.core.media.service.image_uploader
+        class: %elcodi.image_uploader.class%
+        arguments:
+            image_object_manager: @elcodi.object_manager.image
+            file_manager: @elcodi.manager.media_file
+            image_manager: @elcodi.manager.media_image
 
     #
     # Resize
@@ -44,24 +35,24 @@ services:
     #
     # Routes
     #
-    elcodi.core.media.routes.image_resize.loader:
-        class: %elcodi.core.media.routes.image_resize.loader.class%
+    elcodi.router.media_image_resize:
+        class: %elcodi.router.media_image_resize.class%
         arguments:
             image_resize_controller_route_name: %elcodi.core.media.image_resize_controller_route_name%
             image_resize_controller_route: %elcodi.core.media.image_resize_controller_route%
         tags:
             - { name: routing.loader }
 
-    elcodi.core.media.routes.image_view.loader:
-        class: %elcodi.core.media.routes.image_view.loader.class%
+    elcodi.router.media_image_view:
+        class: %elcodi.router.media_image_view.class%
         arguments:
             image_view_controller_route_name: %elcodi.core.media.image_view_controller_route_name%
             image_view_controller_route: %elcodi.core.media.image_view_controller_route%
         tags:
             - { name: routing.loader }
 
-    elcodi.core.media.routes.image_upload.loader:
-        class: %elcodi.core.media.routes.image_upload.loader.class%
+    elcodi.router.media_image_upload:
+        class: %elcodi.router.media_image_upload.class%
         arguments:
             image_upload_controller_route_name: %elcodi.core.media.image_upload_controller_route_name%
             image_upload_controller_route: %elcodi.core.media.image_upload_controller_route%

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/transformers.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/transformers.yml
@@ -3,14 +3,8 @@ services:
     #
     # Transformers
     #
-    elcodi.core.media.transformer.image_etag_transformer:
-        class: %elcodi.core.media.transformer.image_etag_transformer.class%
+    elcodi.transformer.media_image_etag:
+        class: %elcodi.transformer.media_image_etag.class%
 
-    elcodi.image_etag_transformer:
-        alias: elcodi.core.media.transformer.image_etag_transformer
-
-    elcodi.core.media.transformer.file_identifier_transformer:
-        class: %elcodi.core.media.transformer.file_identifier_transformer.class%
-
-    elcodi.file_identifier_transformer:
-        alias: elcodi.core.media.transformer.file_identifier_transformer
+    elcodi.transformer.media_file_identifier:
+        class: %elcodi.transformer.media_file_identifier.class%

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
@@ -3,8 +3,8 @@ services:
     #
     # Twig extensions
     #
-    elcodi.core.media.twig_extension.image_extension:
-        class: %elcodi.core.media.twig_extension.image_extension.class%
+    elcodi.twig_extension.media_image:
+        class: %elcodi.twig_extension.media_image.class%
         arguments:
             router: @router
             image_resize_controller_route_name: %elcodi.core.media.image_resize_controller_route_name%

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageResizeControllerTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageResizeControllerTest.php
@@ -33,7 +33,7 @@ class ImageResizeControllerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.media.controller.image_resize'];
+        return ['elcodi.controller.media_image_resize'];
     }
 
     /**

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageUploadControllerTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageUploadControllerTest.php
@@ -44,7 +44,7 @@ class ImageUploadControllerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.media.controller.image_upload'];
+        return ['elcodi.controller.media_image_upload'];
     }
 
     /**
@@ -80,7 +80,7 @@ class ImageUploadControllerTest extends WebTestCase
         $image = $this->find('image', 1);
         $this->assertInstanceOf('Elcodi\Component\Media\Entity\Interfaces\ImageInterface', $image);
         $this->assertEmpty($image->getContent());
-        $this->get('elcodi.file_manager')->downloadFile($image);
+        $this->get('elcodi.manager.media_file')->downloadFile($image);
 
         $this->assertNotEmpty($image->getContent());
     }

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Factory/ImageFactoryTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Factory/ImageFactoryTest.php
@@ -42,7 +42,6 @@ class ImageFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.media.factory.image',
             'elcodi.factory.image',
         ];
     }

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Router/ImageResizeRouterLoaderTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Router/ImageResizeRouterLoaderTest.php
@@ -31,6 +31,6 @@ class ImageResizeRouterLoaderTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.media.routes.image_resize.loader'];
+        return ['elcodi.router.media_image_resize'];
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Router/ImageUploadRouterLoaderTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Router/ImageUploadRouterLoaderTest.php
@@ -31,6 +31,6 @@ class ImageUploadRouterLoaderTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.media.routes.image_upload.loader'];
+        return ['elcodi.router.media_image_upload'];
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Router/ImageViewRouterLoaderTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Router/ImageViewRouterLoaderTest.php
@@ -31,6 +31,6 @@ class ImageViewRouterLoaderTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.media.routes.image_view.loader'];
+        return ['elcodi.router.media_image_view'];
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/FileServiceTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/FileServiceTest.php
@@ -32,8 +32,7 @@ class FileServiceTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.media.service.file_manager',
-            'elcodi.file_manager',
+            'elcodi.manager.media_file',
         ];
     }
 
@@ -43,15 +42,15 @@ class FileServiceTest extends WebTestCase
      */
     public function testUploadAndDownloadFile()
     {
-        $image = $this->get('elcodi.core.media.factory.image')->create();
+        $image = $this->get('elcodi.factory.image')->create();
         $image->setId(1);
 
-        $fileTransformer = $this->get('elcodi.core.media.transformer.file_identifier_transformer');
+        $fileTransformer = $this->get('elcodi.transformer.media_file_identifier');
         $imageName = $fileTransformer->transform($image);
         $imageData = file_get_contents(realpath(dirname(__FILE__)).'/images/image-10-10.gif');
 
         $this
-            ->get('elcodi.core.media.service.file_manager')
+            ->get('elcodi.manager.media_file')
             ->uploadFile($image, $imageData, true);
 
         $this->assertTrue($this
@@ -60,7 +59,7 @@ class FileServiceTest extends WebTestCase
         );
 
         $image = $this
-            ->get('elcodi.core.media.service.file_manager')
+            ->get('elcodi.manager.media_file')
             ->downloadFile($image);
 
         $this->assertEquals($imageData, $image->getContent());

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/ImageServiceTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/ImageServiceTest.php
@@ -35,8 +35,7 @@ class ImageServiceTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.media.service.image_manager',
-            'elcodi.image_manager',
+            'elcodi.manager.media_image',
         ];
     }
 
@@ -52,7 +51,7 @@ class ImageServiceTest extends WebTestCase
          * @var ImageInterface $image
          */
         $image = $this
-            ->get('elcodi.core.media.service.image_manager')
+            ->get('elcodi.manager.media_image')
             ->createImage($file);
 
         $this->assertInstanceOf('Elcodi\Component\Media\Entity\Interfaces\ImageInterface', $image);

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Transformer/FileIdentifierTransformerTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Transformer/FileIdentifierTransformerTest.php
@@ -32,8 +32,7 @@ class FileIdentifierTransformerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.media.transformer.file_identifier_transformer',
-            'elcodi.file_identifier_transformer',
+            'elcodi.transformer.media_file_identifier',
         ];
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Transformer/ImageEtagTransformerTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Transformer/ImageEtagTransformerTest.php
@@ -32,8 +32,7 @@ class ImageEtagTransformerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.media.transformer.image_etag_transformer',
-            'elcodi.image_etag_transformer',
+            'elcodi.transformer.media_image_etag',
         ];
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Twig/ImageExtensionTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Twig/ImageExtensionTest.php
@@ -31,6 +31,6 @@ class ImageExtensionTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.media.twig_extension.image_extension'];
+        return ['elcodi.twig_extension.media_image'];
     }
 }

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/classes.yml
@@ -3,15 +3,15 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.menu.factory.menu_node.class: Elcodi\Component\Menu\Factory\NodeFactory
-    elcodi.core.menu.factory.menu.class: Elcodi\Component\Menu\Factory\MenuFactory
+    elcodi.factory.menu_node.class: Elcodi\Component\Menu\Factory\NodeFactory
+    elcodi.factory.menu.class: Elcodi\Component\Menu\Factory\MenuFactory
 
     #
     # Services
     #
-    elcodi.core.menu.service.menu_manager.class: Elcodi\Component\Menu\Services\MenuManager
+    elcodi.manager.menu.class: Elcodi\Component\Menu\Services\MenuManager
 
     #
     # Twig extensions
     #
-    elcodi.core.menu.twig_extension.print_route.class: Elcodi\Component\Menu\Twig\PrintRouteExtension
+    elcodi.twig_extension.menu_print_route.class: Elcodi\Component\Menu\Twig\PrintRouteExtension

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/factories.yml
@@ -7,21 +7,15 @@ services:
     #
     # Factory for entity node
     #
-    elcodi.core.menu.factory.menu_node:
-        class: %elcodi.core.menu.factory.menu_node.class%
+    elcodi.factory.menu_node:
+        class: %elcodi.factory.menu_node.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.menu.entity.menu_node.class%"]]
-
-    elcodi.factory.menu_node:
-        alias: elcodi.core.menu.factory.menu_node
 
     #
     # Factory for entity menu
     #
-    elcodi.core.menu.factory.menu:
-        class: %elcodi.core.menu.factory.menu.class%
+    elcodi.factory.menu:
+        class: %elcodi.factory.menu.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.menu.entity.menu.class%"]]
-
-    elcodi.factory.menu:
-        alias: elcodi.core.menu.factory.menu

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/dummyRouter.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/dummyRouter.yml
@@ -3,15 +3,15 @@ parameters:
     #
     # DummyRouter Adapter class
     #
-    elcodi.core.menu.adapter.dummy_route_generator_adapter.class: Elcodi\Component\Menu\Adapter\RouteGenerator\DummyRouteGeneratorAdapter
+    elcodi.adapter.menu_route_generator.dummy.class: Elcodi\Component\Menu\Adapter\RouteGenerator\DummyRouteGeneratorAdapter
 
 services:
 
     #
     # DummyRouter Adapter
     #
-    elcodi.core.menu.adapter.dummy_route_generator_adapter:
-        class: %elcodi.core.menu.adapter.dummy_route_generator_adapter.class%
+    elcodi.adapter.menu_route_generator.dummy:
+        class: %elcodi.adapter.menu_route_generator.dummy.class%
 
-    elcodi.core.menu.adapter.route_generator_adapter:
-        alias: elcodi.core.menu.adapter.dummy_route_generator_adapter
+    elcodi.adapter.menu_route_generator:
+        alias: elcodi.adapter.menu_route_generator.dummy

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/symfonyRouter.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/symfonyRouter.yml
@@ -3,17 +3,17 @@ parameters:
     #
     # SymfonyRouter Adapter class
     #
-    elcodi.core.menu.adapter.symfony_route_generator_adapter.class: Elcodi\Component\Menu\Adapter\RouteGenerator\SymfonyRouteGeneratorAdapter
+    elcodi.adapter.menu_route_generator.symfony_routing.class: Elcodi\Component\Menu\Adapter\RouteGenerator\SymfonyRouteGeneratorAdapter
 
 services:
 
     #
     # SymfonyRouter Adapter
     #
-    elcodi.core.menu.adapter.symfony_route_generator_adapter:
-        class: %elcodi.core.menu.adapter.symfony_route_generator_adapter.class%
+    elcodi.adapter.menu_route_generator.symfony_routing:
+        class: %elcodi.adapter.menu_route_generator.symfony_routing.class%
         arguments:
             router: @router
 
-    elcodi.core.menu.adapter.route_generator_adapter:
-        alias: elcodi.core.menu.adapter.symfony_route_generator_adapter
+    elcodi.adapter.menu_route_generator:
+        alias: elcodi.adapter.menu_route_generator.symfony_routing

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
@@ -3,14 +3,11 @@ services:
     #
     # services
     #
-    elcodi.core.menu.service.menu_manager:
-        class: %elcodi.core.menu.service.menu_manager.class%
+    elcodi.manager.menu:
+        class: %elcodi.manager.menu.class%
         arguments:
             menu_repository: @elcodi.repository.menu
             key: %elcodi.core.menu.cache_key%
         calls:
             - [setCache, [@doctrine_cache.providers.elcodi_menus]]
             - [setEncoder, [@elcodi.json_encoder]]
-
-    elcodi.menu_manager:
-        alias: elcodi.core.menu.service.menu_manager

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/twig.yml
@@ -3,8 +3,8 @@ services:
     #
     # Twig extensions
     #
-    elcodi.core.menu.twig_extension.print_route:
-        class: %elcodi.core.menu.twig_extension.print_route.class%
+    elcodi.twig_extension.menu_print_route:
+        class: %elcodi.twig_extension.menu_print_route.class%
         arguments:
             router: @router
         tags:

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Factory/MenuFactoryTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Factory/MenuFactoryTest.php
@@ -42,7 +42,6 @@ class MenuFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.menu.factory.menu',
             'elcodi.factory.menu',
         ];
     }

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Factory/NodeFactoryTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Factory/NodeFactoryTest.php
@@ -42,7 +42,6 @@ class NodeFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.menu.factory.menu_node',
             'elcodi.factory.menu_node',
         ];
     }

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuManagerTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuManagerTest.php
@@ -33,8 +33,7 @@ class MenuManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.menu.service.menu_manager',
-            'elcodi.menu_manager',
+            'elcodi.manager.menu',
         ];
     }
 
@@ -64,7 +63,7 @@ class MenuManagerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->menuManager = $this->get('elcodi.menu_manager');
+        $this->menuManager = $this->get('elcodi.manager.menu');
     }
 
     /**

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Twig/PrintRouteExtensionTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Twig/PrintRouteExtensionTest.php
@@ -32,7 +32,7 @@ class PrintRouteExtensionTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.menu.twig_extension.print_route',
+            'elcodi.twig_extension.menu_print_route',
         ];
     }
 }

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/objectManagers.yml
@@ -5,7 +5,7 @@ services:
     #
     elcodi.object_manager.entry:
         class: Doctrine\Common\Persistence\ObjectManager
-        factory_service: elcodi.manager_provider
+        factory_service: elcodi.provider.manager
         factory_method: getManagerByEntityNamespace
         arguments:
             entity_namespace: %elcodi.core.metric.entity.metric_entry.class%

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/classes.yml
@@ -3,19 +3,19 @@ parameters:
     #
     # Factory
     #
-    elcodi.core.newsletter.factory.newsletter_subscription.class: Elcodi\Component\Newsletter\Factory\NewsletterSubscriptionFactory
+    elcodi.factory.newsletter_subscription.class: Elcodi\Component\Newsletter\Factory\NewsletterSubscriptionFactory
 
     #
     # Services
     #
-    elcodi.core.newsletter.service.newsletter_manager.class: Elcodi\Component\Newsletter\Services\NewsletterManager
+    elcodi.manager.newsletter.class: Elcodi\Component\Newsletter\Services\NewsletterManager
 
     #
     # Event Listeners
     #
-    elcodi.core.newsletter.event_listener.newsletter.class: Elcodi\Component\Newsletter\EventListener\NewsletterEventListener
+    elcodi.event_listener.newsletter.class: Elcodi\Component\Newsletter\EventListener\NewsletterEventListener
 
     #
     # Event Dispatchers
     #
-    elcodi.core.newsletter.event_dispatcher.newsletter.class: Elcodi\Component\Newsletter\EventDispatcher\NewsletterEventDispatcher
+    elcodi.event_dispatcher.newsletter.class: Elcodi\Component\Newsletter\EventDispatcher\NewsletterEventDispatcher

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventDispatchers.yml
@@ -3,9 +3,6 @@ services:
     #
     # Event Dispatchers
     #
-    elcodi.core.newsletter.event_dispatcher.newsletter:
-        class: %elcodi.core.newsletter.event_dispatcher.newsletter.class%
+    elcodi.event_dispatcher.newsletter:
+        class: %elcodi.event_dispatcher.newsletter.class%
         parent: elcodi.core.core.event_dispatcher.abstract
-
-    elcodi.newsletter_event_dispatcher:
-        alias: elcodi.core.newsletter.event_dispatcher.newsletter

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventListeners.yml
@@ -3,8 +3,8 @@ services:
     #
     # Event Listeners
     #
-    elcodi.core.newsletter.event_listener.newsletter:
-        class: %elcodi.core.newsletter.event_listener.newsletter.class%
+    elcodi.event_listener.newsletter:
+        class: %elcodi.event_listener.newsletter.class%
         arguments:
             newsletter_object_manager: @elcodi.object_manager.newsletter_subscription
         tags:

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/factories.yml
@@ -7,10 +7,7 @@ services:
     #
     # Factory for entity newsletter_subscription
     #
-    elcodi.core.newsletter.factory.newsletter_subscription:
-        class: %elcodi.core.newsletter.factory.newsletter_subscription.class%
+    elcodi.factory.newsletter_subscription:
+        class: %elcodi.factory.newsletter_subscription.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.newsletter.entity.newsletter_subscription.class%"]]
-
-    elcodi.factory.newsletter_subscription:
-        alias: elcodi.core.newsletter.factory.newsletter_subscription

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/services.yml
@@ -3,11 +3,11 @@ services:
     #
     # Services
     #
-    elcodi.core.newsletter.service.newsletter_manager:
-        class: %elcodi.core.newsletter.service.newsletter_manager.class%
+    elcodi.manager.newsletter:
+        class: %elcodi.manager.newsletter.class%
         arguments:
-            newsletter_event_dispatcher: @elcodi.newsletter_event_dispatcher
+            newsletter_event_dispatcher: @elcodi.event_dispatcher.newsletter
             validator: @validator
-            newsletter_subscription_factory: @elcodi.core.newsletter.factory.newsletter_subscription
+            newsletter_subscription_factory: @elcodi.factory.newsletter_subscription
             newsletter_subscription_repository: @elcodi.repository.newsletter_subscription
             hash_generator: @elcodi.generator.sha1

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/EventDispatcher/NewsletterEventDispatcherTest.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/EventDispatcher/NewsletterEventDispatcherTest.php
@@ -32,8 +32,7 @@ class NewsletterEventDispatcherTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.newsletter.event_dispatcher.newsletter',
-            'elcodi.newsletter_event_dispatcher',
+            'elcodi.event_dispatcher.newsletter',
         ];
     }
 }

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/EventListener/NewsletterEventListenerTest.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/EventListener/NewsletterEventListenerTest.php
@@ -32,7 +32,7 @@ class NewsletterEventListenerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.newsletter.event_listener.newsletter',
+            'elcodi.event_listener.newsletter',
         ];
     }
 }

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Factory/NewsletterSubscriptionFactoryTest.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Factory/NewsletterSubscriptionFactoryTest.php
@@ -42,7 +42,6 @@ class NewsletterSubscriptionFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.newsletter.factory.newsletter_subscription',
             'elcodi.factory.newsletter_subscription',
         ];
     }

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Service/NewsletterManagerTest.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Service/NewsletterManagerTest.php
@@ -59,7 +59,7 @@ class NewsletterManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.core.newsletter.service.newsletter_manager'];
+        return ['elcodi.manager.newsletter'];
     }
 
     /**
@@ -83,7 +83,7 @@ class NewsletterManagerTest extends WebTestCase
         parent::setUp();
 
         $this->newsletterManager = $this
-            ->get('elcodi.core.newsletter.service.newsletter_manager');
+            ->get('elcodi.manager.newsletter');
 
         $this->newsletterSubscriptionRepository = $this
             ->getRepository('newsletter_subscription');

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/classes.yml
@@ -8,7 +8,7 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.page.factory.page.class: Elcodi\Component\Page\Factory\PageFactory
+    elcodi.factory.page.class: Elcodi\Component\Page\Factory\PageFactory
 
     #
     # Controllers

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/factories.yml
@@ -7,10 +7,7 @@ services:
     #
     # Factory for entity page
     #
-    elcodi.core.page.factory.page:
-        class: %elcodi.core.page.factory.page.class%
+    elcodi.factory.page:
+        class: %elcodi.factory.page.class%
         calls:
             - [setEntityNamespace, [%elcodi.core.page.entity.page.class%]]
-
-    elcodi.factory.page:
-        alias: elcodi.core.page.factory.page

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/classes.yml
@@ -14,4 +14,4 @@ parameters:
     #
     # Twig extensions
     #
-    elcodi.core.plugin.twig_extension.hook.class: Elcodi\Component\Plugin\Twig\HookExtension
+    elcodi.twig_extension.plugin_hook.class: Elcodi\Component\Plugin\Twig\HookExtension

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
@@ -12,10 +12,10 @@ services:
         class: %elcodi.template_manager.class%
         arguments:
             kernel: @kernel
-            configuration_manager: @elcodi.configuration_manager
+            configuration_manager: @elcodi.manager.configuration
 
     elcodi.plugin_manager:
         class: %elcodi.plugin_manager.class%
         arguments:
             kernel: @kernel
-            configuration_manager: @elcodi.configuration_manager
+            configuration_manager: @elcodi.manager.configuration

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
@@ -3,8 +3,8 @@ services:
     #
     # Twig extensions
     #
-    elcodi.core.plugin.twig_extension.hook:
-        class: %elcodi.core.plugin.twig_extension.hook.class%
+    elcodi.twig_extension.plugin_hook:
+        class: %elcodi.twig_extension.plugin_hook.class%
         arguments:
             - @elcodi.hook_system
         tags:

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/classes.yml
@@ -3,18 +3,18 @@ parameters:
     #
     # Services
     #
-    elcodi.core.product.service.category_tree.class: Elcodi\Component\Product\Services\CategoryTree
-    elcodi.core.product.service.product_collection_provider.class: Elcodi\Component\Product\Services\ProductCollectionProvider
+    elcodi.provider.category_tree.class: Elcodi\Component\Product\Services\CategoryTree
+    elcodi.provider.product_collection.class: Elcodi\Component\Product\Services\ProductCollectionProvider
 
     #
     # Factories
     #
-    elcodi.core.product.factory.product.class: Elcodi\Component\Product\Factory\ProductFactory
-    elcodi.core.product.factory.product_variant.class: Elcodi\Component\Product\Factory\VariantFactory
-    elcodi.core.product.factory.manufacturer.class: Elcodi\Component\Product\Factory\ManufacturerFactory
-    elcodi.core.product.factory.category.class: Elcodi\Component\Product\Factory\CategoryFactory
+    elcodi.factory.product.class: Elcodi\Component\Product\Factory\ProductFactory
+    elcodi.factory.product_variant.class: Elcodi\Component\Product\Factory\VariantFactory
+    elcodi.factory.manufacturer.class: Elcodi\Component\Product\Factory\ManufacturerFactory
+    elcodi.factory.category.class: Elcodi\Component\Product\Factory\CategoryFactory
 
     #
     # Twig extensions
     #
-    elcodi.core.product.twig_extension.product.class: Elcodi\Component\Product\Twig\ProductExtension
+    elcodi.twig_extension.product.class: Elcodi\Component\Product\Twig\ProductExtension

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/factories.yml
@@ -7,46 +7,34 @@ services:
     #
     # Factory for Product entities
     #
-    elcodi.core.product.factory.product:
-        class: %elcodi.core.product.factory.product.class%
+    elcodi.factory.product:
+        class: %elcodi.factory.product.class%
         parent: elcodi.core.currency.factory.abstract.purchasable
         calls:
             - [setEntityNamespace, ["%elcodi.core.product.entity.product.class%"]]
             - [setUseStock, [@=elcodi_config('product.use_stock')]]
 
-    elcodi.factory.product:
-        alias: elcodi.core.product.factory.product
-
     #
     # Factory for Variant entities
     #
-    elcodi.core.product.factory.product_variant:
-        class: %elcodi.core.product.factory.product_variant.class%
+    elcodi.factory.product_variant:
+        class: %elcodi.factory.product_variant.class%
         parent: elcodi.core.currency.factory.abstract.purchasable
         calls:
             - [setEntityNamespace, ["%elcodi.core.product.entity.product_variant.class%"]]
 
-    elcodi.factory.product_variant:
-        alias: elcodi.core.product.factory.product_variant
-
     #
     # Factory for Manufacturer entities
     #
-    elcodi.core.product.factory.manufacturer:
-        class: %elcodi.core.product.factory.manufacturer.class%
+    elcodi.factory.manufacturer:
+        class: %elcodi.factory.manufacturer.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.product.entity.manufacturer.class%"]]
-
-    elcodi.factory.manufacturer:
-        alias: elcodi.core.product.factory.manufacturer
 
     #
     # Factory for Category entities
     #
-    elcodi.core.product.factory.category:
-        class: %elcodi.core.product.factory.category.class%
+    elcodi.factory.category:
+        class: %elcodi.factory.category.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.product.entity.category.class%"]]
-
-    elcodi.factory.category:
-        alias: elcodi.core.product.factory.category

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/services.yml
@@ -3,18 +3,12 @@ services:
     #
     # Services
     #
-    elcodi.core.product.service.category_tree:
-        class: %elcodi.core.product.service.category_tree.class%
+    elcodi.provider.category_tree:
+        class: %elcodi.provider.category_tree.class%
         arguments:
             category_repository: @elcodi.repository.category
 
-    elcodi.category_tree:
-            alias:  elcodi.core.product.service.category_tree
-
-    elcodi.core.product.service.product_collection_provider:
-        class: %elcodi.core.product.service.product_collection_provider.class%
+    elcodi.provider.product_collection:
+        class: %elcodi.provider.product_collection.class%
         arguments:
             product_repository: @elcodi.repository.product
-
-    elcodi.product_collection_provider:
-        alias: elcodi.core.product.service.product_collection_provider

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/twig.yml
@@ -3,8 +3,8 @@ services:
     #
     # Twig extensions
     #
-    elcodi.core.product.twig_extension.product_extension:
-        class: %elcodi.core.product.twig_extension.product.class%
+    elcodi.twig_extension.product:
+        class: %elcodi.twig_extension.product.class%
         arguments: ~
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/CategoryFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/CategoryFactoryTest.php
@@ -42,7 +42,6 @@ class CategoryFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.product.factory.category',
             'elcodi.factory.category',
         ];
     }

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ManufacturerFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ManufacturerFactoryTest.php
@@ -42,7 +42,6 @@ class ManufacturerFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.product.factory.manufacturer',
             'elcodi.factory.manufacturer',
         ];
     }

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ProductFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ProductFactoryTest.php
@@ -54,7 +54,6 @@ class ProductFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.product.factory.product',
             'elcodi.factory.product',
         ];
     }

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/VariantFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/VariantFactoryTest.php
@@ -54,7 +54,6 @@ class VariantFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.product.factory.product_variant',
             'elcodi.factory.product_variant',
         ];
     }

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Services/ProductCollectionProviderTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Services/ProductCollectionProviderTest.php
@@ -62,8 +62,7 @@ class ProductCollectionProviderTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.product.service.product_collection_provider',
-            'elcodi.product_collection_provider',
+            'elcodi.provider.product_collection',
         ];
     }
 
@@ -75,7 +74,7 @@ class ProductCollectionProviderTest extends WebTestCase
         parent::setUp();
 
         $this->productCollectionProvider = $this
-            ->get('elcodi.product_collection_provider');
+            ->get('elcodi.provider.product_collection');
     }
 
     /**

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/classes.yml
@@ -9,20 +9,20 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.referral_program.factory.referral_rule.class: Elcodi\Component\ReferralProgram\Factory\ReferralRuleFactory
-    elcodi.core.referral_program.factory.referral_line.class: Elcodi\Component\ReferralProgram\Factory\ReferralLineFactory
-    elcodi.core.referral_program.factory.referral_hash.class: Elcodi\Component\ReferralProgram\Factory\ReferralHashFactory
-    elcodi.core.referral_program.factory.invitation.class: Elcodi\Component\ReferralProgram\Factory\InvitationFactory
-    elcodi.core.referral_program.factory.invitation_bag.class: Elcodi\Component\ReferralProgram\Factory\InvitationBagFactory
+    elcodi.factory.referral_rule.class: Elcodi\Component\ReferralProgram\Factory\ReferralRuleFactory
+    elcodi.factory.referral_line.class: Elcodi\Component\ReferralProgram\Factory\ReferralLineFactory
+    elcodi.factory.referral_hash.class: Elcodi\Component\ReferralProgram\Factory\ReferralHashFactory
+    elcodi.factory.referral_invitation.class: Elcodi\Component\ReferralProgram\Factory\InvitationFactory
+    elcodi.factory.referral_invitation_bag.class: Elcodi\Component\ReferralProgram\Factory\InvitationBagFactory
 
     #
     # Services
     #
-    elcodi.core.referral_program.service.referral_program_manager.class: Elcodi\Component\ReferralProgram\Services\ReferralProgramManager
-    elcodi.core.referral_program.service.referral_hash_manager.class: Elcodi\Component\ReferralProgram\Services\ReferralHashManager
-    elcodi.core.referral_program.service.referral_route_manager.class: Elcodi\Component\ReferralProgram\Services\ReferralRouteManager
-    elcodi.core.referral_program.service.referral_coupon_manager.class: Elcodi\Component\ReferralProgram\Services\ReferralCouponManager
-    elcodi.core.referral_program.service.referral_rule_manager.class: Elcodi\Component\ReferralProgram\Services\ReferralRuleManager
+    elcodi.manager.referral_program.class: Elcodi\Component\ReferralProgram\Services\ReferralProgramManager
+    elcodi.manager.referral_hash.class: Elcodi\Component\ReferralProgram\Services\ReferralHashManager
+    elcodi.manager.referral_route.class: Elcodi\Component\ReferralProgram\Services\ReferralRouteManager
+    elcodi.manager.referral_coupon.class: Elcodi\Component\ReferralProgram\Services\ReferralCouponManager
+    elcodi.manager.referral_rule.class: Elcodi\Component\ReferralProgram\Services\ReferralRuleManager
 
     #
     # Routes
@@ -37,4 +37,4 @@ parameters:
     #
     # Controllers
     #
-    elcodi.core.referral_program.controller.referral_program.class: Elcodi\Component\ReferralProgram\Controller\ReferralProgramController
+    elcodi.controller.referral_program.class: Elcodi\Component\ReferralProgram\Controller\ReferralProgramController

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/controllers.yml
@@ -3,8 +3,8 @@ services:
     #
     # Controllers
     #
-    elcodi.core.referral_program.controller.referral_program:
-        class: %elcodi.core.referral_program.controller.referral_program.class%
+    elcodi.controller.referral_program:
+        class: %elcodi.controller.referral_program.class%
         arguments:
             request_stack: @request_stack
             router: @router

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/eventListeners.yml
@@ -7,7 +7,7 @@ services:
         class: %elcodi.core.referral_program.event_listener.referral_program_event_listener.class%
         arguments:
             referral_coupon_manager: @elcodi.core.referral_program.service.referral_coupon_manager
-            order_coupon_manager: @elcodi.order_coupon_manager
+            order_coupon_manager: @elcodi.manager.order_coupon
             request_stack: @request_stack
         tags:
             - { name: kernel.event_listener, event: user.register, method: onCustomerRegister }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.core.referral_program.event_listener.referral_program_event_listener:
         class: %elcodi.core.referral_program.event_listener.referral_program_event_listener.class%
         arguments:
-            referral_coupon_manager: @elcodi.core.referral_program.service.referral_coupon_manager
+            referral_coupon_manager: @elcodi.manager.referral_coupon
             order_coupon_manager: @elcodi.manager.order_coupon
             request_stack: @request_stack
         tags:

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/factories.yml
@@ -7,54 +7,39 @@ services:
     #
     # Factory for entity referral_rule
     #
-    elcodi.core.referral_program.factory.referral_rule:
-        class: %elcodi.core.referral_program.factory.referral_rule.class%
+    elcodi.factory.referral_rule:
+        class: %elcodi.factory.referral_rule.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.referral_program.entity.referral_rule.class%"]]
-
-    elcodi.factory.referral_rule:
-        alias: elcodi.core.referral_program.factory.referral_rule
 
     #
     # Factory for entity referral_line
     #
-    elcodi.core.referral_program.factory.referral_line:
-        class: %elcodi.core.referral_program.factory.referral_line.class%
+    elcodi.factory.referral_line:
+        class: %elcodi.factory.referral_line.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.referral_program.entity.referral_line.class%"]]
-
-    elcodi.factory.referral_line:
-        alias: elcodi.core.referral_program.factory.referral_line
 
     #
     # Factory for entity referral_hash
     #
-    elcodi.core.referral_program.factory.referral_hash:
-        class: %elcodi.core.referral_program.factory.referral_hash.class%
+    elcodi.factory.referral_hash:
+        class: %elcodi.factory.referral_hash.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.referral_program.entity.referral_hash.class%"]]
-
-    elcodi.factory.referral_hash:
-        alias: elcodi.core.referral_program.factory.referral_hash
 
     #
     # Factory for entity invitation
     #
-    elcodi.core.referral_program.factory.invitation:
-        class: %elcodi.core.referral_program.factory.invitation.class%
+    elcodi.factory.referral_invitation:
+        class: %elcodi.factory.referral_invitation.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.referral_program.entity.invitation.class%"]]
-
-    elcodi.factory.invitation:
-        alias: elcodi.core.referral_program.factory.invitation
 
     #
     # Factory for entity invitation_bag
     #
-    elcodi.core.referral_program.factory.invitation_bag:
-        class: %elcodi.core.referral_program.factory.invitation_bag.class%
+    elcodi.factory.referral_invitation_bag:
+        class: %elcodi.factory.referral_invitation_bag.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.referral_program.entity.invitation_bag.class%"]]
-
-    elcodi.factory.invitation_bag:
-        alias: elcodi.core.referral_program.factory.invitation_bag

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/services.yml
@@ -51,7 +51,7 @@ services:
             event_dispatcher: @event_dispatcher
             referral_program_manager: @elcodi.core.referral_program.service.referral_program_manager
             entity_manager: @doctrine.orm.default_entity_manager
-            coupon_manager: @elcodi.coupon_manager
+            coupon_manager: @elcodi.manager.coupon
             referral_line_repository: @elcodi.repository.referral_line
             referral_hash_manager: @elcodi.core.referral_program.service.referral_hash_manager
 

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Resources/config/services.yml
@@ -3,69 +3,66 @@ services:
     #
     # Services
     #
-    elcodi.core.referral_program.service.referral_program_manager:
-        class: %elcodi.core.referral_program.service.referral_program_manager.class%
+    elcodi.manager.referral_program:
+        class: %elcodi.manager.referral_program.class%
         arguments:
             event_dispatcher: @event_dispatcher
             referral_rule_repository: @elcodi.repository.referral_rule
             referral_line_repository: @elcodi.repository.referral_line
             entity_manager: @doctrine.orm.default_entity_manager
-            referral_route_manager: @elcodi.core.referral_program.service.referral_route_manager
-            referral_hash_manager: @elcodi.core.referral_program.service.referral_hash_manager
-            referral_line_factory: @elcodi.core.referral_program.factory.referral_line
-            invitation_bag_factory: @elcodi.core.referral_program.factory.invitation_bag
-            invitation_factory: @elcodi.core.referral_program.factory.invitation
+            referral_route_manager: @elcodi.manager.referral_route
+            referral_hash_manager: @elcodi.manager.referral_hash
+            referral_line_factory: @elcodi.factory.referral_line
+            invitation_bag_factory: @elcodi.factory.referral_invitation_bag
+            invitation_factory: @elcodi.factory.referral_invitation
             customer_repository: @elcodi.repository.customer
             purge_disabled_lines: %elcodi.core.referral_program.purge_disabled_lines%
             auto_referral_assignment: %elcodi.core.referral_program.auto_referral_assignment%
 
-    elcodi.referral_program_manager:
-        alias: elcodi.core.referral_program.service.referral_program_manager
-
     elcodi.referral_program:
-        alias: elcodi.referral_program_manager
+        alias: elcodi.manager.referral_program
 
-    elcodi.core.referral_program.service.referral_route_manager:
-        class: %elcodi.core.referral_program.service.referral_route_manager.class%
+    elcodi.manager.referral_route:
+        class: %elcodi.manager.referral_route.class%
         arguments:
             router: @router
             controller_route_name: %elcodi.core.referral_program.controller_route_name%
 
     elcodi.referral_route_manager:
-        alias: elcodi.core.referral_program.service.referral_route_manager
+        alias: elcodi.manager.referral_route
 
-    elcodi.core.referral_program.service.referral_hash_manager:
-        class: %elcodi.core.referral_program.service.referral_hash_manager.class%
+    elcodi.manager.referral_hash:
+        class: %elcodi.manager.referral_hash.class%
         arguments:
             referral_hash_repository: @elcodi.repository.referral_hash
             entity_manager: @doctrine.orm.default_entity_manager
             referral_hash_generator: @elcodi.generator.sha1
             referral_hash_factory: @elcodi.factory.referral_hash
 
-    elcodi.referral_hash_manager:
-        alias: elcodi.core.referral_program.service.referral_hash_manager
+    elcodi.manager.referral_hash:
+        alias: elcodi.manager.referral_hash
 
-    elcodi.core.referral_program.service.referral_coupon_manager:
-        class: %elcodi.core.referral_program.service.referral_coupon_manager.class%
+    elcodi.manager.referral_coupon:
+        class: %elcodi.manager.referral_coupon.class%
         arguments:
             event_dispatcher: @event_dispatcher
-            referral_program_manager: @elcodi.core.referral_program.service.referral_program_manager
+            referral_program_manager: @elcodi.manager.referral_program
             entity_manager: @doctrine.orm.default_entity_manager
             coupon_manager: @elcodi.manager.coupon
             referral_line_repository: @elcodi.repository.referral_line
-            referral_hash_manager: @elcodi.core.referral_program.service.referral_hash_manager
+            referral_hash_manager: @elcodi.manager.referral_hash
 
-    elcodi.referral_coupon_manager:
-        alias: elcodi.core.referral_program.service.referral_coupon_manager
+    elcodi.manager.referral_coupon:
+        alias: elcodi.manager.referral_coupon
 
-    elcodi.core.referral_program.service.referral_rule_manager:
-        class: %elcodi.core.referral_program.service.referral_rule_manager.class%
+    elcodi.manager.referral_rule:
+        class: %elcodi.manager.referral_rule.class%
         arguments:
             referral_rule_repository: @elcodi.repository.referral_rule
             entity_manager: @doctrine.orm.default_entity_manager
 
-    elcodi.referral_rule_manager:
-        alias: elcodi.core.referral_program.service.referral_rule_manager
+    elcodi.manager.referral_rule:
+        alias: elcodi.manager.referral_rule
 
     #
     # Routes

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Controller/ReferralProgramControllerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Controller/ReferralProgramControllerTest.php
@@ -33,7 +33,7 @@ class ReferralProgramControllerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.controller.referral_program',
+            'elcodi.controller.referral_program',
         ];
     }
 

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/InvitationBagFactoryTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/InvitationBagFactoryTest.php
@@ -42,8 +42,7 @@ class InvitationBagFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.factory.invitation_bag',
-            'elcodi.factory.invitation_bag',
+            'elcodi.factory.referral_invitation_bag',
         ];
     }
 }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/InvitationFactoryTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/InvitationFactoryTest.php
@@ -42,8 +42,7 @@ class InvitationFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.factory.invitation',
-            'elcodi.factory.invitation',
+            'elcodi.factory.referral_invitation',
         ];
     }
 }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/ReferralHashFactoryTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/ReferralHashFactoryTest.php
@@ -42,7 +42,6 @@ class ReferralHashFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.factory.referral_hash',
             'elcodi.factory.referral_hash',
         ];
     }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/ReferralLineFactoryTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/ReferralLineFactoryTest.php
@@ -42,7 +42,6 @@ class ReferralLineFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.factory.referral_line',
             'elcodi.factory.referral_line',
         ];
     }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/ReferralRuleFactoryTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Factory/ReferralRuleFactoryTest.php
@@ -42,7 +42,6 @@ class ReferralRuleFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.factory.referral_rule',
             'elcodi.factory.referral_rule',
         ];
     }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralCouponManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralCouponManagerTest.php
@@ -42,8 +42,7 @@ class ReferralCouponManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.service.referral_coupon_manager',
-            'elcodi.referral_coupon_manager',
+            'elcodi.manager.referral_coupon',
         ];
     }
 
@@ -96,7 +95,7 @@ class ReferralCouponManagerTest extends WebTestCase
         $referralRule = $this->find('referral_rule', 2);
 
         $this
-            ->get('elcodi.referral_rule_manager')
+            ->get('elcodi.manager.referral_rule')
             ->enableReferralRule($referralRule);
 
         $invitations = new ArrayCollection();
@@ -107,7 +106,7 @@ class ReferralCouponManagerTest extends WebTestCase
         $invitations->add($invitation1);
 
         $referralProgramManager = $this
-            ->get('elcodi.referral_program_manager');
+            ->get('elcodi.manager.referral_program');
 
         $referralProgramManager->invite(
             $this->find('customer', 1),
@@ -135,7 +134,7 @@ class ReferralCouponManagerTest extends WebTestCase
         $referrer = $this->find('customer', 1);
 
         $referralHash = $this
-            ->get('elcodi.referral_hash_manager')
+            ->get('elcodi.manager.referral_hash')
             ->getReferralHashByCustomer($referrer);
         $hash = $referralHash->getHash();
 
@@ -160,7 +159,7 @@ class ReferralCouponManagerTest extends WebTestCase
         ));
 
         $referralCouponManager = $this
-            ->get('elcodi.referral_coupon_manager');
+            ->get('elcodi.manager.referral_coupon');
 
         $referralCouponManager
             ->checkCouponAssignment(
@@ -246,7 +245,7 @@ class ReferralCouponManagerTest extends WebTestCase
         $referralRule = $this->find('referral_rule', 4);
 
         $this
-            ->get('elcodi.referral_rule_manager')
+            ->get('elcodi.manager.referral_rule')
             ->enableReferralRule($referralRule);
 
         $this
@@ -263,7 +262,7 @@ class ReferralCouponManagerTest extends WebTestCase
         $invited = $this->find('customer', 2);
 
         $referralHash = $this
-            ->get('elcodi.referral_hash_manager')
+            ->get('elcodi.manager.referral_hash')
             ->getReferralHashByCustomer($referrer);
         $hash = $referralHash->getHash();
 
@@ -275,14 +274,14 @@ class ReferralCouponManagerTest extends WebTestCase
         $invitations->add($invitation1);
 
         $this
-            ->get('elcodi.referral_program_manager')
+            ->get('elcodi.manager.referral_program')
             ->invite($referrer, $invitations);
 
         /**
          * * Invited registers in site
          * * Referrer Customer receive coupons
          */
-        $referralCouponManager = $this->get('elcodi.referral_coupon_manager');
+        $referralCouponManager = $this->get('elcodi.manager.referral_coupon');
 
         $referralCouponManager->checkCouponAssignment(
             $invited,

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralHashManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralHashManagerTest.php
@@ -34,8 +34,7 @@ class ReferralHashManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.service.referral_hash_manager',
-            'elcodi.referral_hash_manager',
+            'elcodi.manager.referral_hash',
         ];
     }
 
@@ -78,7 +77,7 @@ class ReferralHashManagerTest extends WebTestCase
         /**
          * @var ReferralHashManager $referralHashManager
          */
-        $referralHashManager = $this->get('elcodi.referral_hash_manager');
+        $referralHashManager = $this->get('elcodi.manager.referral_hash');
         $referralHash = $referralHashManager->getReferralHashByCustomer($customer);
 
         $this->assertInstanceOf('Elcodi\Component\ReferralProgram\Entity\Interfaces\ReferralHashInterface', $referralHash);
@@ -98,7 +97,7 @@ class ReferralHashManagerTest extends WebTestCase
         /**
          * @var ReferralHashManager $referralHashManager
          */
-        $referralHashManager = $this->get('elcodi.referral_hash_manager');
+        $referralHashManager = $this->get('elcodi.manager.referral_hash');
         $referralHash = $referralHashManager->getReferralHashByCustomer($customer);
 
         $this->assertInstanceOf('Elcodi\Component\ReferralProgram\Entity\Interfaces\ReferralHashInterface', $referralHash);

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralProgramManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralProgramManagerTest.php
@@ -42,8 +42,7 @@ class ReferralProgramManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.service.referral_program_manager',
-            'elcodi.referral_program_manager',
+            'elcodi.manager.referral_program',
             'elcodi.referral_program',
         ];
     }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralRuleManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralRuleManagerTest.php
@@ -35,8 +35,7 @@ class ReferralRuleManagerTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.referral_program.service.referral_rule_manager',
-            'elcodi.referral_rule_manager',
+            'elcodi.manager.referral_rule',
         ];
     }
 
@@ -77,7 +76,7 @@ class ReferralRuleManagerTest extends WebTestCase
         $referralRule = $this->find('referral_rule', 4);
 
         $this
-            ->get('elcodi.core.referral_program.service.referral_rule_manager')
+            ->get('elcodi.manager.referral_rule')
             ->enableReferralRule($referralRule);
 
         /**

--- a/src/Elcodi/Bundle/RuleBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Resources/config/classes.yml
@@ -13,7 +13,7 @@ parameters:
     #
     # Managers
     #
-    elcodi.rule_manager.class: Elcodi\Component\Rule\Services\RuleManager
+    elcodi.manager.rule.class: Elcodi\Component\Rule\Services\RuleManager
 
     #
     # ExpressionLanguage

--- a/src/Elcodi/Bundle/RuleBundle/Resources/config/expressionLanguage.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Resources/config/expressionLanguage.yml
@@ -23,6 +23,6 @@ services:
         class: %elcodi.expression_language_rule_provider.class%
         arguments:
             - @elcodi.repository.rule
-            - @elcodi.rule_manager
+            - @elcodi.manager.rule
         tags:
             - { name: elcodi.rule_configuration }

--- a/src/Elcodi/Bundle/RuleBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Resources/config/services.yml
@@ -3,8 +3,8 @@ services:
     #
     # Managers
     #
-    elcodi.rule_manager:
-        class: %elcodi.rule_manager.class%
+    elcodi.manager.rule:
+        class: %elcodi.manager.rule.class%
         lazy: true
         arguments:
             expression_language: @elcodi.expression_language

--- a/src/Elcodi/Bundle/RuleBundle/Tests/Functional/Services/RuleManagerTest.php
+++ b/src/Elcodi/Bundle/RuleBundle/Tests/Functional/Services/RuleManagerTest.php
@@ -50,7 +50,7 @@ class RuleManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.rule_manager'];
+        return ['elcodi.manager.rule'];
     }
 
     /**
@@ -72,7 +72,7 @@ class RuleManagerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->ruleManager = $this->get('elcodi.rule_manager');
+        $this->ruleManager = $this->get('elcodi.manager.rule');
     }
 
     /**

--- a/src/Elcodi/Bundle/ShippingBundle/DataFixtures/ORM/CarrierData.php
+++ b/src/Elcodi/Bundle/ShippingBundle/DataFixtures/ORM/CarrierData.php
@@ -43,12 +43,12 @@ class CarrierData extends AbstractFixture implements DependentFixtureInterface
          * @var CarrierPriceRangeFactory  $carrierPriceRangeFactory
          * @var CarrierWeightRangeFactory $carrierWeightRangeFactory
          */
-        $carrierFactory = $this->getFactory('carrier');
-        $carrierPriceRangeFactory = $this->getFactory('carrier_price_range');
-        $carrierWeightRangeFactory = $this->getFactory('carrier_weight_range');
-        $carrierObjectManager = $this->getObjectManager('carrier');
-        $carrierPriceRangeObjectManager = $this->getObjectManager('carrier_price_range');
-        $carrierWeightRangeObjectManager = $this->getObjectManager('carrier_weight_range');
+        $carrierFactory = $this->getFactory('shipping_carrier');
+        $carrierPriceRangeFactory = $this->getFactory('shipping_carrier_price_range');
+        $carrierWeightRangeFactory = $this->getFactory('shipping_carrier_weight_range');
+        $carrierObjectManager = $this->getObjectManager('shipping_carrier');
+        $carrierPriceRangeObjectManager = $this->getObjectManager('shipping_carrier_price_range');
+        $carrierWeightRangeObjectManager = $this->getObjectManager('shipping_carrier_weight_range');
 
         /**
          * @var CurrencyInterface $currencyEuro

--- a/src/Elcodi/Bundle/ShippingBundle/DataFixtures/ORM/WarehouseData.php
+++ b/src/Elcodi/Bundle/ShippingBundle/DataFixtures/ORM/WarehouseData.php
@@ -36,8 +36,8 @@ class WarehouseData extends AbstractFixture implements DependentFixtureInterface
         /**
          * @var WarehouseFactory $warehouseFactory
          */
-        $warehouseFactory = $this->getFactory('warehouse');
-        $warehouseObjectManager = $this->getObjectManager('warehouse');
+        $warehouseFactory = $this->getFactory('shipping_warehouse');
+        $warehouseObjectManager = $this->getObjectManager('shipping_warehouse');
 
         /**
          * Warehouse

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/classes.yml
@@ -12,16 +12,16 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.shipping.factory.carrier.class: Elcodi\Component\Shipping\Factory\CarrierFactory
-    elcodi.core.shipping.factory.carrier_price_range.class: Elcodi\Component\Shipping\Factory\CarrierPriceRangeFactory
-    elcodi.core.shipping.factory.carrier_weight_range.class: Elcodi\Component\Shipping\Factory\CarrierWeightRangeFactory
-    elcodi.core.shipping.factory.warehouse.class: Elcodi\Component\Shipping\Factory\WarehouseFactory
+    elcodi.factory.shipping_carrier.class: Elcodi\Component\Shipping\Factory\CarrierFactory
+    elcodi.factory.shipping_carrier_price_range.class: Elcodi\Component\Shipping\Factory\CarrierPriceRangeFactory
+    elcodi.factory.shipping_carrier_weight_range.class: Elcodi\Component\Shipping\Factory\CarrierWeightRangeFactory
+    elcodi.factory.shipping_warehouse.class: Elcodi\Component\Shipping\Factory\WarehouseFactory
 
     #
     # Providers
     #
-    elcodi.core.shipping.provider.carrier_provider.class: Elcodi\Component\Shipping\Provider\CarrierProvider
-    elcodi.core.shipping.provider.shipping_provider.class: Elcodi\Component\Shipping\Provider\ShippingProvider
+    elcodi.provider.shipping_carrier.class: Elcodi\Component\Shipping\Provider\CarrierProvider
+    elcodi.provider.shipping.class: Elcodi\Component\Shipping\Provider\ShippingProvider
 
     #
     # Resolvers

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/classes.yml
@@ -26,4 +26,4 @@ parameters:
     #
     # Resolvers
     #
-    elcodi.core.shipping.resolver.carrier_resolver.class: Elcodi\Component\Shipping\Resolver\CarrierResolver
+    elcodi.carrier_resolver.class: Elcodi\Component\Shipping\Resolver\CarrierResolver

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/factories.yml
@@ -7,43 +7,31 @@ services:
     #
     # Factory for entity carrier
     #
-    elcodi.core.shipping.factory.carrier:
-        class: %elcodi.core.shipping.factory.carrier.class%
+    elcodi.factory.shipping_carrier:
+        class: %elcodi.factory.shipping_carrier.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.shipping.entity.carrier.class%"]]
-
-    elcodi.factory.carrier:
-        alias: elcodi.core.shipping.factory.carrier
 
     #
     # Factory for entity carrier_price_range
     #
-    elcodi.core.shipping.factory.carrier_price_range:
-        class: %elcodi.core.shipping.factory.carrier_price_range.class%
+    elcodi.factory.shipping_carrier_price_range:
+        class: %elcodi.factory.shipping_carrier_price_range.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.shipping.entity.carrier_price_range.class%"]]
 
-    elcodi.factory.carrier_price_range:
-        alias: elcodi.core.shipping.factory.carrier_price_range
-
     #
     # Factory for entity carrier_weight_range
     #
-    elcodi.core.shipping.factory.carrier_weight_range:
-        class: %elcodi.core.shipping.factory.carrier_weight_range.class%
+    elcodi.factory.shipping_carrier_weight_range:
+        class: %elcodi.factory.shipping_carrier_weight_range.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.shipping.entity.carrier_weight_range.class%"]]
 
-    elcodi.factory.carrier_weight_range:
-        alias: elcodi.core.shipping.factory.carrier_weight_range
-
     #
     # Factory for entity carrier_weight_range
     #
-    elcodi.core.shipping.factory.warehouse:
-        class: %elcodi.core.shipping.factory.warehouse.class%
+    elcodi.factory.shipping_warehouse:
+        class: %elcodi.factory.shipping_warehouse.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.shipping.entity.warehouse.class%"]]
-
-    elcodi.factory.warehouse:
-        alias: elcodi.core.shipping.factory.warehouse

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/objectManagers.yml
@@ -3,18 +3,18 @@ services:
     #
     # Object Managers
     #
-    elcodi.object_manager.carrier_price_range:
+    elcodi.object_manager.shipping_carrier_price_range:
         parent: elcodi.abstract_manager
         arguments: [ %elcodi.core.shipping.entity.carrier_price_range.class% ]
 
-    elcodi.object_manager.carrier_weight_range:
+    elcodi.object_manager.shipping_carrier_weight_range:
         parent: elcodi.abstract_manager
         arguments: [ %elcodi.core.shipping.entity.carrier_weight_range.class% ]
 
-    elcodi.object_manager.carrier:
+    elcodi.object_manager.shipping_carrier:
         parent: elcodi.abstract_manager
         arguments: [ %elcodi.core.shipping.entity.carrier.class% ]
 
-    elcodi.object_manager.warehouse:
+    elcodi.object_manager.shipping_warehouse:
         parent: elcodi.abstract_manager
         arguments: [ %elcodi.core.shipping.entity.warehouse.class% ]

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/providers.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/providers.yml
@@ -7,7 +7,7 @@ services:
         class: %elcodi.core.shipping.provider.carrier_provider.class%
         arguments:
             carrier_repository: @elcodi.repository.carrier
-            currency_converter: @elcodi.currency_converter
+            currency_converter: @elcodi.converter.currency
             warehouse_repository: @elcodi.repository.warehouse
             zone_matcher: @elcodi.zone_matcher
 

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/providers.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/providers.yml
@@ -3,22 +3,16 @@ services:
     #
     # Providers
     #
-    elcodi.core.shipping.provider.carrier_provider:
-        class: %elcodi.core.shipping.provider.carrier_provider.class%
+    elcodi.provider.shipping_carrier:
+        class: %elcodi.provider.shipping_carrier.class%
         arguments:
             carrier_repository: @elcodi.repository.carrier
             currency_converter: @elcodi.converter.currency
-            warehouse_repository: @elcodi.repository.warehouse
+            warehouse_repository: @elcodi.repository.shipping_warehouse
             zone_matcher: @elcodi.zone_matcher
 
-    elcodi.carrier_provider:
-        alias: elcodi.core.shipping.provider.carrier_provider
-
-    elcodi.core.shipping.provider.shipping_provider:
-        class: %elcodi.core.shipping.provider.shipping_provider.class%
+    elcodi.provider.shipping:
+        class: %elcodi.provider.shipping.class%
         arguments:
-            carrier_provider: @elcodi.carrier_provider
+            carrier_provider: @elcodi.provider.shipping_carrier
             carrier_resolver: @elcodi.carrier_resolver
-
-    elcodi.shipping_provider:
-        alias: elcodi.core.shipping.provider.shipping_provider

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/repositories.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/repositories.yml
@@ -35,6 +35,6 @@ services:
     #
     # Repository for entity warehouse
     #
-    elcodi.repository.warehouse:
+    elcodi.repository.shipping_warehouse:
         parent: elcodi.abstract_repository
         arguments: [ %elcodi.core.shipping.entity.warehouse.class% ]

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/resolvers.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/resolvers.yml
@@ -3,11 +3,8 @@ services:
     #
     # Resolvers
     #
-    elcodi.core.shipping.resolver.carrier_resolver:
-        class: %elcodi.core.shipping.resolver.carrier_resolver.class%
-        arguments:
-            currency_converter: @elcodi.currency_converter
-            carrier_resolver_strategy: %elcodi.core.shipping.carrier_resolver_strategy%
-
     elcodi.carrier_resolver:
-        alias: elcodi.core.shipping.resolver.carrier_resolver
+        class: %elcodi.carrier_resolver.class%
+        arguments:
+            currency_converter: @elcodi.converter.currency
+            carrier_resolver_strategy: %elcodi.core.shipping.carrier_resolver_strategy%

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/CarrierFactoryTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/CarrierFactoryTest.php
@@ -42,8 +42,7 @@ class CarrierFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.shipping.factory.carrier',
-            'elcodi.factory.carrier',
+            'elcodi.factory.shipping_carrier',
         ];
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/CarrierPriceRangeFactoryTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/CarrierPriceRangeFactoryTest.php
@@ -42,8 +42,7 @@ class CarrierPriceRangeFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.shipping.factory.carrier_price_range',
-            'elcodi.factory.carrier_price_range',
+            'elcodi.factory.shipping_carrier_price_range',
         ];
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/CarrierWeightRangeFactoryTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/CarrierWeightRangeFactoryTest.php
@@ -42,8 +42,7 @@ class CarrierWeightRangeFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.shipping.factory.carrier_weight_range',
-            'elcodi.factory.carrier_weight_range',
+            'elcodi.factory.shipping_carrier_weight_range',
         ];
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/WarehouseFactoryTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Factory/WarehouseFactoryTest.php
@@ -42,8 +42,7 @@ class WarehouseFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.shipping.factory.warehouse',
-            'elcodi.factory.warehouse',
+            'elcodi.factory.shipping_warehouse',
         ];
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Provider/CarrierProviderTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Provider/CarrierProviderTest.php
@@ -59,8 +59,7 @@ class CarrierProviderTest extends AbstractProviderTest
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.shipping.provider.carrier_provider',
-            'elcodi.carrier_provider',
+            'elcodi.provider.shipping_carrier',
         ];
     }
 
@@ -72,7 +71,7 @@ class CarrierProviderTest extends AbstractProviderTest
         $order = $this->createShippingEnvironment(2, 1);
 
         $carriers = $this
-            ->get('elcodi.carrier_provider')
+            ->get('elcodi.provider.shipping_carrier')
             ->provideCarrierRangesSatisfiedWithOrder($order);
 
         $this->assertCount(3, $carriers);
@@ -86,7 +85,7 @@ class CarrierProviderTest extends AbstractProviderTest
         $order = $this->createShippingEnvironment(2, 2);
 
         $carriers = $this
-            ->get('elcodi.carrier_provider')
+            ->get('elcodi.provider.shipping_carrier')
             ->provideCarrierRangesSatisfiedWithOrder($order);
 
         $this->assertCount(1, $carriers);

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Provider/ShippingProviderTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Provider/ShippingProviderTest.php
@@ -58,8 +58,7 @@ class ShippingProviderTest extends AbstractProviderTest
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.shipping.provider.shipping_provider',
-            'elcodi.shipping_provider',
+            'elcodi.provider.shipping',
         ];
     }
 
@@ -71,7 +70,7 @@ class ShippingProviderTest extends AbstractProviderTest
         $order = $this->createShippingEnvironment(2, 1);
 
         $carriers = $this
-            ->get('elcodi.shipping_provider')
+            ->get('elcodi.provider.shipping')
             ->getValidCarrierRangesFromCart($order);
 
         $this->assertCount(1, $carriers);
@@ -87,7 +86,7 @@ class ShippingProviderTest extends AbstractProviderTest
         $order = $this->createShippingEnvironment(2, 2);
 
         $carriers = $this
-            ->get('elcodi.shipping_provider')
+            ->get('elcodi.provider.shipping')
             ->getValidCarrierRangesFromCart($order);
 
         $this->assertCount(1, $carriers);
@@ -103,7 +102,7 @@ class ShippingProviderTest extends AbstractProviderTest
         $order = $this->createShippingEnvironment(2, 1);
 
         $carriers = $this
-            ->get('elcodi.shipping_provider')
+            ->get('elcodi.provider.shipping')
             ->getAllCarrierRangesFromOrder($order);
 
         $this->assertCount(3, $carriers);
@@ -117,7 +116,7 @@ class ShippingProviderTest extends AbstractProviderTest
         $order = $this->createShippingEnvironment(2, 2);
 
         $carriers = $this
-            ->get('elcodi.shipping_provider')
+            ->get('elcodi.provider.shipping')
             ->getAllCarrierRangesFromOrder($order);
 
         $this->assertCount(1, $carriers);

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Repository/WarehouseRepositoryTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Repository/WarehouseRepositoryTest.php
@@ -32,7 +32,7 @@ class WarehouseRepositoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.repository.warehouse',
+            'elcodi.repository.shipping_warehouse',
         ];
     }
 
@@ -43,7 +43,7 @@ class WarehouseRepositoryTest extends WebTestCase
     {
         $this->assertInstanceOf(
             'Doctrine\Common\Persistence\ObjectRepository',
-            $this->get('elcodi.repository.warehouse')
+            $this->get('elcodi.repository.shipping_warehouse')
         );
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Resolver/CarrierResolverTest.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/Resolver/CarrierResolverTest.php
@@ -42,7 +42,6 @@ class CarrierResolverTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.shipping.resolver.carrier_resolver',
             'elcodi.carrier_resolver',
         ];
     }

--- a/src/Elcodi/Bundle/SitemapBundle/DependencyInjection/ElcodiSitemapExtension.php
+++ b/src/Elcodi/Bundle/SitemapBundle/DependencyInjection/ElcodiSitemapExtension.php
@@ -179,7 +179,7 @@ class ElcodiSitemapExtension extends AbstractExtension
                 )
                 ->addArgument(new Reference($profile['render']))
                 ->addArgument(new Reference('elcodi.sitemap_profile.'.$profileName))
-                ->addArgument(new Reference('elcodi.sitemap_event_dispatcher'))
+                ->addArgument(new Reference('elcodi.event_dispatcher.sitemap'))
                 ->setPublic(true)
                 ->addTag('elcodi.sitemap_dumper');
         }

--- a/src/Elcodi/Bundle/SitemapBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/SitemapBundle/Resources/config/classes.yml
@@ -29,4 +29,4 @@ parameters:
     #
     # Event Dispatchers
     #
-    elcodi.core.sitemap.event_dispatcher.sitemap.class: Elcodi\Component\Sitemap\EventDispatcher\SitemapEventDispatcher
+    elcodi.event_dispatcher.sitemap.class: Elcodi\Component\Sitemap\EventDispatcher\SitemapEventDispatcher

--- a/src/Elcodi/Bundle/SitemapBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/SitemapBundle/Resources/config/eventDispatchers.yml
@@ -3,9 +3,6 @@ services:
     #
     # Event Dispatchers
     #
-    elcodi.core.sitemap.event_dispatcher.sitemap:
-        class: %elcodi.core.sitemap.event_dispatcher.sitemap.class%
+    elcodi.event_dispatcher.sitemap:
+        class: %elcodi.event_dispatcher.sitemap.class%
         parent: elcodi.core.core.event_dispatcher.abstract
-
-    elcodi.sitemap_event_dispatcher:
-        alias: elcodi.core.sitemap.event_dispatcher.sitemap

--- a/src/Elcodi/Bundle/TaxBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/TaxBundle/Resources/config/classes.yml
@@ -3,5 +3,5 @@ parameters:
     #
     # Factories
     #
-    elcodi.core.tax.factory.tax.class: Elcodi\Component\Tax\Factory\TaxFactory
-    elcodi.core.tax.factory.tax_group.class: Elcodi\Component\Tax\Factory\TaxGroupFactory
+    elcodi.factory.tax.class: Elcodi\Component\Tax\Factory\TaxFactory
+    elcodi.factory.tax_group.class: Elcodi\Component\Tax\Factory\TaxGroupFactory

--- a/src/Elcodi/Bundle/TaxBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/TaxBundle/Resources/config/factories.yml
@@ -7,21 +7,15 @@ services:
     #
     # Factory for entity tax
     #
-    elcodi.core.tax.factory.tax:
-        class: %elcodi.core.tax.factory.tax.class%
+    elcodi.factory.tax:
+        class: %elcodi.factory.tax.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.tax.entity.tax.class%"]]
-
-    elcodi.factory.tax:
-        alias: elcodi.core.tax.factory.tax
 
     #
     # Factory for entity tax group
     #
-    elcodi.core.tax.factory.tax_group:
-        class: %elcodi.core.tax.factory.tax_group.class%
+    elcodi.factory.tax_group:
+        class: %elcodi.factory.tax_group.class%
         calls:
             - [setEntityNamespace, ["%elcodi.core.tax.entity.tax_group.class%"]]
-
-    elcodi.factory.tax_group:
-        alias: elcodi.core.tax.factory.tax_group

--- a/src/Elcodi/Bundle/TaxBundle/Tests/Functional/Factory/TaxFactoryTest.php
+++ b/src/Elcodi/Bundle/TaxBundle/Tests/Functional/Factory/TaxFactoryTest.php
@@ -42,7 +42,6 @@ class TaxFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.tax.factory.tax',
             'elcodi.factory.tax',
         ];
     }

--- a/src/Elcodi/Bundle/TaxBundle/Tests/Functional/Factory/TaxGroupFactoryTest.php
+++ b/src/Elcodi/Bundle/TaxBundle/Tests/Functional/Factory/TaxGroupFactoryTest.php
@@ -42,7 +42,6 @@ class TaxGroupFactoryTest extends WebTestCase
     public function getServiceCallableName()
     {
         return [
-            'elcodi.core.tax.factory.tax_group',
             'elcodi.factory.tax_group',
         ];
     }

--- a/src/Elcodi/Bundle/TemplateBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/TemplateBundle/Resources/config/commands.yml
@@ -13,6 +13,6 @@ services:
     elcodi.templates_enable_command:
         class: %elcodi.templates_enable_command.class%
         arguments:
-            configuration_manager: @elcodi.configuration_manager
+            configuration_manager: @elcodi.manager.configuration
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/TemplateBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/TemplateBundle/Resources/config/services.yml
@@ -7,4 +7,4 @@ services:
         class: %elcodi.template_manager.class%
         arguments:
             kernel: @kernel
-            configuration_manager: @elcodi.configuration_manager
+            configuration_manager: @elcodi.manager.configuration

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/classes.yml
@@ -9,15 +9,15 @@ parameters:
     #
     # Services
     #
-    elcodi.password_manager.class: Elcodi\Component\User\Services\PasswordManager
-    elcodi.customer_manager.class: Elcodi\Component\User\Services\CustomerManager
-    elcodi.admin_user_manager.class: Elcodi\Component\User\Services\AdminUserManager
+    elcodi.manager.password.class: Elcodi\Component\User\Services\PasswordManager
+    elcodi.manager.customer.class: Elcodi\Component\User\Services\CustomerManager
+    elcodi.manager.admin_user.class: Elcodi\Component\User\Services\AdminUserManager
 
     #
     # Wrappers
     #
-    elcodi.customer_wrapper.class: Elcodi\Component\User\Wrapper\CustomerWrapper
-    elcodi.admin_user_wrapper.class: Elcodi\Component\User\Wrapper\AdminUserWrapper
+    elcodi.wrapper.customer.class: Elcodi\Component\User\Wrapper\CustomerWrapper
+    elcodi.wrapper.admin_user.class: Elcodi\Component\User\Wrapper\AdminUserWrapper
 
     #
     # Event Listeners

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.event_listener.authentication_success:
         class: %elcodi.event_listener.authentication_success.class%
         arguments:
-            cart_wrapper: @elcodi.cart_wrapper
+            cart_wrapper: @elcodi.wrapper.cart
             cart_entity_manager: @elcodi.object_manager.cart
         tags:
             - { name: kernel.event_listener, event: security.authentication.success, method: onAuthenticationSuccess  }

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
@@ -3,22 +3,22 @@ services:
     #
     # Services
     #
-    elcodi.password_manager:
-        class: %elcodi.password_manager.class%
+    elcodi.manager.password:
+        class: %elcodi.manager.password.class%
         arguments:
             entity_manager: @doctrine.orm.entity_manager
             router: @router
             event_dispatcher: @event_dispatcher
             recovery_hash_generator: @elcodi.generator.sha1
 
-    elcodi.customer_manager:
-        class: %elcodi.customer_manager.class%
+    elcodi.manager.customer:
+        class: %elcodi.manager.customer.class%
         arguments:
             event_dispatcher: @event_dispatcher
             security_context: @?security.context
 
-    elcodi.admin_user_manager:
-        class: %elcodi.admin_user_manager.class%
+    elcodi.manager.admin_user:
+        class: %elcodi.manager.admin_user.class%
         arguments:
             event_dispatcher: @event_dispatcher
             security_context: @?security.context

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/wrappers.yml
@@ -3,14 +3,14 @@ services:
     #
     # Wrappers
     #
-    elcodi.customer_wrapper:
-        class: %elcodi.customer_wrapper.class%
+    elcodi.wrapper.customer:
+        class: %elcodi.wrapper.customer.class%
         arguments:
             customer_factory: @elcodi.factory.customer
             security_context: @?security.context
 
-    elcodi.admin_user_wrapper:
-        class: %elcodi.admin_user_wrapper.class%
+    elcodi.wrapper.admin_user:
+        class: %elcodi.wrapper.admin_user.class%
         arguments:
             admin_user_factory: @elcodi.factory.admin_user
             security_context: @?security.context

--- a/src/Elcodi/Bundle/UserBundle/Tests/Functional/Services/AdminUserManagerTest.php
+++ b/src/Elcodi/Bundle/UserBundle/Tests/Functional/Services/AdminUserManagerTest.php
@@ -31,6 +31,6 @@ class AdminUserManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.admin_user_manager'];
+        return ['elcodi.manager.admin_user'];
     }
 }

--- a/src/Elcodi/Bundle/UserBundle/Tests/Functional/Services/CustomerManagerTest.php
+++ b/src/Elcodi/Bundle/UserBundle/Tests/Functional/Services/CustomerManagerTest.php
@@ -31,6 +31,6 @@ class CustomerManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.customer_manager'];
+        return ['elcodi.manager.customer'];
     }
 }

--- a/src/Elcodi/Bundle/UserBundle/Tests/Functional/Services/PasswordManagerTest.php
+++ b/src/Elcodi/Bundle/UserBundle/Tests/Functional/Services/PasswordManagerTest.php
@@ -31,6 +31,6 @@ class PasswordManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.password_manager'];
+        return ['elcodi.manager.password'];
     }
 }

--- a/src/Elcodi/Bundle/UserBundle/Tests/Functional/Wrapper/AdminUserWrapperTest.php
+++ b/src/Elcodi/Bundle/UserBundle/Tests/Functional/Wrapper/AdminUserWrapperTest.php
@@ -31,6 +31,6 @@ class AdminUserWrapperTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.admin_user_wrapper'];
+        return ['elcodi.wrapper.admin_user'];
     }
 }

--- a/src/Elcodi/Bundle/UserBundle/Tests/Functional/Wrapper/CustomerWrapperTest.php
+++ b/src/Elcodi/Bundle/UserBundle/Tests/Functional/Wrapper/CustomerWrapperTest.php
@@ -31,6 +31,6 @@ class CustomerWrapperTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.customer_wrapper'];
+        return ['elcodi.wrapper.customer'];
     }
 }

--- a/src/Elcodi/Component/Cart/Entity/Cart.php
+++ b/src/Elcodi/Component/Cart/Entity/Cart.php
@@ -63,7 +63,7 @@ class Cart implements CartInterface
     protected $ordered;
 
     /**
-     * @var Collection
+     * @var CartLineInterface[]|Collection
      *
      * Lines
      */
@@ -288,16 +288,13 @@ class Cart implements CartInterface
      */
     public function getTotalItemNumber()
     {
-        $totalItems = array_reduce(
+        return array_reduce(
             $this->cartLines->toArray(),
             function ($previousTotal, CartLineInterface $current) {
                 return $previousTotal + $current->getQuantity();
-            }
+            },
+            0
         );
-
-        return is_null($totalItems)
-            ? 0
-            : $totalItems;
     }
 
     /**

--- a/src/Elcodi/Component/Cart/Entity/Interfaces/CartInterface.php
+++ b/src/Elcodi/Component/Cart/Entity/Interfaces/CartInterface.php
@@ -20,6 +20,7 @@ namespace Elcodi\Component\Cart\Entity\Interfaces;
 use Doctrine\Common\Collections\Collection;
 
 use Elcodi\Component\Core\Entity\Interfaces\DateTimeInterface;
+use Elcodi\Component\Core\Entity\Interfaces\IdentifiableInterface;
 use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
 use Elcodi\Component\Product\Entity\Interfaces\DimensionableInterface;
 use Elcodi\Component\User\Entity\Interfaces\CustomerInterface;
@@ -27,7 +28,11 @@ use Elcodi\Component\User\Entity\Interfaces\CustomerInterface;
 /**
  * Class CartInterface
  */
-interface CartInterface extends DateTimeInterface, DimensionableInterface
+interface CartInterface
+    extends
+        DateTimeInterface,
+        DimensionableInterface,
+        IdentifiableInterface
 {
     /**
      * Gets amount with tax

--- a/src/Elcodi/Component/Cart/EventListener/LimitNegativeCartsListener.php
+++ b/src/Elcodi/Component/Cart/EventListener/LimitNegativeCartsListener.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Cart\EventListener;
+
+use Elcodi\Component\Cart\Event\CartOnLoadEvent;
+
+/**
+ * Class LimitNegativeCartsListener
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class LimitNegativeCartsListener
+{
+    /**
+     * When a cart goes below 0 (due to discounts), set the amount to 0.
+     *
+     * @param CartOnLoadEvent $event Event
+     */
+    public function limitCartAmount(CartOnLoadEvent $event)
+    {
+        $cart = $event->getCart();
+
+        $amount = $cart->getAmount();
+
+        if ($amount->getAmount() <= 0) {
+            $cart->setAmount($amount->setAmount(0));
+        }
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/ElcodiCartCouponEvents.php
+++ b/src/Elcodi/Component/CartCoupon/ElcodiCartCouponEvents.php
@@ -23,6 +23,14 @@ namespace Elcodi\Component\CartCoupon;
 final class ElcodiCartCouponEvents
 {
     /**
+     * This event is dispatched while checking if a Coupon applies to a Cart
+     *
+     * event.name : cart_coupon.oncheck
+     * event.class : CartCouponOnCheckEvent
+     */
+    const CART_COUPON_ONCHECK = 'cart_coupon.oncheck';
+
+    /**
      * This event is dispatched each time a coupon is applied into a Cart
      *
      * event.name : cart_coupon.onapply

--- a/src/Elcodi/Component/CartCoupon/Event/CartCouponOnCheckEvent.php
+++ b/src/Elcodi/Component/CartCoupon/Event/CartCouponOnCheckEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Event;
+
+use Elcodi\Component\CartCoupon\Event\Abstracts\AbstractCartCouponEvent;
+
+/**
+ * Class CartCouponOnCheckEvent
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class CartCouponOnCheckEvent extends AbstractCartCouponEvent
+{
+}

--- a/src/Elcodi/Component/CartCoupon/EventDispatcher/CartCouponEventDispatcher.php
+++ b/src/Elcodi/Component/CartCoupon/EventDispatcher/CartCouponEventDispatcher.php
@@ -74,7 +74,7 @@ class CartCouponEventDispatcher extends AbstractEventDispatcher
     /**
      * Dispatch event when a coupon application is rejected
      *
-     * @param CartInterface   $cart   Cart where the coupon is going to be applied
+     * @param CartInterface   $cart   Cart where the coupon should be rejected
      * @param CouponInterface $coupon Rejected coupon
      *
      * @return $this Self object

--- a/src/Elcodi/Component/CartCoupon/EventDispatcher/CartCouponEventDispatcher.php
+++ b/src/Elcodi/Component/CartCoupon/EventDispatcher/CartCouponEventDispatcher.php
@@ -21,6 +21,7 @@ use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
 use Elcodi\Component\CartCoupon\ElcodiCartCouponEvents;
 use Elcodi\Component\CartCoupon\Entity\Interfaces\CartCouponInterface;
 use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
+use Elcodi\Component\CartCoupon\Event\CartCouponOnCheckEvent;
 use Elcodi\Component\CartCoupon\Event\CartCouponOnRejectedEvent;
 use Elcodi\Component\CartCoupon\Event\CartCouponOnRemoveEvent;
 use Elcodi\Component\Core\EventDispatcher\Abstracts\AbstractEventDispatcher;
@@ -31,6 +32,25 @@ use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
  */
 class CartCouponEventDispatcher extends AbstractEventDispatcher
 {
+    /**
+     * Dispatch event to check a coupon applies to a Cart
+     *
+     * @param CartInterface   $cart   Cart where the coupon should apply
+     * @param CouponInterface $coupon Coupon to be checked
+     *
+     * @return $this Self object
+     */
+    public function dispatchCartCouponOnCheckEvent(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        $event = new CartCouponOnCheckEvent($cart, $coupon);
+        $this->eventDispatcher->dispatch(
+            ElcodiCartCouponEvents::CART_COUPON_ONCHECK,
+            $event
+        );
+    }
+
     /**
      * Dispatch event just before a coupon is applied into a Cart
      *

--- a/src/Elcodi/Component/CartCoupon/EventListener/AutomaticCouponApplicatorListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/AutomaticCouponApplicatorListener.php
@@ -70,6 +70,10 @@ class AutomaticCouponApplicatorListener
     {
         $cart = $event->getCart();
 
+        if ($cart->getCartLines()->isEmpty()) {
+            return;
+        }
+
         /**
          * @var CouponInterface[] $automaticCoupons
          */

--- a/src/Elcodi/Component/CartCoupon/EventListener/AutomaticCouponApplicatorListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/AutomaticCouponApplicatorListener.php
@@ -86,6 +86,7 @@ class AutomaticCouponApplicatorListener
                 $this
                     ->cartCouponManager
                     ->addCoupon($cart, $coupon);
+
             } catch (AbstractCouponException $e) {
                 // Silently tries next coupon on controlled exception
             }

--- a/src/Elcodi/Component/CartCoupon/EventListener/AvoidDuplicatesListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/AvoidDuplicatesListener.php
@@ -22,9 +22,9 @@ use Elcodi\Component\CartCoupon\Exception\CouponAlreadyAppliedException;
 use Elcodi\Component\CartCoupon\Repository\CartCouponRepository;
 
 /**
- * Class CartCouponDuplicateListener
+ * Class AvoidDuplicatesListener
  */
-class CartCouponDuplicateListener
+class AvoidDuplicatesListener
 {
     /**
      * @var CartCouponRepository
@@ -50,12 +50,14 @@ class CartCouponDuplicateListener
      *
      * @throws CouponAlreadyAppliedException
      */
-    public function onCartCouponApply(CartCouponOnApplyEvent $event)
+    public function checkDuplicates(CartCouponOnApplyEvent $event)
     {
-        $cartCoupon = $this->cartCouponRepository->findOneBy([
-            'cart' => $event->getCart(),
-            'coupon' => $event->getCoupon(),
-        ]);
+        $cartCoupon = $this
+            ->cartCouponRepository
+            ->findOneBy([
+                'cart' => $event->getCart(),
+                'coupon' => $event->getCoupon(),
+            ]);
 
         if (null !== $cartCoupon) {
             throw new CouponAlreadyAppliedException();

--- a/src/Elcodi/Component/CartCoupon/EventListener/CartCouponManagerListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CartCouponManagerListener.php
@@ -24,11 +24,11 @@ use Elcodi\Component\CartCoupon\Event\CartCouponOnRemoveEvent;
 use Elcodi\Component\CartCoupon\Factory\CartCouponFactory;
 
 /**
- * Class CartCouponEventListener
+ * Class CartCouponManagerListener
  *
  * These Event Listeners are
  */
-class CartCouponEventListener
+class CartCouponManagerListener
 {
     /**
      * @var ObjectManager
@@ -72,13 +72,19 @@ class CartCouponEventListener
          * We create a new instance of CartCoupon.
          * We also persist and flush relation
          */
-        $cartCoupon = $this->cartCouponFactory->create();
-        $cartCoupon
+        $cartCoupon = $this
+            ->cartCouponFactory
+            ->create()
             ->setCart($cart)
             ->setCoupon($coupon);
 
-        $this->cartCouponObjectManager->persist($cartCoupon);
-        $this->cartCouponObjectManager->flush();
+        $this
+            ->cartCouponObjectManager
+            ->persist($cartCoupon);
+
+        $this
+            ->cartCouponObjectManager
+            ->flush($cartCoupon);
 
         $event->setCartCoupon($cartCoupon);
     }
@@ -92,7 +98,12 @@ class CartCouponEventListener
     {
         $cartCoupon = $event->getCartCoupon();
 
-        $this->cartCouponObjectManager->remove($cartCoupon);
-        $this->cartCouponObjectManager->flush();
+        $this
+            ->cartCouponObjectManager
+            ->remove($cartCoupon);
+
+        $this
+            ->cartCouponObjectManager
+            ->flush($cartCoupon);
     }
 }

--- a/src/Elcodi/Component/CartCoupon/EventListener/CartCouponRulesEventListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CartCouponRulesEventListener.php
@@ -18,7 +18,6 @@
 namespace Elcodi\Component\CartCoupon\EventListener;
 
 use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
-use Elcodi\Component\CartCoupon\EventDispatcher\CartCouponEventDispatcher;
 use Elcodi\Component\CartCoupon\Exception\CouponRulesNotValidateException;
 use Elcodi\Component\CartCoupon\Services\CartCouponRuleManager;
 
@@ -35,46 +34,32 @@ class CartCouponRulesEventListener
     protected $cartCouponRuleManager;
 
     /**
-     * @var CartCouponEventDispatcher
-     *
-     * CartCoupon Event Dispatcher
-     */
-    protected $cartCouponEventDispatcher;
-
-    /**
      * Construct method
      *
      * @param CartCouponRuleManager     $cartCouponRuleManager     Manager for cart coupon rules
-     * @param CartCouponEventDispatcher $cartCouponEventDispatcher Dispatcher for cart coupon events
      */
-    public function __construct(
-        CartCouponRuleManager $cartCouponRuleManager,
-        CartCouponEventDispatcher $cartCouponEventDispatcher
-    ) {
+    public function __construct(CartCouponRuleManager $cartCouponRuleManager)
+    {
         $this->cartCouponRuleManager = $cartCouponRuleManager;
-        $this->cartCouponEventDispatcher = $cartCouponEventDispatcher;
     }
 
     /**
-     * Applies Coupon in Cart, and flushes it
+     * Check for the rules required by the coupon
      *
      * @param CartCouponOnApplyEvent $event Event
      *
      * @throws CouponRulesNotValidateException
      */
-    public function onCartCouponApply(CartCouponOnApplyEvent $event)
+    public function checkCoupon(CartCouponOnApplyEvent $event)
     {
-        $cart = $event->getCart();
-        $coupon = $event->getCoupon();
+        $isValid = $this
+            ->cartCouponRuleManager
+            ->checkCouponValidity(
+                $event->getCart(),
+                $event->getCoupon()
+            );
 
-        if (!$this->cartCouponRuleManager->checkCouponValidity($cart, $coupon)) {
-            $this
-                ->cartCouponEventDispatcher
-                ->dispatchCartCouponOnRejectedEvent(
-                    $cart,
-                    $coupon
-                );
-
+        if (!$isValid) {
             throw new CouponRulesNotValidateException();
         }
     }

--- a/src/Elcodi/Component/CartCoupon/EventListener/CartCouponRulesEventListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CartCouponRulesEventListener.php
@@ -17,7 +17,7 @@
 
 namespace Elcodi\Component\CartCoupon\EventListener;
 
-use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
+use Elcodi\Component\CartCoupon\Event\CartCouponOnCheckEvent;
 use Elcodi\Component\CartCoupon\Exception\CouponRulesNotValidateException;
 use Elcodi\Component\CartCoupon\Services\CartCouponRuleManager;
 
@@ -46,11 +46,11 @@ class CartCouponRulesEventListener
     /**
      * Check for the rules required by the coupon
      *
-     * @param CartCouponOnApplyEvent $event Event
+     * @param CartCouponOnCheckEvent $event Event
      *
      * @throws CouponRulesNotValidateException
      */
-    public function checkCoupon(CartCouponOnApplyEvent $event)
+    public function checkCoupon(CartCouponOnCheckEvent $event)
     {
         $isValid = $this
             ->cartCouponRuleManager

--- a/src/Elcodi/Component/CartCoupon/EventListener/CheckCartCouponListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CheckCartCouponListener.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\EventListener;
+
+use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
+use Elcodi\Component\CartCoupon\EventDispatcher\CartCouponEventDispatcher;
+use Elcodi\Component\CartCoupon\Repository\CartCouponRepository;
+
+/**
+ * Class CheckCartCouponListener
+ */
+class CheckCartCouponListener
+{
+    /**
+     * @var CartCouponRepository
+     *
+     * CartCoupon Repository
+     */
+    protected $cartCouponDispatcher;
+
+    /**
+     * Construct method
+     *
+     * @param CartCouponEventDispatcher $cartCouponDispatcher Event dispatcher for CartCoupon
+     */
+    public function __construct(CartCouponEventDispatcher $cartCouponDispatcher)
+    {
+        $this->cartCouponDispatcher = $cartCouponDispatcher;
+    }
+
+    /**
+     * Checks if a Coupon is applicable to a Cart
+     *
+     * @param CartCouponOnApplyEvent $event
+     *
+     * @return bool true if the coupon applies, false otherwise
+     *
+     */
+    public function checkCoupon(CartCouponOnApplyEvent $event)
+    {
+        $this
+            ->cartCouponDispatcher
+            ->dispatchCartCouponOnCheckEvent(
+                $event->getCart(),
+                $event->getCoupon()
+            );
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/EventListener/CheckCouponEventListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CheckCouponEventListener.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Elcodi package.
  *
@@ -18,6 +19,7 @@ namespace Elcodi\Component\CartCoupon\EventListener;
 
 use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
 use Elcodi\Component\Coupon\Exception\Abstracts\AbstractCouponException;
+use Elcodi\Component\Coupon\Exception\CouponIncompatibleException;
 use Elcodi\Component\Coupon\Services\CouponManager;
 
 /**
@@ -51,8 +53,15 @@ class CheckCouponEventListener
      */
     public function checkCoupon(CartCouponOnApplyEvent $event)
     {
+        if ($event->getCart()->getQuantity() === 0) {
+
+            throw new CouponIncompatibleException();
+        }
+
         $coupon = $event->getCoupon();
 
-        $this->couponManager->checkCoupon($coupon);
+        $this
+            ->couponManager
+            ->checkCoupon($coupon);
     }
 }

--- a/src/Elcodi/Component/CartCoupon/EventListener/CheckCouponEventListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CheckCouponEventListener.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+
+namespace Elcodi\Component\CartCoupon\EventListener;
+
+use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
+use Elcodi\Component\Coupon\Exception\Abstracts\AbstractCouponException;
+use Elcodi\Component\Coupon\Services\CouponManager;
+
+/**
+ * Class CheckCouponEventListener
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class CheckCouponEventListener
+{
+    /**
+     * @var CouponManager
+     */
+    protected $couponManager;
+
+    /**
+     * Constructor
+     *
+     * @param CouponManager $couponManager
+     */
+    public function __construct(CouponManager $couponManager)
+    {
+        $this->couponManager = $couponManager;
+    }
+
+    /**
+     * Check if cart meets basic requirements for a coupon
+     *
+     * @param CartCouponOnApplyEvent $event
+     *
+     * @throws AbstractCouponException
+     */
+    public function checkCoupon(CartCouponOnApplyEvent $event)
+    {
+        $coupon = $event->getCoupon();
+
+        $this->couponManager->checkCoupon($coupon);
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/EventListener/CheckCouponListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CheckCouponListener.php
@@ -17,17 +17,17 @@
 
 namespace Elcodi\Component\CartCoupon\EventListener;
 
-use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
+use Elcodi\Component\CartCoupon\Event\CartCouponOnCheckEvent;
 use Elcodi\Component\Coupon\Exception\Abstracts\AbstractCouponException;
 use Elcodi\Component\Coupon\Exception\CouponIncompatibleException;
 use Elcodi\Component\Coupon\Services\CouponManager;
 
 /**
- * Class CheckCouponEventListener
+ * Class CheckCouponListener
  *
  * @author Berny Cantos <be@rny.cc>
  */
-class CheckCouponEventListener
+class CheckCouponListener
 {
     /**
      * @var CouponManager
@@ -47,11 +47,11 @@ class CheckCouponEventListener
     /**
      * Check if cart meets basic requirements for a coupon
      *
-     * @param CartCouponOnApplyEvent $event
+     * @param CartCouponOnCheckEvent $event
      *
      * @throws AbstractCouponException
      */
-    public function checkCoupon(CartCouponOnApplyEvent $event)
+    public function checkCoupon(CartCouponOnCheckEvent $event)
     {
         if ($event->getCart()->getQuantity() === 0) {
 

--- a/src/Elcodi/Component/CartCoupon/EventListener/CheckRulesListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CheckRulesListener.php
@@ -22,9 +22,9 @@ use Elcodi\Component\CartCoupon\Exception\CouponRulesNotValidateException;
 use Elcodi\Component\CartCoupon\Services\CartCouponRuleManager;
 
 /**
- * Class CartCouponRulesEventListener
+ * Class CheckRulesListener
  */
-class CartCouponRulesEventListener
+class CheckRulesListener
 {
     /**
      * @var CartCouponRuleManager

--- a/src/Elcodi/Component/CartCoupon/EventListener/ConvertToOrderCouponsListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/ConvertToOrderCouponsListener.php
@@ -29,9 +29,9 @@ use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
 use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
 
 /**
- * Class OrderEventListener
+ * Class ConvertToOrderCouponsListener
  */
-class OrderEventListener
+class ConvertToOrderCouponsListener
 {
     /**
      * @var OrderCouponEventDispatcher
@@ -88,7 +88,7 @@ class OrderEventListener
      *
      * @param OrderOnCreatedEvent $orderOnCreatedEvent OrderOnCreated Event
      */
-    public function onOrderOnCreatedEvent(OrderOnCreatedEvent $orderOnCreatedEvent)
+    public function convertCoupontToOrder(OrderOnCreatedEvent $orderOnCreatedEvent)
     {
         $order = $orderOnCreatedEvent->getOrder();
         $cart = $orderOnCreatedEvent->getCart();
@@ -99,9 +99,11 @@ class OrderEventListener
         }
 
         /**
-         * @var Collection $coupons
+         * @var CouponInterface[]|Collection $coupons
          */
-        $coupons = $this->cartCouponManager->getCoupons($cart);
+        $coupons = $this
+            ->cartCouponManager
+            ->getCoupons($cart);
 
         if ($coupons->isEmpty()) {
             return;
@@ -116,7 +118,7 @@ class OrderEventListener
         /**
          * An event is dispatched for each convertible coupon
          */
-        $coupons->map(function (CouponInterface $coupon) use ($order) {
+        foreach ($coupons as $coupon) {
 
             $this
                 ->orderCouponEventDispatcher
@@ -124,7 +126,7 @@ class OrderEventListener
                     $order,
                     $coupon
                 );
-        });
+        }
     }
 
     /**

--- a/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponEventListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponEventListener.php
@@ -16,7 +16,7 @@
 
 namespace Elcodi\Component\CartCoupon\EventListener;
 
-use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
+use Elcodi\Component\CartCoupon\Event\CartCouponOnCheckEvent;
 use Elcodi\Component\Coupon\Exception\CouponBelowMinimumPurchaseException;
 use Elcodi\Component\Currency\Services\CurrencyConverter;
 
@@ -43,11 +43,11 @@ class MinimumPriceCouponEventListener
     /**
      * Check if cart meets minimum price requirements for a coupon
      *
-     * @param CartCouponOnApplyEvent $event
+     * @param CartCouponOnCheckEvent $event
      *
      * @throws CouponBelowMinimumPurchaseException
      */
-    public function checkMinimumPrice(CartCouponOnApplyEvent $event)
+    public function checkMinimumPrice(CartCouponOnCheckEvent $event)
     {
         $couponMinimumPrice = $event
             ->getCoupon()

--- a/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponEventListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponEventListener.php
@@ -18,7 +18,6 @@ namespace Elcodi\Component\CartCoupon\EventListener;
 
 use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
 use Elcodi\Component\Coupon\Exception\CouponBelowMinimumPurchaseException;
-use Elcodi\Component\Currency\Entity\NullMoney;
 use Elcodi\Component\Currency\Services\CurrencyConverter;
 
 /**
@@ -50,17 +49,18 @@ class MinimumPriceCouponEventListener
      */
     public function checkMinimumPrice(CartCouponOnApplyEvent $event)
     {
-        $couponMinimumPrice = $event->getCoupon()->getMinimumPurchase();
+        $couponMinimumPrice = $event
+            ->getCoupon()
+            ->getMinimumPurchase();
+
         if ($couponMinimumPrice->getAmount() === 0) {
 
             return;
         }
 
-        $productMoney = $event->getCart()->getProductAmount();
-        if ($productMoney->getAmount() === 0) {
-
-            return;
-        }
+        $productMoney = $event
+            ->getCart()
+            ->getProductAmount();
 
         if ($couponMinimumPrice->getCurrency() != $productMoney->getCurrency()) {
             $couponMinimumPrice = $this

--- a/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponEventListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponEventListener.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ */
+
+
+namespace Elcodi\Component\CartCoupon\EventListener;
+
+use Elcodi\Component\CartCoupon\Event\CartCouponOnApplyEvent;
+use Elcodi\Component\Coupon\Exception\CouponBelowMinimumPurchaseException;
+use Elcodi\Component\Currency\Entity\NullMoney;
+use Elcodi\Component\Currency\Services\CurrencyConverter;
+
+/**
+ * Class MinimumPriceCouponEventListener
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class MinimumPriceCouponEventListener
+{
+    /**
+     * @var CurrencyConverter
+     */
+    protected $currencyConverter;
+
+    /**
+     * @param $currencyConverter
+     */
+    public function __construct($currencyConverter)
+    {
+        $this->currencyConverter = $currencyConverter;
+    }
+
+    /**
+     * Check if cart meets minimum price requirements for a coupon
+     *
+     * @param CartCouponOnApplyEvent $event
+     *
+     * @throws CouponBelowMinimumPurchaseException
+     */
+    public function checkMinimumPrice(CartCouponOnApplyEvent $event)
+    {
+        $couponMinimumPrice = $event->getCoupon()->getMinimumPurchase();
+        if ($couponMinimumPrice->getAmount() === 0) {
+
+            return;
+        }
+
+        $productMoney = $event->getCart()->getProductAmount();
+        if ($productMoney->getAmount() === 0) {
+
+            return;
+        }
+
+        if ($couponMinimumPrice->getCurrency() != $productMoney->getCurrency()) {
+            $couponMinimumPrice = $this
+                ->currencyConverter
+                ->convertMoney(
+                    $couponMinimumPrice,
+                    $productMoney->getCurrency()
+                );
+        }
+
+        if ($productMoney->isLessThan($couponMinimumPrice)) {
+
+            throw new CouponBelowMinimumPurchaseException();
+        }
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponListener.php
@@ -21,11 +21,11 @@ use Elcodi\Component\Coupon\Exception\CouponBelowMinimumPurchaseException;
 use Elcodi\Component\Currency\Services\CurrencyConverter;
 
 /**
- * Class MinimumPriceCouponEventListener
+ * Class MinimumPriceCouponListener
  *
  * @author Berny Cantos <be@rny.cc>
  */
-class MinimumPriceCouponEventListener
+class MinimumPriceCouponListener
 {
     /**
      * @var CurrencyConverter

--- a/src/Elcodi/Component/CartCoupon/EventListener/OrderCouponManagerListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/OrderCouponManagerListener.php
@@ -24,11 +24,11 @@ use Elcodi\Component\CartCoupon\Factory\OrderCouponFactory;
 use Elcodi\Component\Coupon\EventDispatcher\CouponEventDispatcher;
 
 /**
- * Class OrderCouponEventListener
+ * Class OrderCouponManagerListener
  *
  * This eventListener is subscribed into OpenCoupon events.
  */
-class OrderCouponEventListener
+class OrderCouponManagerListener
 {
     /**
      * @var ObjectManager
@@ -78,21 +78,27 @@ class OrderCouponEventListener
      *
      * @param OrderCouponOnApplyEvent $event Event
      */
-    public function onOrderCouponApply(OrderCouponOnApplyEvent $event)
+    public function convertToOrderCoupons(OrderCouponOnApplyEvent $event)
     {
         $order = $event->getOrder();
         $coupon = $event->getCoupon();
 
-        $orderCoupon = $this->orderCouponFactory->create();
-        $orderCoupon
+        $orderCoupon = $this
+            ->orderCouponFactory
+            ->create()
             ->setOrder($order)
             ->setCoupon($coupon)
             ->setAmount($coupon->getAbsolutePrice())
             ->setName($coupon->getName())
             ->setCode($coupon->getCode());
 
-        $this->orderCouponObjectManager->persist($orderCoupon);
-        $this->orderCouponObjectManager->flush($orderCoupon);
+        $this
+            ->orderCouponObjectManager
+            ->persist($orderCoupon);
+
+        $this
+            ->orderCouponObjectManager
+            ->flush($orderCoupon);
 
         $this
             ->couponEventDispatcher

--- a/src/Elcodi/Component/CartCoupon/EventListener/RefreshCouponsListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/RefreshCouponsListener.php
@@ -19,8 +19,6 @@ namespace Elcodi\Component\CartCoupon\EventListener;
 
 use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
 use Elcodi\Component\Cart\Event\CartOnLoadEvent;
-use Elcodi\Component\Cart\Event\CartPreLoadEvent;
-use Elcodi\Component\CartCoupon\Entity\Interfaces\CartCouponInterface;
 use Elcodi\Component\CartCoupon\EventDispatcher\CartCouponEventDispatcher;
 use Elcodi\Component\CartCoupon\Services\CartCouponManager;
 use Elcodi\Component\Coupon\ElcodiCouponTypes;

--- a/src/Elcodi/Component/CartCoupon/EventListener/RefreshCouponsListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/RefreshCouponsListener.php
@@ -33,12 +33,12 @@ use Elcodi\Component\Currency\Services\CurrencyConverter;
 use Elcodi\Component\Currency\Wrapper\CurrencyWrapper;
 
 /**
- * Class RefreshCartListener
+ * Class RefreshCouponsListener
  *
  * This event listener should update the cart given in the event, applying
  * all the coupon features.
  */
-class RefreshCartListener
+class RefreshCouponsListener
 {
     /**
      * @var CouponManager
@@ -99,21 +99,18 @@ class RefreshCartListener
     }
 
     /**
-     * Method subscribed to PreCartLoad event
+     * Method subscribed to CartLoad event
      *
      * Checks if all Coupons applied to current cart are still valid.
      * If are not, they will be deleted from the Cart and new Event typeof
      * CartCouponOnRejected will be dispatched
      *
-     * @param CartPreLoadEvent $cartPreLoadEvent Event
+     * @param CartOnLoadEvent $event Event
      */
-    public function onCartPreLoadCoupons(CartPreLoadEvent $cartPreLoadEvent)
+    public function refreshCartCoupons(CartOnLoadEvent $event)
     {
-        $cart = $cartPreLoadEvent->getCart();
+        $cart = $event->getCart();
 
-        /**
-         * @var CartCouponInterface[] $cartCoupons
-         */
         $cartCoupons = $this
             ->cartCouponManager
             ->getCartCoupons($cart);
@@ -155,22 +152,21 @@ class RefreshCartListener
      * Calculates coupons price given actual Cart, and overrides Cart price
      * given new information.
      *
-     * @param CartOnLoadEvent $cartOnLoadEvent Event
+     * @param CartOnLoadEvent $event
      */
-    public function onCartLoadCoupons(CartOnLoadEvent $cartOnLoadEvent)
+    public function refreshCouponAmount(CartOnLoadEvent $event)
     {
-        $cart = $cartOnLoadEvent->getCart();
+        $cart = $event->getCart();
+
         $couponAmount = Money::create(
             0,
             $this->currencyWrapper->loadCurrency()
         );
+
         $coupons = $this
             ->cartCouponManager
             ->getCoupons($cart);
 
-        /**
-         * @var CouponInterface $coupon
-         */
         foreach ($coupons as $coupon) {
             $currentCouponAmount = $this
                 ->getPriceCoupon(

--- a/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
+++ b/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
@@ -26,6 +26,7 @@ use Elcodi\Component\CartCoupon\EventDispatcher\CartCouponEventDispatcher;
 use Elcodi\Component\CartCoupon\Repository\CartCouponRepository;
 use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
 use Elcodi\Component\Coupon\Exception\Abstracts\AbstractCouponException;
+use Elcodi\Component\Coupon\Exception\CouponNotAvailableException;
 use Elcodi\Component\Coupon\Repository\CouponRepository;
 use Elcodi\Component\Coupon\Services\CouponManager;
 
@@ -34,14 +35,6 @@ use Elcodi\Component\Coupon\Services\CouponManager;
  *
  * This class aims to be a bridge between Coupons and Carts.
  * Manages all coupons instances inside Carts
- *
- * Public methods:
- *
- * getCartCoupons(CartInterface) : Collection
- * addCouponByCode(CartInterface, $couponCode) : self
- * removeCouponByCode(CartInterface, $couponCode) : self
- * addCoupon(CartInterface, CouponInterface) : self
- * removeCoupon(CartInterface, CouponInterface) : self
  */
 class CartCouponManager
 {
@@ -176,8 +169,9 @@ class CartCouponManager
                 'enabled' => true,
             ));
 
-        if (!($coupon instanceof CouponInterface)) {
-            return false;
+        if (false === $coupon instanceof CouponInterface) {
+
+            throw new CouponNotAvailableException();
         }
 
         return $this->addCoupon($cart, $coupon);

--- a/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
+++ b/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
@@ -91,7 +91,7 @@ class CartCouponManager
      *
      * @param CartInterface $cart Cart
      *
-     * @return Collection OrderCoupons
+     * @return CartCouponInterface[]|Collection OrderCoupons
      */
     public function getCartCoupons(CartInterface $cart)
     {

--- a/src/Elcodi/Component/CartCoupon/Services/CartCouponRuleManager.php
+++ b/src/Elcodi/Component/CartCoupon/Services/CartCouponRuleManager.php
@@ -63,6 +63,7 @@ class CartCouponRuleManager
         }
 
         try {
+
             return $this
                 ->ruleManager
                 ->evaluate(
@@ -72,9 +73,11 @@ class CartCouponRuleManager
                         'coupon' => $coupon,
                     ]
                 );
+
         } catch (\Exception $e) {
             // Maybe log something in case of exception?
-            return false;
         }
+
+        return false;
     }
 }

--- a/src/Elcodi/Component/Configuration/ExpressionLanguage/ConfigurationExpressionLanguageProvider.php
+++ b/src/Elcodi/Component/Configuration/ExpressionLanguage/ConfigurationExpressionLanguageProvider.php
@@ -33,12 +33,12 @@ class ConfigurationExpressionLanguageProvider implements ExpressionFunctionProvi
         return array(
             new ExpressionFunction('elcodi_config', function ($name) {
                 return sprintf(
-                    '$this->get(\'elcodi.configuration_manager\')->get(%s)',
+                    '$this->get(\'elcodi.manager.configuration\')->get(%s)',
                     $name
                 );
             }, function (array $variables, $name) {
                 return $variables['container']
-                    ->get('elcodi.configuration_manager')
+                    ->get('elcodi.manager.configuration')
                     ->get($name);
             }),
         );

--- a/src/Elcodi/Component/Coupon/Entity/Coupon.php
+++ b/src/Elcodi/Component/Coupon/Entity/Coupon.php
@@ -460,9 +460,9 @@ class Coupon implements CouponInterface
      */
     public function makeUse()
     {
-        $this->used++;
+        ++$this->used;
 
-        if ($this->count <= $this->used) {
+        if ($this->count > 0 && $this->count <= $this->used) {
             $this->enabled = false;
         }
 

--- a/src/Elcodi/Component/Coupon/Factory/CouponFactory.php
+++ b/src/Elcodi/Component/Coupon/Factory/CouponFactory.php
@@ -53,6 +53,7 @@ class CouponFactory extends AbstractPurchasableFactory
             ->setMinimumPurchase($zeroPrice)
             ->setEnforcement(ElcodiCouponTypes::ENFORCEMENT_MANUAL)
             ->setUsed(0)
+            ->setCount(0)
             ->setPriority(0)
             ->setEnabled(false)
             ->setCreatedAt($now)

--- a/src/Elcodi/Component/Coupon/Services/CouponManager.php
+++ b/src/Elcodi/Component/Coupon/Services/CouponManager.php
@@ -210,7 +210,7 @@ class CouponManager
     {
         $count = $coupon->getCount();
 
-        if ($count === null) {
+        if ($count === 0) {
             return true;
         }
 

--- a/src/Elcodi/Component/Coupon/Services/CouponManager.php
+++ b/src/Elcodi/Component/Coupon/Services/CouponManager.php
@@ -125,6 +125,7 @@ class CouponManager
             ->setValidFrom($dateFrom)
             ->setValidTo($dateTo)
             ->setRule($coupon->getRule())
+            ->setEnforcement($coupon->getEnforcement())
             ->setEnabled(true);
 
         return $couponGenerated;

--- a/src/Elcodi/Component/Coupon/Services/CouponManager.php
+++ b/src/Elcodi/Component/Coupon/Services/CouponManager.php
@@ -23,7 +23,6 @@ use Elcodi\Component\Core\Generator\Interfaces\GeneratorInterface;
 use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
 use Elcodi\Component\Coupon\Exception\Abstracts\AbstractCouponException;
 use Elcodi\Component\Coupon\Exception\CouponAppliedException;
-use Elcodi\Component\Coupon\Exception\CouponBelowMinimumPurchaseException;
 use Elcodi\Component\Coupon\Exception\CouponNotActiveException;
 use Elcodi\Component\Coupon\Factory\CouponFactory;
 
@@ -31,11 +30,6 @@ use Elcodi\Component\Coupon\Factory\CouponFactory;
  * Coupon manager service
  *
  * Manages all coupon actions
- *
- * Public methods:
- *
- * * checkCoupon(CouponInterface, $price)
- * * duplicateCoupon(CouponInterface)
  */
 class CouponManager
 {
@@ -135,13 +129,12 @@ class CouponManager
      * Checks whether a coupon can be applied or not.
      *
      * @param CouponInterface $coupon Coupon to work with
-     * @param float           $price  Price
      *
      * @return boolean Coupon can be applied
      *
      * @throws AbstractCouponException
      */
-    protected function checkCoupon(CouponInterface $coupon, $price)
+    public function checkCoupon(CouponInterface $coupon)
     {
         if (!$this->IsActive($coupon)) {
             throw new CouponNotActiveException();
@@ -149,21 +142,6 @@ class CouponManager
 
         if (!$this->canBeUsed($coupon)) {
             throw new CouponAppliedException();
-        }
-
-        /**
-         * check if coupon still can be applied
-         */
-        $count = $coupon->getCount();
-        if (null !== $count && $count > $coupon->getUsed()) {
-            throw new CouponAppliedException();
-        }
-
-        /**
-         * you cannot add this coupon, too cheap
-         */
-        if ($coupon->getMinimumPurchase()->getAmount() > $price) {
-            throw new CouponBelowMinimumPurchaseException();
         }
 
         return true;

--- a/src/Elcodi/Component/Coupon/Services/CouponManager.php
+++ b/src/Elcodi/Component/Coupon/Services/CouponManager.php
@@ -150,10 +150,6 @@ class CouponManager
             throw new CouponAppliedException();
         }
 
-        if (!$this->isApplicable($coupon)) {
-            throw new CouponBelowMinimumPurchaseException();
-        }
-
         /**
          * check if coupon still can be applied
          */

--- a/src/Elcodi/Component/Media/Router/ImageResizeRouterLoader.php
+++ b/src/Elcodi/Component/Media/Router/ImageResizeRouterLoader.php
@@ -82,7 +82,7 @@ class ImageResizeRouterLoader implements LoaderInterface
         $routes = new RouteCollection();
 
         $routes->add($this->imageResizeControllerRouteName, new Route($this->imageResizeControllerRoute, array(
-            '_controller' => 'elcodi.core.media.controller.image_resize:resizeAction',
+            '_controller' => 'elcodi.controller.media_image_resize:resizeAction',
         )));
 
         $this->loaded = true;

--- a/src/Elcodi/Component/Media/Router/ImageUploadRouterLoader.php
+++ b/src/Elcodi/Component/Media/Router/ImageUploadRouterLoader.php
@@ -81,7 +81,7 @@ class ImageUploadRouterLoader implements LoaderInterface
 
         $routes = new RouteCollection();
         $routes->add($this->imageUploadControllerRouteName, new Route($this->imageUploadControllerRoute, array(
-            '_controller' => 'elcodi.core.media.controller.image_upload:uploadAction',
+            '_controller' => 'elcodi.controller.media_image_upload:uploadAction',
         )));
 
         $this->loaded = true;

--- a/src/Elcodi/Component/Media/Router/ImageViewRouterLoader.php
+++ b/src/Elcodi/Component/Media/Router/ImageViewRouterLoader.php
@@ -84,7 +84,7 @@ class ImageViewRouterLoader implements LoaderInterface
         $routes = new RouteCollection();
 
         $routes->add($this->imageViewControllerRouteName, new Route($this->imageViewControllerRoute, array(
-            '_controller' => 'elcodi.core.media.controller.image_resize:resizeAction',
+            '_controller' => 'elcodi.controller.media_image_resize:resizeAction',
             'height'      => 0,
             'width'       => 0,
             'type'        => ElcodiMediaImageResizeTypes::NO_RESIZE,

--- a/src/Elcodi/Component/ReferralProgram/Router/ReferralProgramRoutesLoader.php
+++ b/src/Elcodi/Component/ReferralProgram/Router/ReferralProgramRoutesLoader.php
@@ -79,7 +79,7 @@ class ReferralProgramRoutesLoader implements LoaderInterface
 
         $routes = new RouteCollection();
         $routes->add($this->controllerRouteName, new Route($this->controllerRoute, array(
-            '_controller' => 'elcodi.core.referral_program.controller.referral_program:trackAction',
+            '_controller' => 'elcodi.controller.referral_program:trackAction',
         )));
 
         $this->loaded = true;


### PR DESCRIPTION
- Unlimited usage of coupon when `count` is `0`.
- `Coupon::used` is now an integer.
- check for availability, minimum price and rule validation in separated listeners. 
- avoid duplicated coupons.
- add `cart_coupon.oncheck` event for checking coupons.
- shorten service names.
- Fixes dependencies for `--prefer-lowest`.