### PR TITLE
Rename `getConfiguration` to `elcodi_config` in twig

### DIFF
--- a/src/Elcodi/Bundle/BambooBundle/Resources/views/Page/layout.html.twig
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/views/Page/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends getConfiguration('store.template') ~ '::Layout/_static.html.twig' %}
+{% extends elcodi_config('store.template') ~ '::Layout/_static.html.twig' %}
 
 
 {% block title %}{{ page.title }}{% endblock title %}

--- a/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
+++ b/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
@@ -55,7 +55,7 @@ class ConfigurationExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            new Twig_SimpleFunction('getConfiguration', array($this, 'getParameter')),
+            new Twig_SimpleFunction('elcodi_config', array($this, 'getParameter')),
         );
     }
 


### PR DESCRIPTION
Fixes #447

Remember to start using `elcodi_config` instead in your templates.