### PR TITLE
Makes default currency writable

### DIFF
--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/configuration.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/configuration.yml
@@ -115,4 +115,4 @@ elcodi_configuration:
             namespace: currency
             type: string
             reference: elcodi.core.currency.default_currency
-            read_only: true
+            read_only: false


### PR DESCRIPTION
Default currency is marked as `read-only` and can't be changed from services.

This also brings another problem: when an ajax request fails (like this one did, sending back a 500 HTTP error), the admin should warn the user, but now it makes him wait forever. Ping @tonipinel 