### PR TITLE
Fix database fixtures bug

### DIFF
--- a/src/Elcodi/Bundle/ProductBundle/DataFixtures/ORM/CategoryData.php
+++ b/src/Elcodi/Bundle/ProductBundle/DataFixtures/ORM/CategoryData.php
@@ -55,6 +55,7 @@ class CategoryData extends AbstractFixture
             ->setRoot(true);
 
         $manager->persist($rootCategory);
+        $categoryObjectManager->flush($rootCategory);
         $this->addReference('rootCategory', $rootCategory);
 
         /**
@@ -73,9 +74,6 @@ class CategoryData extends AbstractFixture
         $manager->persist($category);
         $this->addReference('category', $category);
 
-        $categoryObjectManager->flush([
-            $rootCategory,
-            $category,
-        ]);
+        $categoryObjectManager->flush($category);
     }
 }


### PR DESCRIPTION
[`NewCategoryPositionEventListener` from bamboo](https://github.com/elcodi/bamboo/blob/master/src/Elcodi/Admin/ProductBundle/EventListener/NewCategoryPositionEventListener.php#L51) fails as the $rootCategory doesn’t have an id yet:

```
[Doctrine\ORM\ORMInvalidArgumentException]
  Binding entities to query parameters only allowed for entities that have an identifier.
```