### PR TITLE
Fix Phpdoc inconsistencies/typos etc.

### DIFF
--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
@@ -58,8 +58,8 @@ class CartCouponRulesEventListenerTest extends WebTestCase
     /**
      * Tests coupon rules when all rules validate
      *
-     * @param array $expressions   One or more expressions, only the last one will be checked
-     * @param int   $couponsNumber Number of coupons that should apply
+     * @param array   $expressions   One or more expressions, only the last one will be checked
+     * @param integer $couponsNumber Number of coupons that should apply
      *
      * @dataProvider dataOnCartCouponApplyValidate
      */
@@ -117,8 +117,8 @@ class CartCouponRulesEventListenerTest extends WebTestCase
     /**
      * Tests coupon rules when all rules validate
      *
-     * @param array $expressions            One or more expressions, only the last one will be checked
-     * @param int   $appliedCouponsExpected Number of coupons that should apply
+     * @param array   $expressions            One or more expressions, only the last one will be checked
+     * @param integer $appliedCouponsExpected Number of coupons that should apply
      *
      * @dataProvider dataOnCartCouponApplyValidate
      */

--- a/src/Elcodi/Component/Attribute/Entity/Attribute.php
+++ b/src/Elcodi/Component/Attribute/Entity/Attribute.php
@@ -111,7 +111,7 @@ class Attribute implements AttributeInterface
     }
 
     /**
-     * Removes a value to this attribute collection
+     * Removes a value from this attribute collection
      *
      * @param ValueInterface $value
      *

--- a/src/Elcodi/Component/Attribute/Entity/Interfaces/AttributeInterface.php
+++ b/src/Elcodi/Component/Attribute/Entity/Interfaces/AttributeInterface.php
@@ -77,7 +77,7 @@ interface AttributeInterface
     public function addValue(ValueInterface $value);
 
     /**
-     * Removes a value to this attribute collection
+     * Removes a value from this attribute collection
      *
      * @param ValueInterface $value
      *

--- a/src/Elcodi/Component/Cart/Entity/Cart.php
+++ b/src/Elcodi/Component/Cart/Entity/Cart.php
@@ -148,7 +148,7 @@ class Cart implements CartInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -158,7 +158,7 @@ class Cart implements CartInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */
@@ -298,7 +298,7 @@ class Cart implements CartInterface
     /**
      * Set quantity
      *
-     * @param int $quantity Quantity
+     * @param integer $quantity Quantity
      *
      * @return $this Self object
      */
