### PR TITLE
Add official twig extension for text

### DIFF
--- a/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
+++ b/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
@@ -117,6 +117,7 @@ class ElcodiBambooExtension extends AbstractExtension
 
         return [
             'services',
+            'twig',
             [
                 'emails/customerPasswordRemember',
                 $config['emails']['customer_password_remember']['enabled'],

--- a/src/Elcodi/Bundle/BambooBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/BambooBundle/Resources/config/twig.yml
@@ -1,0 +1,9 @@
+services:
+
+    #
+    # Twig extensions
+    #
+    twig.extension.text:
+        class: Twig_Extensions_Extension_Text
+        tags:
+            - { name: twig.extension }


### PR DESCRIPTION
Was defined in `AdminCoreExtension` and `StoreCoreExtension`. Moved from there.