### PR TITLE
Fix Symfony CS link for codesniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Contributing
 This projects follows Symfony coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard) 
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/AttributeBundle/README.md
+++ b/src/Elcodi/Bundle/AttributeBundle/README.md
@@ -167,7 +167,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/BambooBundle/README.md
+++ b/src/Elcodi/Bundle/BambooBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/BannerBundle/README.md
+++ b/src/Elcodi/Bundle/BannerBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/CartBundle/README.md
+++ b/src/Elcodi/Bundle/CartBundle/README.md
@@ -285,7 +285,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/CartCouponBundle/README.md
+++ b/src/Elcodi/Bundle/CartCouponBundle/README.md
@@ -158,7 +158,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/CommentBundle/README.md
+++ b/src/Elcodi/Bundle/CommentBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/ConfigurationBundle/README.md
+++ b/src/Elcodi/Bundle/ConfigurationBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/CoreBundle/README.md
+++ b/src/Elcodi/Bundle/CoreBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/CouponBundle/README.md
+++ b/src/Elcodi/Bundle/CouponBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/CurrencyBundle/README.md
+++ b/src/Elcodi/Bundle/CurrencyBundle/README.md
@@ -231,7 +231,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/README.md
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/README.md
@@ -350,7 +350,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/README.md
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/GeoBundle/README.md
+++ b/src/Elcodi/Bundle/GeoBundle/README.md
@@ -264,8 +264,7 @@ phpcs
 checks. Read more details about
 [Symfony2 coding standards]
 (http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition]
-(https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/LanguageBundle/README.md
+++ b/src/Elcodi/Bundle/LanguageBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/MediaBundle/README.md
+++ b/src/Elcodi/Bundle/MediaBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/MenuBundle/README.md
+++ b/src/Elcodi/Bundle/MenuBundle/README.md
@@ -177,7 +177,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/MetricBundle/README.md
+++ b/src/Elcodi/Bundle/MetricBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/NewsletterBundle/README.md
+++ b/src/Elcodi/Bundle/NewsletterBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/PageBundle/README.md
+++ b/src/Elcodi/Bundle/PageBundle/README.md
@@ -164,7 +164,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/PluginBundle/README.md
+++ b/src/Elcodi/Bundle/PluginBundle/README.md
@@ -39,7 +39,7 @@ Contributing
 ------------
 All issues and Pull Requests should be on the main repository [elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
 
-This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard) to run code validation.
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard) to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must be explained step by step to make the review process easy in order to accept and merge them. New features must come paired with PHPUnit tests.
 

--- a/src/Elcodi/Bundle/ProductBundle/README.md
+++ b/src/Elcodi/Bundle/ProductBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/ReferralProgramBundle/README.md
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/RuleBundle/README.md
+++ b/src/Elcodi/Bundle/RuleBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/ShippingBundle/README.md
+++ b/src/Elcodi/Bundle/ShippingBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/SitemapBundle/README.md
+++ b/src/Elcodi/Bundle/SitemapBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/README.md
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/TaxBundle/README.md
+++ b/src/Elcodi/Bundle/TaxBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/TemplateBundle/README.md
+++ b/src/Elcodi/Bundle/TemplateBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/TestCommonBundle/README.md
+++ b/src/Elcodi/Bundle/TestCommonBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/UserBundle/README.md
+++ b/src/Elcodi/Bundle/UserBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Bundle/ZoneBundle/README.md
+++ b/src/Elcodi/Bundle/ZoneBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Attribute/README.md
+++ b/src/Elcodi/Component/Attribute/README.md
@@ -101,7 +101,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Banner/README.md
+++ b/src/Elcodi/Component/Banner/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Cart/README.md
+++ b/src/Elcodi/Component/Cart/README.md
@@ -362,7 +362,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/CartCoupon/README.md
+++ b/src/Elcodi/Component/CartCoupon/README.md
@@ -299,7 +299,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass
 phpcs checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Comment/README.md
+++ b/src/Elcodi/Component/Comment/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Configuration/README.md
+++ b/src/Elcodi/Component/Configuration/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Core/README.md
+++ b/src/Elcodi/Component/Core/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Coupon/README.md
+++ b/src/Elcodi/Component/Coupon/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Currency/README.md
+++ b/src/Elcodi/Component/Currency/README.md
@@ -194,7 +194,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/EntityTranslator/README.md
+++ b/src/Elcodi/Component/EntityTranslator/README.md
@@ -339,7 +339,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Geo/README.md
+++ b/src/Elcodi/Component/Geo/README.md
@@ -236,7 +236,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass
 phpcs checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Language/README.md
