### PR TITLE
Message on settings to disable under construction mode

### DIFF
--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/config/templating.yml
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/config/templating.yml
@@ -17,3 +17,4 @@ services:
             - { name: kernel.event_listener, event: admin.body_top, method: renderMiniWizard }
             - { name: kernel.event_listener, event: admin.body_top, method: renderEnableStoreMessage }
             - { name: kernel.event_listener, event: admin.body_top, method: renderGoNextStepMessage }
+            - { name: kernel.event_listener, event: admin.body_top, method: renderDisableUnderConstructionMode }

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/translations/messages.en.yml
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/translations/messages.en.yml
@@ -8,6 +8,7 @@ wizard:
     go_next_step: Go to next step
     step_finished: <strong>Yehaaaaa!</strong> One step less to go!
     time_to_sell: You are <strong>%1 minutes</strong> away to start selling
+    disable_under_construction: Disable the <strong>Under construction</strong> mode to start selling
     estimated_time: Estimated time %1 min
     step1:
         title: Add products

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/translations/messages.es.yml
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/translations/messages.es.yml
@@ -8,6 +8,7 @@ wizard:
     go_next_step: Ve al siguiente paso
     step_finished: <strong>¡Bravo!</strong> ¡Un paso menos para finalizar!
     time_to_sell: Estás a <strong>%1 minutos</strong> de empezar a vender
+    disable_under_construction: Desactiva el modo <strong>Tienda en construcción</strong> para empezar a vender
     estimated_time: Tiempo estimado %1 min
     step1:
         title: Añade un producto

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/views/Wizard/disable-under-construction.html.twig
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Resources/views/Wizard/disable-under-construction.html.twig
@@ -1,0 +1,3 @@
+<div class="msg-info">
+    <h3>{% trans %}wizard.disable_under_construction{% endtrans %}</h3>
+</div>

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Templating/TwigRenderer.php
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Templating/TwigRenderer.php
@@ -230,6 +230,37 @@ class TwigRenderer
     }
 
     /**
+     * Render the disable under construction mode.
+     *
+     * @param EventInterface $event The event
+     */
+    public function renderDisableUnderConstructionMode(EventInterface $event)
+    {
+        if ($this->plugin->isEnabled()) {
+            $masterRequest = $this
+                ->requestStack
+                ->getMasterRequest();
+            $currentRoute  = $masterRequest
+                ->attributes
+                ->get('_route');
+
+            $isWizardFinished = $this
+                ->wizardStatus
+                ->isWizardFinished();
+
+            if (
+                'admin_configuration_list' == $currentRoute &&
+                $isWizardFinished
+            ) {
+                $this->appendTemplate(
+                    '@ElcodiStoreSetupWizard/Wizard/disable-under-construction.html.twig',
+                    $event
+                );
+            }
+        }
+    }
+
+    /**
      * Checks if the wizard is visible for this request.
      *
      * @return bool If visible


### PR DESCRIPTION
Added a message to remember you that the "under construction" mode should be disabled when the wizard is finished and the user visits the settings page.

Ping @elcodi/owners 