### PR TITLE
fixed default sha1Generator lenght

### DIFF
--- a/src/Elcodi/Component/Core/Generator/Sha1Generator.php
+++ b/src/Elcodi/Component/Core/Generator/Sha1Generator.php
@@ -50,7 +50,7 @@ class Sha1Generator implements GeneratorInterface
      *
      * @return string Result of generation
      */
-    public function generate($length = null)
+    public function generate($length = 1)
     {
         return hash("sha1", $this->generator->generate($length));
     }


### PR DESCRIPTION
otherwise it generates the same hash da39a3ee5e6b4b0d3255bfef95601890afd80709 (null)