+++ b/src/Elcodi/Component/Language/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Media/README.md
+++ b/src/Elcodi/Component/Media/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Menu/README.md
+++ b/src/Elcodi/Component/Menu/README.md
@@ -136,7 +136,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/MetaData/README.md
+++ b/src/Elcodi/Component/MetaData/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Metric/README.md
+++ b/src/Elcodi/Component/Metric/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Newsletter/README.md
+++ b/src/Elcodi/Component/Newsletter/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Page/README.md
+++ b/src/Elcodi/Component/Page/README.md
@@ -106,7 +106,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass
 phpcs checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Plugin/README.md
+++ b/src/Elcodi/Component/Plugin/README.md
@@ -33,7 +33,7 @@ Contributing
 ------------
 All issues and Pull Requests should be on the main repository [elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
 
-This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard) to run code validation.
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard) to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must be explained step by step to make the review process easy in order to accept and merge them. New features must come paired with PHPUnit tests.
 

--- a/src/Elcodi/Component/Product/README.md
+++ b/src/Elcodi/Component/Product/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/ReferralProgram/README.md
+++ b/src/Elcodi/Component/ReferralProgram/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Rule/README.md
+++ b/src/Elcodi/Component/Rule/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Shipping/README.md
+++ b/src/Elcodi/Component/Shipping/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Sitemap/README.md
+++ b/src/Elcodi/Component/Sitemap/README.md
@@ -34,7 +34,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/StateTransitionMachine/README.md
+++ b/src/Elcodi/Component/StateTransitionMachine/README.md
@@ -261,7 +261,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Tax/README.md
+++ b/src/Elcodi/Component/Tax/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Template/README.md
+++ b/src/Elcodi/Component/Template/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/User/README.md
+++ b/src/Elcodi/Component/User/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Component/Zone/README.md
+++ b/src/Elcodi/Component/Zone/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Plugin/DisqusBundle/README.md
+++ b/src/Elcodi/Plugin/DisqusBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Plugin/FacebookBundle/README.md
+++ b/src/Elcodi/Plugin/FacebookBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Plugin/GoogleAnalyticsBundle/README.md
+++ b/src/Elcodi/Plugin/GoogleAnalyticsBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Plugin/PinterestBundle/README.md
+++ b/src/Elcodi/Plugin/PinterestBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must

--- a/src/Elcodi/Plugin/ProductCsvBundle/README.md
+++ b/src/Elcodi/Plugin/ProductCsvBundle/README.md
@@ -28,7 +28,7 @@ Contributing
 ------------
 All issues and Pull Requests should be on the main repository [elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
 
-This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard) to run code validation.
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard) to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must be explained step by step to make the review process easy in order to accept and merge them. New features must come paired with PHPUnit tests.
 

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/README.md
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/README.md
@@ -28,7 +28,7 @@ Contributing
 ------------
 All issues and Pull Requests should be on the main repository [elcodi/elcodi](https://github.com/elcodi/elcodi), so this one is read-only.
 
-This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard) to run code validation.
+This projects follows Symfony2 coding standards, so pull requests must pass phpcs checks. Read more details about [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html) and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard) to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must be explained step by step to make the review process easy in order to accept and merge them. New features must come paired with PHPUnit tests.
 

--- a/src/Elcodi/Plugin/TwitterBundle/README.md
+++ b/src/Elcodi/Plugin/TwitterBundle/README.md
@@ -28,7 +28,7 @@ All issues and Pull Requests should be on the main repository
 This projects follows Symfony2 coding standards, so pull requests must pass phpcs
 checks. Read more details about
 [Symfony2 coding standards](http://symfony.com/doc/current/contributing/code/standards.html)
-and install the corresponding [CodeSniffer definition](https://github.com/opensky/Symfony2-coding-standard)
+and install the corresponding [CodeSniffer definition](https://github.com/escapestudios/Symfony2-coding-standard)
 to run code validation.
 
 There is also a policy for contributing to this project. Pull requests must


### PR DESCRIPTION
Changes all references to old Symfony CodeSniffer to https://github.com/escapestudios/Symfony2-coding-standard