@@ -435,7 +435,7 @@ class Cart implements CartInterface
     /**
      * Return the maximum depth of all the cartLines
      *
-     * @return int Depth
+     * @return integer Depth
      */
     public function getDepth()
     {
@@ -451,7 +451,7 @@ class Cart implements CartInterface
     /**
      * Return the maximum height of all the cartLines
      *
-     * @return int Height
+     * @return integer Height
      */
     public function getHeight()
     {
@@ -467,7 +467,7 @@ class Cart implements CartInterface
     /**
      * Return the maximum width of all the cartLines
      *
-     * @return int Width
+     * @return integer Width
      */
     public function getWidth()
     {
@@ -483,7 +483,7 @@ class Cart implements CartInterface
     /**
      * Get the sum of all CartLines weight
      *
-     * @return int Weight
+     * @return integer Weight
      */
     public function getWeight()
     {

--- a/src/Elcodi/Component/Cart/Entity/CartLine.php
+++ b/src/Elcodi/Component/Cart/Entity/CartLine.php
@@ -98,7 +98,7 @@ class CartLine implements CartLineInterface
     /**
      * Return the purchasable object depth
      *
-     * @return int Depth
+     * @return integer Depth
      */
     public function getDepth()
     {
@@ -110,7 +110,7 @@ class CartLine implements CartLineInterface
     /**
      * Return the purchasable object height
      *
-     * @return int Height
+     * @return integer Height
      */
     public function getHeight()
     {
@@ -122,7 +122,7 @@ class CartLine implements CartLineInterface
     /**
      * Return the purchasable object width
      *
-     * @return int Width
+     * @return integer Width
      */
     public function getWidth()
     {
@@ -134,7 +134,7 @@ class CartLine implements CartLineInterface
     /**
      * Return the purchasable object weight
      *
-     * @return int Weight
+     * @return integer Weight
      */
     public function getWeight()
     {

--- a/src/Elcodi/Component/Cart/Entity/Interfaces/CartInterface.php
+++ b/src/Elcodi/Component/Cart/Entity/Interfaces/CartInterface.php
@@ -185,7 +185,7 @@ interface CartInterface
     /**
      * Sets the number of items on this cart
      *
-     * @param int $quantity Quantity
+     * @param integer $quantity Quantity
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Cart/Entity/Interfaces/OrderInterface.php
+++ b/src/Elcodi/Component/Cart/Entity/Interfaces/OrderInterface.php
@@ -99,7 +99,7 @@ interface OrderInterface extends PriceInterface, DimensionableInterface
     /**
      * Set quantity
      *
-     * @param int $quantity Quantity
+     * @param integer $quantity Quantity
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Cart/Entity/Interfaces/PriceInterface.php
+++ b/src/Elcodi/Component/Cart/Entity/Interfaces/PriceInterface.php
@@ -27,14 +27,14 @@ interface PriceInterface
     /**
      * Gets the product or products amount with tax
      *
-     * @return \Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface Product amount with tax
+     * @return MoneyInterface Product amount with tax
      */
     public function getProductAmount();
 
     /**
      * Sets the product or products amount with tax
      *
-     * @param \Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface $productAmount product amount with tax
+     * @param MoneyInterface $productAmount product amount with tax
      *
      * @return $this Self object
      */
@@ -43,14 +43,14 @@ interface PriceInterface
     /**
      * Gets the total amount with tax
      *
-     * @return \Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface price with tax
+     * @return MoneyInterface price with tax
      */
     public function getAmount();
 
     /**
      * Sets the total amount with tax
      *
-     * @param \Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface $amount amount without tax
+     * @param MoneyInterface $amount amount without tax
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Cart/Entity/Interfaces/PurchasableWrapperInterface.php
+++ b/src/Elcodi/Component/Cart/Entity/Interfaces/PurchasableWrapperInterface.php
@@ -78,7 +78,7 @@ interface PurchasableWrapperInterface
     /**
      * Sets quantity
      *
-     * @param int $quantity Quantity
+     * @param integer $quantity Quantity
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Cart/Entity/Order.php
+++ b/src/Elcodi/Component/Cart/Entity/Order.php
@@ -155,7 +155,7 @@ class Order implements OrderInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -165,7 +165,7 @@ class Order implements OrderInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */
@@ -281,7 +281,7 @@ class Order implements OrderInterface
     /**
      * Set quantity
      *
-     * @param int $quantity Quantity
+     * @param integer $quantity Quantity
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Cart/Entity/Traits/PriceTrait.php
+++ b/src/Elcodi/Component/Cart/Entity/Traits/PriceTrait.php
@@ -25,7 +25,7 @@ namespace Elcodi\Component\Cart\Entity\Traits;
  * A currency is needed so that a {@see Money} value object can be
  * exploited when doing currency arithmetics. When Currency is not
  * set, it is not possible to return a Money object, so getters
- * wil return null
+ * will return null
  */
 trait PriceTrait
 {

--- a/src/Elcodi/Component/Cart/Entity/Traits/PurchasableWrapperTrait.php
+++ b/src/Elcodi/Component/Cart/Entity/Traits/PurchasableWrapperTrait.php
@@ -132,7 +132,7 @@ trait PurchasableWrapperTrait
     /**
      * Sets quantity
      *
-     * @param int $quantity Quantity
+     * @param integer $quantity Quantity
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Cart/Event/Abstracts/AbstractOrderEvent.php
+++ b/src/Elcodi/Component/Cart/Event/Abstracts/AbstractOrderEvent.php
@@ -45,7 +45,7 @@ abstract class AbstractOrderEvent extends Event
      * construct method
      *
      * @param CartInterface  $cart  Cart
-     * @param OrderInterface $order The order created
+     * @param OrderInterface $order Order
      */
     public function __construct(
         CartInterface $cart,
@@ -66,7 +66,7 @@ abstract class AbstractOrderEvent extends Event
     }
 
     /**
-     * Return order stored
+     * Return order
      *
      * @return OrderInterface Order stored
      */

--- a/src/Elcodi/Component/CartCoupon/EventListener/CheckCartCouponListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/CheckCartCouponListener.php
@@ -48,7 +48,7 @@ class CheckCartCouponListener
      *
      * @param CartCouponOnApplyEvent $event
      *
-     * @return bool true if the coupon applies, false otherwise
+     * @return boolean true if the coupon applies, false otherwise
      *
      */
     public function checkCoupon(CartCouponOnApplyEvent $event)

--- a/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponListener.php
+++ b/src/Elcodi/Component/CartCoupon/EventListener/MinimumPriceCouponListener.php
@@ -34,7 +34,7 @@ class MinimumPriceCouponListener
     protected $currencyConverter;
 
     /**
-     * @param $currencyConverter
+     * @param CurrencyConverter $currencyConverter
      */
     public function __construct($currencyConverter)
     {

--- a/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
+++ b/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
@@ -97,7 +97,7 @@ class CartCouponManager
     {
         /**
          * If Cart id is null means that this cart has been generated from
-         * the scratch. This also means that cannot have any Coupon associated.
+         * scratch. This also means that it cannot have any Coupon associated.
          * If is this case, we avoid this lookup.
          */
         if ($cart->getId() === null) {
@@ -126,7 +126,7 @@ class CartCouponManager
     {
         /**
          * If Cart id is null means that this cart has been generated from
-         * the scratch. This also means that cannot have any Coupon associated.
+         * scratch. This also means that it cannot have any Coupon associated.
          * If is this case, we avoid this lookup.
          */
         if ($cart->getId() === null) {

--- a/src/Elcodi/Component/Comment/Controller/CommentController.php
+++ b/src/Elcodi/Component/Comment/Controller/CommentController.php
@@ -75,7 +75,7 @@ class CommentController
      * @param string $context Context
      * @param string $source  Source
      *
-     * @return array Comments
+     * @return Response Comments
      */
     public function listCommentsAction($context, $source)
     {

--- a/src/Elcodi/Component/Comment/Entity/Comment.php
+++ b/src/Elcodi/Component/Comment/Entity/Comment.php
@@ -110,7 +110,7 @@ class Comment implements CommentInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */
@@ -124,7 +124,7 @@ class Comment implements CommentInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -206,7 +206,7 @@ class Comment implements CommentInterface
     /**
      * Sets ParsingType
      *
-     * @param int $parsingType ParsingType
+     * @param integer $parsingType ParsingType
      *
      * @return $this Self object
      */
@@ -220,7 +220,7 @@ class Comment implements CommentInterface
     /**
      * Get ParsingType
      *
-     * @return int ParsingType
+     * @return integer ParsingType
      */
     public function getParsingType()
     {

--- a/src/Elcodi/Component/Comment/Entity/Interfaces/CommentInterface.php
+++ b/src/Elcodi/Component/Comment/Entity/Interfaces/CommentInterface.php
@@ -95,7 +95,7 @@ interface CommentInterface extends DateTimeInterface, EnabledInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */
@@ -104,7 +104,7 @@ interface CommentInterface extends DateTimeInterface, EnabledInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId();
 
@@ -143,7 +143,7 @@ interface CommentInterface extends DateTimeInterface, EnabledInterface
     /**
      * Sets ParsingType
      *
-     * @param int $parsingType ParsingType
+     * @param integer $parsingType ParsingType
      *
      * @return $this Self object
      */
@@ -152,7 +152,7 @@ interface CommentInterface extends DateTimeInterface, EnabledInterface
     /**
      * Get ParsingType
      *
-     * @return int ParsingType
+     * @return integer ParsingType
      */
     public function getParsingType();
 

--- a/src/Elcodi/Component/Comment/Entity/Vote.php
+++ b/src/Elcodi/Component/Comment/Entity/Vote.php
@@ -73,7 +73,7 @@ class Vote implements VoteInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */
@@ -87,7 +87,7 @@ class Vote implements VoteInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {

--- a/src/Elcodi/Component/Comment/Entity/VotePackage.php
+++ b/src/Elcodi/Component/Comment/Entity/VotePackage.php
@@ -72,7 +72,7 @@ class VotePackage
     /**
      * Get NbDownVotes
      *
-     * @return int NbDownVotes
+     * @return integer NbDownVotes
      */
     public function getNbDownVotes()
     {
@@ -82,7 +82,7 @@ class VotePackage
     /**
      * Get NbUpVotes
      *
-     * @return int NbUpVotes
+     * @return integer NbUpVotes
      */
     public function getNbUpVotes()
     {
@@ -92,7 +92,7 @@ class VotePackage
     /**
      * Get NbVotes
      *
-     * @return int NbVotes
+     * @return integer NbVotes
      */
     public function getNbVotes()
     {

--- a/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
+++ b/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
@@ -233,7 +233,7 @@ class ConfigurationManager extends AbstractCacheWrapper
      *
      * @param string $configurationIdentifier
      *
-     * @return bool
+     * @return boolean
      *
      * @throws ConfigurationNotEditableException       Configuration parameter is read-only
      * @throws ConfigurationParameterNotFoundException Configuration parameter not found

--- a/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
+++ b/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
@@ -231,7 +231,7 @@ class ConfigurationManager extends AbstractCacheWrapper
     /**
      * Deletes a parameter given the format "namespace.key"
      *
-     * @param $configurationIdentifier
+     * @param string $configurationIdentifier
      *
      * @return bool
      *

--- a/src/Elcodi/Component/Core/Entity/Interfaces/IdentifiableInterface.php
+++ b/src/Elcodi/Component/Core/Entity/Interfaces/IdentifiableInterface.php
@@ -25,14 +25,14 @@ interface IdentifiableInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId();
 
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Core/Entity/Traits/IdentifiableTrait.php
+++ b/src/Elcodi/Component/Core/Entity/Traits/IdentifiableTrait.php
@@ -32,7 +32,7 @@ trait IdentifiableTrait
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -42,7 +42,7 @@ trait IdentifiableTrait
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Core/Generator/Interfaces/GeneratorInterface.php
+++ b/src/Elcodi/Component/Core/Generator/Interfaces/GeneratorInterface.php
@@ -31,7 +31,7 @@ interface GeneratorInterface
     /**
      * Generates a hash
      *
-     * @param string $length Length of generation
+     * @param integer $length Length of generation
      *
      * @return string Generation
      */

--- a/src/Elcodi/Component/Core/Generator/RandomGenerator.php
+++ b/src/Elcodi/Component/Core/Generator/RandomGenerator.php
@@ -27,7 +27,7 @@ class RandomGenerator implements GeneratorInterface
     /**
      * Generates a random string with entropy
      *
-     * @param string $length Length of generation
+     * @param integer $length Length of generation
      *
      * @return string Result of generation
      */

--- a/src/Elcodi/Component/Core/Generator/Sha1Generator.php
+++ b/src/Elcodi/Component/Core/Generator/Sha1Generator.php
@@ -46,7 +46,7 @@ class Sha1Generator implements GeneratorInterface
     /**
      * Generates a random string
      *
-     * @param string $length Length of generation
+     * @param integer $length Length of generation
      *
      * @return string Result of generation
      */

--- a/src/Elcodi/Component/Core/Generator/UniqIdGenerator.php
+++ b/src/Elcodi/Component/Core/Generator/UniqIdGenerator.php
@@ -29,7 +29,7 @@ class UniqIdGenerator implements GeneratorInterface
     /**
      * Generates a unique Id
      *
-     * @param string $length Length of generation
+     * @param integer $length Length of generation
      *
      * @return string Result of generation
      */

--- a/src/Elcodi/Component/Core/Services/MappingProvider.php
+++ b/src/Elcodi/Component/Core/Services/MappingProvider.php
@@ -56,7 +56,7 @@ class MappingProvider
      *
      * @param string $implementation Implementation
      *
-     * @return string|bool Interface
+     * @return string|boolean Interface
      */
     public function getInterface($implementation)
     {
@@ -70,7 +70,7 @@ class MappingProvider
      *
      * @param string $interface Interface
      *
-     * @return string|bool Implementation
+     * @return string|boolean Implementation
      */
     public function getImplementation($interface)
     {

--- a/src/Elcodi/Component/Core/Services/ObjectDirector.php
+++ b/src/Elcodi/Component/Core/Services/ObjectDirector.php
@@ -98,10 +98,10 @@ class ObjectDirector
      * an UnexpectedValueException if certain values of the sorting or limiting details are
      * not supported.
      *
-     * @param array      $criteria
-     * @param array|null $orderBy
-     * @param int|null   $limit
-     * @param int|null   $offset
+     * @param array        $criteria
+     * @param array|null   $orderBy
+     * @param integer|null $limit
+     * @param integer|null $offset
      *
      * @return array The objects.
      *

--- a/src/Elcodi/Component/Coupon/ElcodiCouponTypes.php
+++ b/src/Elcodi/Component/Coupon/ElcodiCouponTypes.php
@@ -23,14 +23,14 @@ namespace Elcodi\Component\Coupon;
 final class ElcodiCouponTypes
 {
     /**
-     * @var int
+     * @var integer
      *
      * Coupon type absolute amount
      */
     const TYPE_AMOUNT = 1;
 
     /**
-     * @var int
+     * @var integer
      *
      * Coupon type percent
      */
@@ -41,14 +41,14 @@ final class ElcodiCouponTypes
      */
 
     /**
-     * @var int
+     * @var integer
      *
      * Automatic enforcement
      */
     const ENFORCEMENT_AUTOMATIC = 1;
 
     /**
-     * @var int
+     * @var integer
      *
      * Manual enforcement
      */

--- a/src/Elcodi/Component/Coupon/Entity/Interfaces/CouponInterface.php
+++ b/src/Elcodi/Component/Coupon/Entity/Interfaces/CouponInterface.php
@@ -71,7 +71,7 @@ interface CouponInterface
      * @see ElcodiCouponTypes::TYPE_AMOUNT
      * @see ElcodiCouponTypes::TYPE_PERCENT
      *
-     * @param int $type Type
+     * @param integer $type Type
      *
      * @return $this Self object
      */
@@ -80,7 +80,7 @@ interface CouponInterface
     /**
      * Get type
      *
-     * @return int Type
+     * @return integer Type
      */
     public function getType();
 
@@ -89,7 +89,7 @@ interface CouponInterface
      * @see ElcodiCouponTypes::ENFORCEMENT_AUTOMATIC
      * @see ElcodiCouponTypes::ENFORCEMENT_MANUAL
      *
-     * @param int $enforcement Enforcement
+     * @param integer $enforcement Enforcement
      *
      * @return $this Self object
      */
@@ -98,7 +98,7 @@ interface CouponInterface
     /**
      * Get Enforcement
      *
-     * @return int Enforcement
+     * @return integer Enforcement
      */
     public function getEnforcement();
 
@@ -121,7 +121,7 @@ interface CouponInterface
     /**
      * Set discount
      *
-     * @param int $discount Discount
+     * @param integer $discount Discount
      *
      * @return $this Self object
      */
@@ -130,7 +130,7 @@ interface CouponInterface
     /**
      * Get discount
      *
-     * @return int discount
+     * @return integer discount
      */
     public function getDiscount();
 

--- a/src/Elcodi/Component/Coupon/Services/CouponManager.php
+++ b/src/Elcodi/Component/Coupon/Services/CouponManager.php
@@ -153,7 +153,7 @@ class CouponManager
      * @param CouponInterface $coupon Coupon to check activeness
      * @param DateTime        $now
      *
-     * @return bool
+     * @return boolean
      */
     protected function isActive(CouponInterface $coupon, \DateTime $now = null)
     {
@@ -179,7 +179,7 @@ class CouponManager
      *
      * @param CouponInterface $coupon
      *
-     * @return bool
+     * @return boolean
      */
     protected function canBeUsed(CouponInterface $coupon)
     {

--- a/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/OpenExchangeRatesProviderAdapter.php
+++ b/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/OpenExchangeRatesProviderAdapter.php
@@ -166,7 +166,7 @@ class OpenExchangeRatesProviderAdapter implements CurrencyExchangeRatesProviderA
     /**
      * Get historical data
      *
-     * @param \DateTime $date
+     * @param DateTime $date
      *
      * @return array
      */

--- a/src/Elcodi/Component/Currency/Command/CurrencyExchangeRatesPopulateCommand.php
+++ b/src/Elcodi/Component/Currency/Command/CurrencyExchangeRatesPopulateCommand.php
@@ -65,7 +65,7 @@ class CurrencyExchangeRatesPopulateCommand extends Command
      * @param InputInterface  $input  The input interface
      * @param OutputInterface $output The output interface
      *
-     * @return int|null|void
+     * @return integer|null|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Elcodi/Component/Currency/Entity/Money.php
+++ b/src/Elcodi/Component/Currency/Entity/Money.php
@@ -58,7 +58,7 @@ class Money extends StubMoney implements MoneyInterface
     /**
      * Simple Money Value Object constructor
      *
-     * @param Integer           $amount   Amount
+     * @param integer           $amount   Amount
      * @param CurrencyInterface $currency Currency
      */
     protected function __construct($amount, CurrencyInterface $currency)

--- a/src/Elcodi/Component/Currency/Populator/CurrencyExchangeRatesPopulator.php
+++ b/src/Elcodi/Component/Currency/Populator/CurrencyExchangeRatesPopulator.php
@@ -120,7 +120,7 @@ class CurrencyExchangeRatesPopulator
      *
      * @param OutputInterface $output The output interface
      *
-     * @return int|null|void
+     * @return integer|null|void
      */
     public function populate(OutputInterface $output)
     {

--- a/src/Elcodi/Component/Geo/Command/LocationPopulateCommand.php
+++ b/src/Elcodi/Component/Geo/Command/LocationPopulateCommand.php
@@ -91,7 +91,7 @@ class LocationPopulateCommand extends Command
      * @param InputInterface  $input  The input interface
      * @param OutputInterface $output The output interface
      *
-     * @return int|null|void
+     * @return integer|null|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Elcodi/Component/Media/Adapter/Resizer/ImageMagickResizeAdapter.php
+++ b/src/Elcodi/Component/Media/Adapter/Resizer/ImageMagickResizeAdapter.php
@@ -58,9 +58,9 @@ class ImageMagickResizeAdapter implements ResizeAdapterInterface
      * Generate Thumbnail images with ImageMagick
      *
      * @param string  $imageData Image Data
-     * @param Integer $height    Height value
-     * @param Integer $width     Width value
-     * @param Integer $type      Type
+     * @param integer $height    Height value
+     * @param integer $width     Width value
+     * @param integer $type      Type
      *
      * @return string Resized image data
      *

--- a/src/Elcodi/Component/Media/Adapter/Resizer/Interfaces/ResizeAdapterInterface.php
+++ b/src/Elcodi/Component/Media/Adapter/Resizer/Interfaces/ResizeAdapterInterface.php
@@ -28,9 +28,9 @@ interface ResizeAdapterInterface
      * Interface for resize implementations
      *
      * @param string  $imageData Image Data
-     * @param Integer $height    Height value
-     * @param Integer $width     Width value
-     * @param Integer $type      Type
+     * @param integer $height    Height value
+     * @param integer $width     Width value
+     * @param integer $type      Type
      *
      * @return string Resized image data
      */

--- a/src/Elcodi/Component/Media/Entity/Interfaces/FileInterface.php
+++ b/src/Elcodi/Component/Media/Entity/Interfaces/FileInterface.php
@@ -41,7 +41,7 @@ interface FileInterface extends MediaInterface
     /**
      * Set id
      *
-     * @param int $id Entity Id
+     * @param integer $id Entity Id
      *
      * @return $this Self object
      */
@@ -50,7 +50,7 @@ interface FileInterface extends MediaInterface
     /**
      * Get id
      *
-     * @return int Entity identifier
+     * @return integer Entity identifier
      */
     public function getId();
 

--- a/src/Elcodi/Component/Metric/Core/Entity/Entry.php
+++ b/src/Elcodi/Component/Metric/Core/Entity/Entry.php
@@ -94,7 +94,7 @@ class Entry implements EntryInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -134,7 +134,7 @@ class Entry implements EntryInterface
     /**
      * Get Type
      *
-     * @return int Type
+     * @return integer Type
      */
     public function getType()
     {

--- a/src/Elcodi/Component/Metric/Core/Entity/Entry.php
+++ b/src/Elcodi/Component/Metric/Core/Entity/Entry.php
@@ -144,7 +144,7 @@ class Entry implements EntryInterface
     /**
      * Get CreatedAt
      *
-     * @return mixed CreatedAt
+     * @return DateTime|null CreatedAt
      */
     public function getCreatedAt()
     {

--- a/src/Elcodi/Component/Metric/Core/Entity/Interfaces/EntryInterface.php
+++ b/src/Elcodi/Component/Metric/Core/Entity/Interfaces/EntryInterface.php
@@ -46,14 +46,14 @@ interface EntryInterface
     /**
      * Get Type
      *
-     * @return int Type
+     * @return integer Type
      */
     public function getType();
 
     /**
      * Get CreatedAt
      *
-     * @return mixed CreatedAt
+     * @return \DateTime|null CreatedAt
      */
     public function getCreatedAt();
 }

--- a/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
+++ b/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
@@ -95,7 +95,7 @@ class NewsletterManager
     /**
      * Subscribe email to newsletter
      *
-     * @param String            $email    Email
+     * @param string            $email    Email
      * @param LanguageInterface $language The language
      *
      * @return $this Self object

--- a/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
+++ b/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
@@ -192,7 +192,7 @@ class NewsletterManager
      *
      * @param string $email Email
      *
-     * @return null|object Subscription instance if exists
+     * @return object|null Subscription instance if exists
      */
     public function getSubscription($email)
     {

--- a/src/Elcodi/Component/Page/Entity/Interfaces/PageInterface.php
+++ b/src/Elcodi/Component/Page/Entity/Interfaces/PageInterface.php
@@ -106,14 +106,14 @@ interface PageInterface
     /**
      * Get Type
      *
-     * @return int Type
+     * @return integer Type
      */
     public function getType();
 
     /**
      * Sets Type
      *
-     * @param int $type Type
+     * @param integer $type Type
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Page/Entity/Page.php
+++ b/src/Elcodi/Component/Page/Entity/Page.php
@@ -188,7 +188,7 @@ class Page implements PageInterface
     /**
      * Get Type
      *
-     * @return int Type
+     * @return integer Type
      */
     public function getType()
     {
@@ -198,7 +198,7 @@ class Page implements PageInterface
     /**
      * Sets Type
      *
-     * @param int $type Type
+     * @param integer $type Type
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Page/Renderer/ChainPageRenderer.php
+++ b/src/Elcodi/Component/Page/Renderer/ChainPageRenderer.php
@@ -81,7 +81,7 @@ class ChainPageRenderer implements PageRendererInterface
      *
      * @param PageInterface $page Page to check support
      *
-     * @return bool
+     * @return boolean
      */
     public function supports(PageInterface $page)
     {

--- a/src/Elcodi/Component/Page/Renderer/Interfaces/PageRendererInterface.php
+++ b/src/Elcodi/Component/Page/Renderer/Interfaces/PageRendererInterface.php
@@ -40,7 +40,7 @@ interface PageRendererInterface
      *
      * @param PageInterface $page Page to check support
      *
-     * @return bool
+     * @return boolean
      */
     public function supports(PageInterface $page);
 }

--- a/src/Elcodi/Component/Page/Renderer/TemplatedPageRenderer.php
+++ b/src/Elcodi/Component/Page/Renderer/TemplatedPageRenderer.php
@@ -116,7 +116,7 @@ class TemplatedPageRenderer implements PageRendererInterface
      *
      * @param PageInterface $page Page to check support
      *
-     * @return bool
+     * @return boolean
      */
     public function supports(PageInterface $page)
     {

--- a/src/Elcodi/Component/Plugin/Entity/Plugin.php
+++ b/src/Elcodi/Component/Plugin/Entity/Plugin.php
@@ -283,7 +283,7 @@ class Plugin
     /**
      * Is visible
      *
-     * @return bool Visible
+     * @return boolean Visible
      */
     public function isVisible()
     {

--- a/src/Elcodi/Component/Product/Entity/Category.php
+++ b/src/Elcodi/Component/Product/Entity/Category.php
@@ -72,14 +72,14 @@ class Category implements CategoryInterface
     protected $products;
 
     /**
-     * @var bool
+     * @var boolean
      *
      * Category is a root category
      */
     protected $root;
 
     /**
-     * @var Integer
+     * @var integer
      *
      * Position order to show in menu
      */
@@ -258,7 +258,7 @@ class Category implements CategoryInterface
     /**
      * Set position
      *
-     * @param Integer $position Category relative position
+     * @param integer $position Category relative position
      *
      * @return $this Self object
      */
@@ -272,7 +272,7 @@ class Category implements CategoryInterface
     /**
      * Return Position
      *
-     * @return Integer Category relative position
+     * @return integer Category relative position
      */
     public function getPosition()
     {

--- a/src/Elcodi/Component/Product/Entity/Interfaces/CategoryInterface.php
+++ b/src/Elcodi/Component/Product/Entity/Interfaces/CategoryInterface.php
@@ -163,7 +163,7 @@ interface CategoryInterface
     /**
      * Set position
      *
-     * @param Integer $position Category relative position
+     * @param integer $position Category relative position
      *
      * @return $this Self object
      */
@@ -172,7 +172,7 @@ interface CategoryInterface
     /**
      * Return Position
      *
-     * @return Integer Category relative position
+     * @return integer Category relative position
      */
     public function getPosition();
 }

--- a/src/Elcodi/Component/Product/Entity/Interfaces/DimensionableInterface.php
+++ b/src/Elcodi/Component/Product/Entity/Interfaces/DimensionableInterface.php
@@ -25,28 +25,28 @@ interface DimensionableInterface
     /**
      * Get Depth
      *
-     * @return int Depth
+     * @return integer Depth
      */
     public function getDepth();
 
     /**
      * Get Height
      *
-     * @return int Height
+     * @return integer Height
      */
     public function getHeight();
 
     /**
      * Get Weight
      *
-     * @return int Weight
+     * @return integer Weight
      */
     public function getWeight();
 
     /**
      * Get Width
      *
-     * @return int Width
+     * @return integer Width
      */
     public function getWidth();
 }

--- a/src/Elcodi/Component/Product/Entity/Interfaces/ProductPriceInterface.php
+++ b/src/Elcodi/Component/Product/Entity/Interfaces/ProductPriceInterface.php
@@ -45,7 +45,7 @@ interface ProductPriceInterface
     /**
      * Set price
      *
-     * @param \Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface $amount Reduced Price
+     * @param MoneyInterface $amount Reduced Price
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Product/Entity/Interfaces/PurchasableInterface.php
+++ b/src/Elcodi/Component/Product/Entity/Interfaces/PurchasableInterface.php
@@ -58,14 +58,14 @@ interface PurchasableInterface
     /**
      * Gets the variant stock
      *
-     * @return int stock
+     * @return integer stock
      */
     public function getStock();
 
     /**
      * Sets the variant stock
      *
-     * @param int $stock
+     * @param integer $stock
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Product/Entity/Product.php
+++ b/src/Elcodi/Component/Product/Entity/Product.php
@@ -71,7 +71,7 @@ class Product implements ProductInterface
     protected $type;
 
     /**
-     * @var int
+     * @var integer
      *
      * Stock
      */
@@ -329,7 +329,7 @@ class Product implements ProductInterface
     /**
      * Set stock
      *
-     * @param int $stock Stock
+     * @param integer $stock Stock
      *
      * @return $this Self object
      */
@@ -343,7 +343,7 @@ class Product implements ProductInterface
     /**
      * Get stock
      *
-     * @return int Stock
+     * @return integer Stock
      */
     public function getStock()
     {
@@ -449,7 +449,7 @@ class Product implements ProductInterface
     /**
      * Sets Type
      *
-     * @param int $type Type
+     * @param integer $type Type
      *
      * @return $this Self object
      */
@@ -463,7 +463,7 @@ class Product implements ProductInterface
     /**
      * Get Type
      *
-     * @return int Type
+     * @return integer Type
      */
     public function getType()
     {

--- a/src/Elcodi/Component/Product/Entity/Traits/DimensionsTrait.php
+++ b/src/Elcodi/Component/Product/Entity/Traits/DimensionsTrait.php
@@ -53,7 +53,7 @@ trait DimensionsTrait
     /**
      * Get Depth
      *
-     * @return int Depth
+     * @return integer Depth
      */
     public function getDepth()
     {
@@ -63,7 +63,7 @@ trait DimensionsTrait
     /**
      * Sets Depth
      *
-     * @param int $depth Depth
+     * @param integer $depth Depth
      *
      * @return $this Self object
      */
@@ -77,7 +77,7 @@ trait DimensionsTrait
     /**
      * Get Height
      *
-     * @return int Height
+     * @return integer Height
      */
     public function getHeight()
     {
@@ -87,7 +87,7 @@ trait DimensionsTrait
     /**
      * Sets Height
      *
-     * @param int $height Height
+     * @param integer $height Height
      *
      * @return $this Self object
      */
@@ -101,7 +101,7 @@ trait DimensionsTrait
     /**
      * Get Weight
      *
-     * @return int Weight
+     * @return integer Weight
      */
     public function getWeight()
     {
@@ -111,7 +111,7 @@ trait DimensionsTrait
     /**
      * Sets Weight
      *
-     * @param int $weight Weight
+     * @param integer $weight Weight
      *
      * @return $this Self object
      */
@@ -125,7 +125,7 @@ trait DimensionsTrait
     /**
      * Get Width
      *
-     * @return int Width
+     * @return integer Width
      */
     public function getWidth()
     {
@@ -135,7 +135,7 @@ trait DimensionsTrait
     /**
      * Sets Width
      *
-     * @param int $width Width
+     * @param integer $width Width
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Product/Entity/Variant.php
+++ b/src/Elcodi/Component/Product/Entity/Variant.php
@@ -106,7 +106,7 @@ class Variant implements VariantInterface
     /**
      * Gets the variant stock
      *
-     * @return int Stock
+     * @return integer Stock
      */
     public function getStock()
     {
@@ -116,7 +116,7 @@ class Variant implements VariantInterface
     /**
      * Sets the variant stock
      *
-     * @param int $stock
+     * @param integer $stock
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Product/Repository/VariantRepository.php
+++ b/src/Elcodi/Component/Product/Repository/VariantRepository.php
@@ -33,7 +33,7 @@ class VariantRepository extends EntityRepository
      * returns the Variant that is associated with the options matching the IDs, if any
      *
      * @param ProductInterface $product            to compare Variants from
-     * @param                  $optionsSearchedIds array containing IDs of the options to match
+     * @param array            $optionsSearchedIds array containing IDs of the options to match
      *
      * @return VariantInterface|null Variant if found, or null if not
      */

--- a/src/Elcodi/Component/ReferralProgram/Entity/Interfaces/ReferralLineInterface.php
+++ b/src/Elcodi/Component/ReferralProgram/Entity/Interfaces/ReferralLineInterface.php
@@ -181,7 +181,7 @@ interface ReferralLineInterface
     /**
      * Sets InvitedType
      *
-     * @param int $invitedType InvitedType
+     * @param integer $invitedType InvitedType
      *
      * @return $this Self object
      */
@@ -190,7 +190,7 @@ interface ReferralLineInterface
     /**
      * Get InvitedType
      *
-     * @return int InvitedType
+     * @return integer InvitedType
      */
     public function getInvitedType();
 
@@ -213,7 +213,7 @@ interface ReferralLineInterface
     /**
      * Sets ReferrerType
      *
-     * @param int $referrerType ReferrerType
+     * @param integer $referrerType ReferrerType
      *
      * @return $this Self object
      */
@@ -222,7 +222,7 @@ interface ReferralLineInterface
     /**
      * Get ReferrerType
      *
-     * @return int ReferrerType
+     * @return integer ReferrerType
      */
     public function getReferrerType();
 

--- a/src/Elcodi/Component/ReferralProgram/Entity/InvitationsBag.php
+++ b/src/Elcodi/Component/ReferralProgram/Entity/InvitationsBag.php
@@ -69,7 +69,7 @@ class InvitationsBag
     /**
      * Sets ErrorInvitations
      *
-     * @param \Doctrine\Common\Collections\ArrayCollection $errorInvitations ErrorInvitations
+     * @param ArrayCollection $errorInvitations ErrorInvitations
      *
      * @return $this Self object
      */
@@ -83,7 +83,7 @@ class InvitationsBag
     /**
      * Get ErrorInvitations
      *
-     * @return \Doctrine\Common\Collections\ArrayCollection ErrorInvitations
+     * @return ArrayCollection ErrorInvitations
      */
     public function getErrorInvitations()
     {
@@ -93,7 +93,7 @@ class InvitationsBag
     /**
      * Sets SentInvitations
      *
-     * @param \Doctrine\Common\Collections\ArrayCollection $sentInvitations SentInvitations
+     * @param ArrayCollection $sentInvitations SentInvitations
      *
      * @return $this Self object
      */
@@ -107,7 +107,7 @@ class InvitationsBag
     /**
      * Get SentInvitations
      *
-     * @return \Doctrine\Common\Collections\ArrayCollection SentInvitations
+     * @return ArrayCollection SentInvitations
      */
     public function getSentInvitations()
     {

--- a/src/Elcodi/Component/ReferralProgram/Services/ReferralHashManager.php
+++ b/src/Elcodi/Component/ReferralProgram/Services/ReferralHashManager.php
@@ -120,14 +120,10 @@ class ReferralHashManager
      *
      * @param string $hash Hash
      *
-     * @return null|ReferralHash
+     * @return ReferralHash|null
      */
     public function getReferralHashByHash($hash)
     {
-        /**
-         * @var $referralHash ReferralHash
-         */
-
         return $this->referralHashRepository->findOneBy(array(
             'hash' => $hash,
         ));

--- a/src/Elcodi/Component/ReferralProgram/Services/ReferralProgramManager.php
+++ b/src/Elcodi/Component/ReferralProgram/Services/ReferralProgramManager.php
@@ -265,7 +265,7 @@ class ReferralProgramManager
      * @param CustomerInterface $invited Customer
      * @param string            $hash    Hash
      *
-     * @return null|ReferralHashInterface Related Referral Line
+     * @return ReferralHashInterface|null Related Referral Line
      */
     public function resolve(CustomerInterface $invited, $hash)
     {

--- a/src/Elcodi/Component/Rule/Repository/RuleRepository.php
+++ b/src/Elcodi/Component/Rule/Repository/RuleRepository.php
@@ -31,7 +31,7 @@ class RuleRepository extends EntityRepository
      *
      * @param string $name
      *
-     * @return null|RuleInterface
+     * @return RuleInterface|null
      */
     public function findOneByName($name)
     {

--- a/src/Elcodi/Component/Rule/Repository/RuleRepository.php
+++ b/src/Elcodi/Component/Rule/Repository/RuleRepository.php
@@ -29,7 +29,7 @@ class RuleRepository extends EntityRepository
     /**
      * Return a rule by name
      *
-     * @param $name
+     * @param string $name
      *
      * @return null|RuleInterface
      */

--- a/src/Elcodi/Component/Shipping/Entity/Carrier.php
+++ b/src/Elcodi/Component/Shipping/Entity/Carrier.php
@@ -92,7 +92,7 @@ class Carrier implements CarrierInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -102,7 +102,7 @@ class Carrier implements CarrierInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Shipping/Entity/Interfaces/CarrierInterface.php
+++ b/src/Elcodi/Component/Shipping/Entity/Interfaces/CarrierInterface.php
@@ -46,14 +46,14 @@ interface CarrierInterface extends EnabledInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId();
 
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Shipping/Entity/Interfaces/ShippingWeightRangeInterface.php
+++ b/src/Elcodi/Component/Shipping/Entity/Interfaces/ShippingWeightRangeInterface.php
@@ -25,14 +25,14 @@ interface ShippingWeightRangeInterface
     /**
      * Get ToWeight
      *
-     * @return int ToWeight
+     * @return integer ToWeight
      */
     public function getToWeight();
 
     /**
      * Sets ToWeight
      *
-     * @param int $toWeight ToWeight
+     * @param integer $toWeight ToWeight
      *
      * @return $this Self object
      */
@@ -41,14 +41,14 @@ interface ShippingWeightRangeInterface
     /**
      * Get FromWeight
      *
-     * @return int FromWeight
+     * @return integer FromWeight
      */
     public function getFromWeight();
 
     /**
      * Sets FromWeight
      *
-     * @param int $fromWeight FromWeight
+     * @param integer $fromWeight FromWeight
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Shipping/Entity/Traits/ShippingWeightRangeTrait.php
+++ b/src/Elcodi/Component/Shipping/Entity/Traits/ShippingWeightRangeTrait.php
@@ -39,7 +39,7 @@ trait ShippingWeightRangeTrait
     /**
      * Get ToWeight
      *
-     * @return int ToWeight
+     * @return integer ToWeight
      */
     public function getToWeight()
     {
@@ -49,7 +49,7 @@ trait ShippingWeightRangeTrait
     /**
      * Sets ToWeight
      *
-     * @param int $toWeight ToWeight
+     * @param integer $toWeight ToWeight
      *
      * @return $this Self object
      */
@@ -63,7 +63,7 @@ trait ShippingWeightRangeTrait
     /**
      * Get FromWeight
      *
-     * @return int FromWeight
+     * @return integer FromWeight
      */
     public function getFromWeight()
     {
@@ -73,7 +73,7 @@ trait ShippingWeightRangeTrait
     /**
      * Sets FromWeight
      *
-     * @param int $fromWeight FromWeight
+     * @param integer $fromWeight FromWeight
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Shipping/Provider/ShippingRangeProvider.php
+++ b/src/Elcodi/Component/Shipping/Provider/ShippingRangeProvider.php
@@ -183,7 +183,7 @@ class ShippingRangeProvider
      * @param CartInterface          $cart          Cart
      * @param ShippingRangeInterface $shippingRange Carrier Range
      *
-     * @return bool ShippingRange is satisfied by cart
+     * @return boolean ShippingRange is satisfied by cart
      */
     public function isShippingPriceRangeSatisfiedByCart(
         CartInterface $cart,
@@ -216,7 +216,7 @@ class ShippingRangeProvider
      * @param CartInterface          $cart          Cart
      * @param ShippingRangeInterface $shippingRange Carrier Range
      *
-     * @return bool ShippingRange is satisfied by cart
+     * @return boolean ShippingRange is satisfied by cart
      */
     public function isShippingWeightRangeSatisfiedByCart(
         CartInterface $cart,
@@ -242,7 +242,7 @@ class ShippingRangeProvider
      * @param CartInterface          $cart          Cart
      * @param ShippingRangeInterface $shippingRange Carrier Range
      *
-     * @return bool ShippingRange is satisfied by cart
+     * @return boolean ShippingRange is satisfied by cart
      */
     public function isShippingRangeZonesSatisfiedByCart(
         CartInterface $cart,

--- a/src/Elcodi/Component/Sitemap/Command/DumpSitemapCommand.php
+++ b/src/Elcodi/Component/Sitemap/Command/DumpSitemapCommand.php
@@ -66,7 +66,7 @@ class DumpSitemapCommand extends Command
      * @param InputInterface  $input  The input interface
      * @param OutputInterface $output The output interface
      *
-     * @return int|null|void
+     * @return integer|null|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Elcodi/Component/Sitemap/Render/Interfaces/SitemapRenderInterface.php
+++ b/src/Elcodi/Component/Sitemap/Render/Interfaces/SitemapRenderInterface.php
@@ -29,7 +29,7 @@ interface SitemapRenderInterface
      *
      * @param SitemapProfileInterface $sitemapProfile Sitemap profile
      *
-     * @return string Renderization
+     * @return string Rendered XML
      */
     public function render(SitemapProfileInterface $sitemapProfile);
 }

--- a/src/Elcodi/Component/Sitemap/Render/XmlRender.php
+++ b/src/Elcodi/Component/Sitemap/Render/XmlRender.php
@@ -30,7 +30,7 @@ class XmlRender implements SitemapRenderInterface
      *
      * @param SitemapProfileInterface $sitemapProfile Sitemap profile
      *
-     * @return string Renderization
+     * @return string Rendered XML
      */
     public function render(SitemapProfileInterface $sitemapProfile)
     {

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/InconsistentTransitionConfigurationException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/InconsistentTransitionConfigurationException.php
@@ -29,7 +29,7 @@ class InconsistentTransitionConfigurationException extends Exception
      *
      * @param string    $state      State name
      * @param string    $transition Transition name
-     * @param int       $code       [optional] The Exception code.
+     * @param integer   $code       [optional] The Exception code.
      * @param Exception $previous   [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
     public function __construct($state, $transition, $code = 0, Exception $previous = null)

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/InvalidPointOfEntryException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/InvalidPointOfEntryException.php
@@ -28,7 +28,7 @@ class InvalidPointOfEntryException extends Exception
      * Exception constructor
      *
      * @param string    $state    Invalid state
-     * @param int       $code     [optional] The Exception code.
+     * @param integer   $code     [optional] The Exception code.
      * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
     public function __construct($state, $code = 0, Exception $previous = null)

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/ObjectAlreadyInitializedException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/ObjectAlreadyInitializedException.php
@@ -31,7 +31,7 @@ class ObjectAlreadyInitializedException extends Exception
      * @link http://php.net/manual/en/exception.construct.php
      *
      * @param string    $message  [optional] The Exception message to throw.
-     * @param int       $code     [optional] The Exception code.
+     * @param integer   $code     [optional] The Exception code.
      * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
     public function __construct($message = "", $code = 0, Exception $previous = null)

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/ObjectNotInitializedException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/ObjectNotInitializedException.php
@@ -31,7 +31,7 @@ class ObjectNotInitializedException extends Exception
      * @link http://php.net/manual/en/exception.construct.php
      *
      * @param string    $message  [optional] The Exception message to throw.
-     * @param int       $code     [optional] The Exception code.
+     * @param integer   $code     [optional] The Exception code.
      * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
     public function __construct($message = "", $code = 0, Exception $previous = null)

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/StateNotValidException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/StateNotValidException.php
@@ -28,7 +28,7 @@ class StateNotValidException extends Exception
      * Exception constructor
      *
      * @param string    $state    Invalid state
-     * @param int       $code     [optional] The Exception code.
+     * @param integer   $code     [optional] The Exception code.
      * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
     public function __construct($state, $code = 0, Exception $previous = null)

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/TransitionNotValidException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/TransitionNotValidException.php
@@ -30,7 +30,7 @@ class TransitionNotValidException extends AbstractTransitionException
      * Exception constructor
      *
      * @param string    $message  [optional] Message
-     * @param int       $code     [optional] The Exception code.
+     * @param integer   $code     [optional] The Exception code.
      * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
     public function __construct($message = '', $code = 0, Exception $previous = null)

--- a/src/Elcodi/Component/Tax/Entity/Interfaces/TaxGroupInterface.php
+++ b/src/Elcodi/Component/Tax/Entity/Interfaces/TaxGroupInterface.php
@@ -27,14 +27,14 @@ interface TaxGroupInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId();
 
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Tax/Entity/Interfaces/TaxInterface.php
+++ b/src/Elcodi/Component/Tax/Entity/Interfaces/TaxInterface.php
@@ -27,14 +27,14 @@ interface TaxInterface extends EnabledInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId();
 
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Tax/Entity/Tax.php
+++ b/src/Elcodi/Component/Tax/Entity/Tax.php
@@ -66,7 +66,7 @@ class Tax implements TaxInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -76,7 +76,7 @@ class Tax implements TaxInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/Tax/Entity/TaxGroup.php
+++ b/src/Elcodi/Component/Tax/Entity/TaxGroup.php
@@ -58,7 +58,7 @@ class TaxGroup implements TaxGroupInterface
     /**
      * Get Id
      *
-     * @return int Id
+     * @return integer Id
      */
     public function getId()
     {
@@ -68,7 +68,7 @@ class TaxGroup implements TaxGroupInterface
     /**
      * Sets Id
      *
-     * @param int $id Id
+     * @param integer $id Id
      *
      * @return $this Self object
      */

--- a/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
+++ b/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
@@ -70,7 +70,7 @@ abstract class AbstractUser implements AbstractUserInterface
     protected $lastname;
 
     /**
-     * @var int
+     * @var integer
      *
      * gender
      */
@@ -158,7 +158,7 @@ abstract class AbstractUser implements AbstractUserInterface
     /**
      * Set gender
      *
-     * @param int $gender Gender
+     * @param integer $gender Gender
      *
      * @return $this Self object
      */
@@ -172,7 +172,7 @@ abstract class AbstractUser implements AbstractUserInterface
     /**
      * Get gender
      *
-     * @return int Gender
+     * @return integer Gender
      */
     public function getGender()
     {

--- a/src/Elcodi/Component/User/Entity/Customer.php
+++ b/src/Elcodi/Component/User/Entity/Customer.php
@@ -68,7 +68,7 @@ class Customer extends AbstractUser implements CustomerInterface
     protected $guest;
 
     /**
-     * @var bool
+     * @var boolean
      *
      * Has newsletter
      */

--- a/src/Elcodi/Component/User/Entity/Interfaces/AbstractUserInterface.php
+++ b/src/Elcodi/Component/User/Entity/Interfaces/AbstractUserInterface.php
@@ -101,7 +101,7 @@ interface AbstractUserInterface
     /**
      * Set gender
      *
-     * @param int $gender Gender
+     * @param integer $gender Gender
      *
      * @return $this Self object
      */
@@ -110,7 +110,7 @@ interface AbstractUserInterface
     /**
      * Get gender
      *
-     * @return int Gender
+     * @return integer Gender
      */
     public function getGender();
 

--- a/src/Elcodi/Component/User/Repository/CustomerRepository.php
+++ b/src/Elcodi/Component/User/Repository/CustomerRepository.php
@@ -47,7 +47,7 @@ class CustomerRepository extends EntityRepository implements UserEmaileableInter
      * @param integer $customerId The customer Id
      * @param integer $addressId  The address Id
      *
-     * @return bool
+     * @return boolean
      */
     public function findAddress($customerId, $addressId)
     {

--- a/src/Elcodi/Component/User/Services/PasswordManager.php
+++ b/src/Elcodi/Component/User/Services/PasswordManager.php
@@ -146,7 +146,7 @@ class PasswordManager
      * @param string       $hash        Hash given by provider
      * @param string       $newPassword New password
      *
-     * @return $this
+     * @return $this Self object
      */
     public function recoverPassword(AbstractUser $user, $hash, $newPassword)
     {

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Services/WizardRoutes.php
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Services/WizardRoutes.php
@@ -109,7 +109,7 @@ class WizardRoutes
      *
      * @param string $route The received route
      *
-     * @return bool If is part of the wizards setup.
+     * @return boolean If is part of the wizards setup.
      */
     public function isWizardSetupRoute($route)
     {
@@ -119,7 +119,7 @@ class WizardRoutes
     /**
      * Gets the default route.
      *
-     * @return bool If is the default route.
+     * @return boolean If is the default route.
      */
     public function getDefaultWizardRoute()
     {
@@ -131,7 +131,7 @@ class WizardRoutes
      *
      * @param string $route The route to check.
      *
-     * @return bool iF the wizard is hidden.
+     * @return boolean If the wizard is hidden.
      */
     public function isWizardHidden($route)
     {

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Services/WizardStatus.php
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Services/WizardStatus.php
@@ -70,7 +70,7 @@ class WizardStatus
     /**
      * Checks if the wizard has already been finished
      *
-     * @return bool
+     * @return boolean
      */
     public function isWizardFinished()
     {
@@ -80,7 +80,7 @@ class WizardStatus
     /**
      * Get the next step.
      *
-     * @return int|null The next step, null if the wizard is finished.
+     * @return integer|null The next step, null if the wizard is finished.
      */
     public function getNextStep()
     {
@@ -100,7 +100,7 @@ class WizardStatus
      *
      * @param integer $stepNumber A step number.
      *
-     * @return bool If the step is finished
+     * @return boolean If the step is finished
      */
     public function isStepFinished($stepNumber)
     {
@@ -121,7 +121,7 @@ class WizardStatus
     /**
      * Gets the finish status for all the steps
      *
-     * @return bool[]
+     * @return boolean[]
      */
     public function getStepsFinishStatus()
     {
@@ -136,7 +136,7 @@ class WizardStatus
     /**
      * Checks if the address has been fulfilled.
      *
-     * @return bool
+     * @return boolean
      */
     protected function isAddressFulfilled()
     {
@@ -150,7 +150,7 @@ class WizardStatus
     /**
      * Checks if there is any product on the store.
      *
-     * @return bool
+     * @return boolean
      */
     protected function isThereAnyProduct()
     {
@@ -166,7 +166,7 @@ class WizardStatus
     /**
      * Checks if the payment has been fulfilled
      *
-     * @return bool
+     * @return boolean
      */
     protected function isPaymentFulfilled()
     {
@@ -189,7 +189,7 @@ class WizardStatus
     /**
      * Checks if any carrier has been added to the store.
      *
-     * @return bool
+     * @return boolean
      */
     protected function isThereAnyCarrier()
     {

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/Templating/TwigRenderer.php
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/Templating/TwigRenderer.php
@@ -263,7 +263,7 @@ class TwigRenderer
     /**
      * Checks if the wizard is visible for this request.
      *
-     * @return bool If visible
+     * @return boolean If visible
      */
     protected function isVisible()
     {


### PR DESCRIPTION
While working on this I realized that there are several hundred Phpdoc blocks which have really redundant descriptions..examples:
https://github.com/elcodi/elcodi/blob/master/src/Elcodi/Component/Currency/Entity/Money.php#L154 
https://github.com/elcodi/elcodi/blob/master/src/Elcodi/Component/Cart/EventListener/CartSessionEventListener.php#L44
https://github.com/elcodi/elcodi/blob/master/src/Elcodi/Component/Cart/EventListener/CartSessionEventListener.php#L54

My suggestion is to remove bad explanations and add better ones later.