### PR TITLE
Fixed wizard bug when the wizard is finished

### DIFF
--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Templating/TwigRenderer.php
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Templating/TwigRenderer.php
@@ -187,7 +187,14 @@ class TwigRenderer
                 ->wizardRoutes
                 ->isWizardSetupRoute($currentRoute);
 
-            if ($isWizardRoute) {
+            $isWizardFinished = $this
+                ->wizardStatus
+                ->isWizardFinished();
+
+            if (
+                $isWizardRoute &&
+                !$isWizardFinished
+            ) {
                 $currentStep = $this
                     ->wizardRoutes
                     ->getStepByRoute($currentRoute);


### PR DESCRIPTION
The mini wizard to go to the next page was shown when the wizard was already finished