### PR TITLE
Feature/cs fixer config

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,16 @@
+<?php
+
+return Symfony\CS\Config\Config::create()
+    // use SYMFONY_LEVEL:
+    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
+    // and extra fixers:
+    ->fixers(array(
+        'concat_with_spaces',
+        'multiline_spaces_before_semicolon',
+        'short_array_syntax'
+    ))
+    ->finder(
+        Symfony\CS\Finder\DefaultFinder::create()
+            ->in('src/')
+    )
+;

--- a/src/Elcodi/Bundle/AttributeBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/AttributeBundle/CompilerPass/MappingCompilerPass.php
@@ -48,7 +48,6 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
                 'elcodi.core.attribute.entity.attribute_value.class',
                 'elcodi.core.attribute.entity.attribute_value.mapping_file',
                 'elcodi.core.attribute.entity.attribute_value.enabled'
-            )
-        ;
+            );
     }
 }

--- a/src/Elcodi/Bundle/AttributeBundle/DependencyInjection/ElcodiAttributeExtension.php
+++ b/src/Elcodi/Bundle/AttributeBundle/DependencyInjection/ElcodiAttributeExtension.php
@@ -41,7 +41,7 @@ class ElcodiAttributeExtension extends AbstractExtension implements EntitiesOver
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/app/AppKernel.php
@@ -32,7 +32,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -52,7 +52,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\AttributeBundle\ElcodiAttributeBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -64,8 +64,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerAttribute';
     }
 }

--- a/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
+++ b/src/Elcodi/Bundle/BambooBundle/DependencyInjection/ElcodiBambooExtension.php
@@ -40,7 +40,7 @@ class ElcodiBambooExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/BannerBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/BannerBundle/CompilerPass/MappingCompilerPass.php
@@ -48,7 +48,6 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
                 'elcodi.core.banner.entity.banner_zone.class',
                 'elcodi.core.banner.entity.banner_zone.mapping_file',
                 'elcodi.core.banner.entity.banner_zone.enabled'
-            )
-        ;
+            );
     }
 }

--- a/src/Elcodi/Bundle/BannerBundle/DependencyInjection/ElcodiBannerExtension.php
+++ b/src/Elcodi/Bundle/BannerBundle/DependencyInjection/ElcodiBannerExtension.php
@@ -41,7 +41,7 @@ class ElcodiBannerExtension extends AbstractExtension implements EntitiesOverrid
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Services/BannerManagerTest.php
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Services/BannerManagerTest.php
@@ -41,10 +41,10 @@ class BannerManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiLanguageBundle',
             'ElcodiBannerBundle',
-        );
+        ];
     }
 
     /**
@@ -64,9 +64,9 @@ class BannerManagerTest extends WebTestCase
     {
         $language = $this
             ->getRepository('language')
-            ->findOneBy(array(
+            ->findOneBy([
                 'iso' => 'es',
-            ));
+            ]);
 
         $zones = $this
             ->get('elcodi.manager.banner')

--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -58,7 +58,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle(),
             new \Elcodi\Bundle\MediaBundle\ElcodiMediaBundle(),
             new \Elcodi\Bundle\BannerBundle\ElcodiBannerBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -70,8 +70,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerBanner';
     }
 }

--- a/src/Elcodi/Bundle/CartBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CartBundle/CompilerPass/MappingCompilerPass.php
@@ -62,7 +62,6 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
                 'elcodi.core.cart.entity.order_line.class',
                 'elcodi.core.cart.entity.order_line.mapping_file',
                 'elcodi.core.cart.entity.order_line.enabled'
-            )
-        ;
+            );
     }
 }

--- a/src/Elcodi/Bundle/CartBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/CartBundle/DependencyInjection/Configuration.php
@@ -87,10 +87,10 @@ class Configuration extends AbstractConfiguration
                             ->defaultValue('unpaid')
                         ->end()
                         ->variableNode('states')
-                            ->defaultValue(array(
+                            ->defaultValue([
                                 ['unpaid', 'pay', 'paid'],
                                 ['paid', 'refund', 'refunded'],
-                            ))
+                            ])
                         ->end()
                     ->end()
                 ->end()
@@ -104,9 +104,9 @@ class Configuration extends AbstractConfiguration
                             ->defaultValue('not shipped')
                         ->end()
                         ->variableNode('states')
-                            ->defaultValue(array(
+                            ->defaultValue([
                                 ['not shipped', 'ship', 'shipped'],
-                            ))
+                            ])
                         ->end()
                     ->end()
                 ->end()

--- a/src/Elcodi/Bundle/CartBundle/DependencyInjection/ElcodiCartExtension.php
+++ b/src/Elcodi/Bundle/CartBundle/DependencyInjection/ElcodiCartExtension.php
@@ -41,7 +41,7 @@ class ElcodiCartExtension extends AbstractExtension implements EntitiesOverridab
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartLineTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartLineTest.php
@@ -41,9 +41,9 @@ class CartLineTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiCartBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartTest.php
@@ -41,9 +41,9 @@ class CartTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiCartBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -69,7 +69,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle(),
             new \Elcodi\Bundle\TaxBundle\ElcodiTaxBundle(),
             new \Elcodi\Bundle\ZoneBundle\ElcodiZoneBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -81,8 +81,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return $this->name.
-        ucfirst($this->environment).
+        return $this->name .
+        ucfirst($this->environment) .
         'DebugProjectContainerCart';
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/DependencyInjection/ElcodiCartCouponExtension.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/DependencyInjection/ElcodiCartCouponExtension.php
@@ -41,7 +41,7 @@ class ElcodiCartCouponExtension extends AbstractExtension implements EntitiesOve
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
@@ -49,10 +49,10 @@ class CartCouponRulesEventListenerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiCartBundle',
             'ElcodiCouponBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartEventListenerTest.php
@@ -58,7 +58,7 @@ class CartEventListenerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiUserBundle',
             'ElcodiCurrencyBundle',
             'ElcodiAttributeBundle',
@@ -67,7 +67,7 @@ class CartEventListenerTest extends WebTestCase
             'ElcodiCartBundle',
             'ElcodiCouponBundle',
             'ElcodiRuleBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderEventListenerTest.php
@@ -48,7 +48,7 @@ class OrderEventListenerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiUserBundle',
             'ElcodiCurrencyBundle',
             'ElcodiAttributeBundle',
@@ -57,7 +57,7 @@ class OrderEventListenerTest extends WebTestCase
             'ElcodiCartBundle',
             'ElcodiCouponBundle',
             'ElcodiCartCouponBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -72,7 +72,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle(),
             new \Elcodi\Bundle\TaxBundle\ElcodiTaxBundle(),
             new \Elcodi\Bundle\ZoneBundle\ElcodiZoneBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -84,8 +84,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerCartCoupon';
     }
 }

--- a/src/Elcodi/Bundle/CommentBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CommentBundle/CompilerPass/MappingCompilerPass.php
@@ -48,7 +48,6 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
                 'elcodi.entity.comment_vote.class',
                 'elcodi.entity.comment_vote.mapping_file',
                 'elcodi.entity.comment_vote.enabled'
-            )
-        ;
+            );
     }
 }

--- a/src/Elcodi/Bundle/CommentBundle/DependencyInjection/ElcodiCommentExtension.php
+++ b/src/Elcodi/Bundle/CommentBundle/DependencyInjection/ElcodiCommentExtension.php
@@ -42,7 +42,7 @@ class ElcodiCommentExtension extends AbstractExtension implements EntitiesOverri
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/CommentBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CommentBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -52,7 +52,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\CommentBundle\ElcodiCommentBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -64,8 +64,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerComment';
     }
 }

--- a/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/Configuration.php
@@ -93,7 +93,7 @@ class Configuration extends AbstractConfiguration implements ConfigurationInterf
                             $newElements = [];
                             foreach ($elements as $element) {
                                 $completeParameterName = isset($element['namespace'])
-                                    ? $element['namespace'].'.'.$element['key']
+                                    ? $element['namespace'] . '.' . $element['key']
                                     : $element['key'];
 
                                 $newElements[$completeParameterName] = $element;

--- a/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/ElcodiConfigurationExtension.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/ElcodiConfigurationExtension.php
@@ -41,7 +41,7 @@ class ElcodiConfigurationExtension extends AbstractExtension implements Entities
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
@@ -59,9 +59,9 @@ class ConfigurationManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiConfigurationBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -52,7 +52,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -64,8 +64,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerConfiguration';
     }
 }

--- a/src/Elcodi/Bundle/CoreBundle/Container/Traits/ContainerAccessorTrait.php
+++ b/src/Elcodi/Bundle/CoreBundle/Container/Traits/ContainerAccessorTrait.php
@@ -47,7 +47,7 @@ trait ContainerAccessorTrait
     {
         return $this
             ->container
-            ->get('elcodi.object_manager.'.$entityName);
+            ->get('elcodi.object_manager.' . $entityName);
     }
 
     /**
@@ -61,7 +61,7 @@ trait ContainerAccessorTrait
     {
         return $this
             ->container
-            ->get('elcodi.repository.'.$entityName);
+            ->get('elcodi.repository.' . $entityName);
     }
 
     /**
@@ -75,7 +75,7 @@ trait ContainerAccessorTrait
     {
         return $this
             ->container
-            ->get('elcodi.factory.'.$entityName);
+            ->get('elcodi.factory.' . $entityName);
     }
 
     /**
@@ -89,7 +89,7 @@ trait ContainerAccessorTrait
     {
         return $this
             ->container
-            ->get('elcodi.director.'.$entityName);
+            ->get('elcodi.director.' . $entityName);
     }
 
     /**

--- a/src/Elcodi/Bundle/CoreBundle/DependencyInjection/Abstracts/AbstractExtension.php
+++ b/src/Elcodi/Bundle/CoreBundle/DependencyInjection/Abstracts/AbstractExtension.php
@@ -125,7 +125,7 @@ abstract class AbstractExtension
      */
     public function getNamespace()
     {
-        return 'http://example.org/schema/dic/'.$this->getAlias();
+        return 'http://example.org/schema/dic/' . $this->getAlias();
     }
 
     /**
@@ -286,7 +286,7 @@ abstract class AbstractExtension
                 $configFile = $configFile[0];
             }
 
-            $loader->load($configFile.'.yml');
+            $loader->load($configFile . '.yml');
         }
     }
 

--- a/src/Elcodi/Bundle/CoreBundle/DependencyInjection/ElcodiCoreExtension.php
+++ b/src/Elcodi/Bundle/CoreBundle/DependencyInjection/ElcodiCoreExtension.php
@@ -40,7 +40,7 @@ class ElcodiCoreExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/CoreBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CoreBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -49,7 +49,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle(),
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -61,8 +61,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerCore';
     }
 }

--- a/src/Elcodi/Bundle/CouponBundle/DependencyInjection/ElcodiCouponExtension.php
+++ b/src/Elcodi/Bundle/CouponBundle/DependencyInjection/ElcodiCouponExtension.php
@@ -41,7 +41,7 @@ class ElcodiCouponExtension extends AbstractExtension implements EntitiesOverrid
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
@@ -52,9 +52,9 @@ class CouponFactoryTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiCurrencyBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -54,7 +54,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle(),
             new \Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle(),
             new \Elcodi\Bundle\RuleBundle\ElcodiRuleBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -66,8 +66,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerCoupon';
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/DependencyInjection/ElcodiCurrencyExtension.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/DependencyInjection/ElcodiCurrencyExtension.php
@@ -42,7 +42,7 @@ class ElcodiCurrencyExtension extends AbstractExtension implements EntitiesOverr
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -52,7 +52,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle(),
             new \Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -64,8 +64,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerCurrency';
     }
 }

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/DependencyInjection/Configuration.php
@@ -90,11 +90,11 @@ class Configuration extends AbstractConfiguration implements ConfigurationInterf
                                         }
 
                                         if (!isset($fieldConfiguration['getter'])) {
-                                            $fields[$fieldName]['getter'] = 'get'.ucfirst($fieldName);
+                                            $fields[$fieldName]['getter'] = 'get' . ucfirst($fieldName);
                                         }
 
                                         if (!isset($fieldConfiguration['getter'])) {
-                                            $fields[$fieldName]['setter'] = 'set'.ucfirst($fieldName);
+                                            $fields[$fieldName]['setter'] = 'set' . ucfirst($fieldName);
                                         }
                                     }
 

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/DependencyInjection/ElcodiEntityTranslatorExtension.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/DependencyInjection/ElcodiEntityTranslatorExtension.php
@@ -41,7 +41,7 @@ class ElcodiEntityTranslatorExtension extends AbstractExtension implements Entit
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/Services/TranslatorTest.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/Services/TranslatorTest.php
@@ -85,17 +85,17 @@ class TranslatorTest extends WebTestCase
 
         $this
             ->get('elcodi.entity_translator')
-            ->save($translatableProduct, array(
-                'es' => array(
+            ->save($translatableProduct, [
+                'es' => [
                     'name'        => 'el nombre',
-                ),
-                'en' => array(
+                ],
+                'en' => [
                     'name'         => 'the name',
-                ),
-                'fr' => array(
+                ],
+                'fr' => [
                     'name'         => 'le nom',
-                ),
-            ));
+                ],
+            ]);
 
         $this->assertCount(3, $this
             ->findAll('entity_translation')

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -52,7 +52,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle(),
             new \Elcodi\Bundle\EntityTranslatorBundle\ElcodiEntityTranslatorBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -64,8 +64,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerEntityTranslator';
     }
 }

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/Command/LoadDataFixturesDoctrineCommand.php
@@ -90,15 +90,15 @@ class LoadDataFixturesDoctrineCommand extends OriginalCommand
          * Same code as parent implementation
          */
         $dirOrFile = $input->getOption('fixtures');
-        $paths = array();
+        $paths = [];
 
         if ($dirOrFile) {
             $paths = is_array($dirOrFile)
                 ? $dirOrFile :
-                array($dirOrFile);
+                [$dirOrFile];
         } else {
             foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
-                $paths[] = $bundle->getPath().'/DataFixtures/ORM';
+                $paths[] = $bundle->getPath() . '/DataFixtures/ORM';
             }
         }
 
@@ -109,7 +109,7 @@ class LoadDataFixturesDoctrineCommand extends OriginalCommand
         $paths[] = get_class($this->kernel);
 
         sort($paths, SORT_STRING);
-        $backupFileName = '/tmp/'.sha1(serialize($paths)).'.backup.database';
+        $backupFileName = '/tmp/' . sha1(serialize($paths)) . '.backup.database';
         if (file_exists($backupFileName)) {
             copy($backupFileName, $this->databaseFilePath);
 

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/DependencyInjection/ElcodiFixturesBoosterExtension.php
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/DependencyInjection/ElcodiFixturesBoosterExtension.php
@@ -36,7 +36,7 @@ class ElcodiFixturesBoosterExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/GeoBundle/DependencyInjection/ElcodiGeoExtension.php
+++ b/src/Elcodi/Bundle/GeoBundle/DependencyInjection/ElcodiGeoExtension.php
@@ -42,7 +42,7 @@ class ElcodiGeoExtension extends AbstractExtension implements EntitiesOverridabl
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/GeoBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/GeoBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -51,7 +51,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\GeoBundle\ElcodiGeoBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -63,8 +63,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerGeo';
     }
 }

--- a/src/Elcodi/Bundle/LanguageBundle/DependencyInjection/ElcodiLanguageExtension.php
+++ b/src/Elcodi/Bundle/LanguageBundle/DependencyInjection/ElcodiLanguageExtension.php
@@ -41,7 +41,7 @@ class ElcodiLanguageExtension extends AbstractExtension implements EntitiesOverr
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Twig/LanguageExtensionTest.php
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Twig/LanguageExtensionTest.php
@@ -43,9 +43,9 @@ class LanguageExtensionTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiLanguageBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -51,7 +51,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -63,8 +63,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerLanguage';
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/DependencyInjection/ElcodiMediaExtension.php
+++ b/src/Elcodi/Bundle/MediaBundle/DependencyInjection/ElcodiMediaExtension.php
@@ -42,7 +42,7 @@ class ElcodiMediaExtension extends AbstractExtension implements EntitiesOverrida
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**
@@ -145,7 +145,7 @@ class ElcodiMediaExtension extends AbstractExtension implements EntitiesOverrida
 
         $container->setAlias(
             'elcodi.core.media.resize.default',
-            'elcodi.core.media.resize.'.$container->getParameter('elcodi.core.media.image_resize_engine')
+            'elcodi.core.media.resize.' . $container->getParameter('elcodi.core.media.image_resize_engine')
         );
 
         $container->setAlias(

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageResizeControllerTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageResizeControllerTest.php
@@ -53,7 +53,7 @@ class ImageResizeControllerTest extends WebTestCase
     {
         $client = $this->createClient();
         $image = new UploadedFile(
-            dirname(__FILE__).'/images/image.png',
+            dirname(__FILE__) . '/images/image.png',
             'image.png',
             'image/png',
             3966,

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageUploadControllerTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Controller/ImageUploadControllerTest.php
@@ -54,7 +54,7 @@ class ImageUploadControllerTest extends WebTestCase
     {
         $client = $this->createClient();
         $image = new UploadedFile(
-            dirname(__FILE__).'/images/image.png',
+            dirname(__FILE__) . '/images/image.png',
             'image.png',
             'image/png',
             3966,

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/FileServiceTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/FileServiceTest.php
@@ -47,7 +47,7 @@ class FileServiceTest extends WebTestCase
 
         $fileTransformer = $this->get('elcodi.transformer.media_file_identifier');
         $imageName = $fileTransformer->transform($image);
-        $imageData = file_get_contents(realpath(dirname(__FILE__)).'/images/image-10-10.gif');
+        $imageData = file_get_contents(realpath(dirname(__FILE__)) . '/images/image-10-10.gif');
 
         $this
             ->get('elcodi.manager.media_file')

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/ImageServiceTest.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/Services/ImageServiceTest.php
@@ -44,7 +44,7 @@ class ImageServiceTest extends WebTestCase
      */
     public function testCreateImage()
     {
-        $imagePath = realpath(dirname(__FILE__)).'/images/image-10-10.gif';
+        $imagePath = realpath(dirname(__FILE__)) . '/images/image-10-10.gif';
         $file = new File($imagePath);
 
         /**

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -56,7 +56,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\MediaBundle\ElcodiMediaBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -68,8 +68,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerMedia';
     }
 }

--- a/src/Elcodi/Bundle/MenuBundle/DependencyInjection/ElcodiMenuExtension.php
+++ b/src/Elcodi/Bundle/MenuBundle/DependencyInjection/ElcodiMenuExtension.php
@@ -41,7 +41,7 @@ class ElcodiMenuExtension extends AbstractExtension implements EntitiesOverridab
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -52,7 +52,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\MenuBundle\ElcodiMenuBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -64,8 +64,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerMenu';
     }
 }

--- a/src/Elcodi/Bundle/MetricBundle/DependencyInjection/ElcodiMetricExtension.php
+++ b/src/Elcodi/Bundle/MetricBundle/DependencyInjection/ElcodiMetricExtension.php
@@ -42,7 +42,7 @@ class ElcodiMetricExtension extends AbstractExtension implements EntitiesOverrid
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/NewsletterBundle/DependencyInjection/ElcodiNewsletterExtension.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/DependencyInjection/ElcodiNewsletterExtension.php
@@ -41,7 +41,7 @@ class ElcodiNewsletterExtension extends AbstractExtension implements EntitiesOve
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Service/NewsletterManagerTest.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Service/NewsletterManagerTest.php
@@ -69,10 +69,10 @@ class NewsletterManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiLanguageBundle',
             'ElcodiNewsletterBundle',
-        );
+        ];
     }
 
     /**
@@ -96,9 +96,9 @@ class NewsletterManagerTest extends WebTestCase
     {
         $this->assertCount(2, $this
                 ->newsletterSubscriptionRepository
-                ->findBy(array(
+                ->findBy([
                     'enabled' => true,
-                ))
+                ])
         );
 
         /**
@@ -106,9 +106,9 @@ class NewsletterManagerTest extends WebTestCase
          */
         $language = $this
             ->getRepository('language')
-            ->findOneBy(array(
+            ->findOneBy([
                 'iso' => 'es',
-            ));
+            ]);
 
         $this
             ->newsletterManager
@@ -116,9 +116,9 @@ class NewsletterManagerTest extends WebTestCase
 
         $this->assertCount(3, $this
                 ->newsletterSubscriptionRepository
-                ->findBy(array(
+                ->findBy([
                     'enabled' => true,
-                ))
+                ])
         );
 
         /**
@@ -126,9 +126,9 @@ class NewsletterManagerTest extends WebTestCase
          */
         $newsletterSubscription = $this
             ->newsletterSubscriptionRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'email' => 'hi@hi.org',
-            ));
+            ]);
 
         $this->assertNotEmpty($newsletterSubscription->getHash());
     }
@@ -140,9 +140,9 @@ class NewsletterManagerTest extends WebTestCase
     {
         $this->assertCount(2, $this
                 ->newsletterSubscriptionRepository
-                ->findBy(array(
+                ->findBy([
                     'enabled' => true,
-                ))
+                ])
         );
 
         $this
@@ -151,9 +151,9 @@ class NewsletterManagerTest extends WebTestCase
 
         $this->assertCount(3, $this
                 ->newsletterSubscriptionRepository
-                ->findBy(array(
+                ->findBy([
                     'enabled' => true,
-                ))
+                ])
         );
     }
 
@@ -164,9 +164,9 @@ class NewsletterManagerTest extends WebTestCase
     {
         $this->assertCount(2, $this
                 ->newsletterSubscriptionRepository
-                ->findBy(array(
+                ->findBy([
                     'enabled' => true,
-                ))
+                ])
         );
 
         $this
@@ -183,9 +183,9 @@ class NewsletterManagerTest extends WebTestCase
          */
         $language = $this
             ->getRepository('language')
-            ->findOneBy(array(
+            ->findOneBy([
                 'iso' => 'es',
-            ));
+            ]);
 
         $reason = 'my reason';
         $this
@@ -194,16 +194,16 @@ class NewsletterManagerTest extends WebTestCase
 
         $this->assertCount(1, $this
                 ->newsletterSubscriptionRepository
-                ->findBy(array(
+                ->findBy([
                     'enabled' => true,
-                ))
+                ])
         );
 
         $disabledNewsletterSubscription = $this
             ->newsletterSubscriptionRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'enabled' => false,
-            ));
+            ]);
 
         $this->assertEquals($disabledNewsletterSubscription->getReason(), $reason);
     }

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -52,7 +52,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle(),
             new \Elcodi\Bundle\NewsletterBundle\ElcodiNewsletterBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -64,8 +64,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerNewsletter';
     }
 }

--- a/src/Elcodi/Bundle/PageBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/PageBundle/DependencyInjection/Configuration.php
@@ -76,7 +76,6 @@ class Configuration extends AbstractConfiguration implements ConfigurationInterf
                 ->arrayNode('renderers')
                     ->prototype('scalar')->end()
                 ->end()
-            ->end()
-        ;
+            ->end();
     }
 }

--- a/src/Elcodi/Bundle/PageBundle/DependencyInjection/ElcodiPageExtension.php
+++ b/src/Elcodi/Bundle/PageBundle/DependencyInjection/ElcodiPageExtension.php
@@ -45,7 +45,7 @@ class ElcodiPageExtension extends AbstractExtension implements EntitiesOverridab
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/PluginBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/PluginBundle/DependencyInjection/Configuration.php
@@ -38,7 +38,6 @@ class Configuration extends AbstractConfiguration
                 ->scalarNode('hook_system')
                     ->defaultValue('elcodi.core.plugin.hook_system.adapter.event_dispatcher')
                 ->end()
-            ->end()
-        ;
+            ->end();
     }
 }

--- a/src/Elcodi/Bundle/PluginBundle/DependencyInjection/ElcodiPluginExtension.php
+++ b/src/Elcodi/Bundle/PluginBundle/DependencyInjection/ElcodiPluginExtension.php
@@ -43,7 +43,7 @@ class ElcodiPluginExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/ProductBundle/DependencyInjection/ElcodiProductExtension.php
+++ b/src/Elcodi/Bundle/ProductBundle/DependencyInjection/ElcodiProductExtension.php
@@ -41,7 +41,7 @@ class ElcodiProductExtension extends AbstractExtension implements EntitiesOverri
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ProductFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ProductFactoryTest.php
@@ -41,9 +41,9 @@ class ProductFactoryTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiCurrencyBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/VariantFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/VariantFactoryTest.php
@@ -41,9 +41,9 @@ class VariantFactoryTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiCurrencyBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Services/ProductCollectionProviderTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Services/ProductCollectionProviderTest.php
@@ -49,9 +49,9 @@ class ProductCollectionProviderTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiProductBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -62,7 +62,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle(),
             new \Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle(),
             new \Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -74,8 +74,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerProduct';
     }
 }

--- a/src/Elcodi/Bundle/ReferralProgramBundle/DependencyInjection/ElcodiReferralProgramExtension.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/DependencyInjection/ElcodiReferralProgramExtension.php
@@ -41,7 +41,7 @@ class ElcodiReferralProgramExtension extends AbstractExtension implements Entiti
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralCouponManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralCouponManagerTest.php
@@ -63,10 +63,10 @@ class ReferralCouponManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiUserBundle',
             'ElcodiReferralProgramBundle',
-        );
+        ];
     }
 
     /**
@@ -154,9 +154,9 @@ class ReferralCouponManagerTest extends WebTestCase
         $customerObjectManager->flush();
         $customerObjectManager->clear();
 
-        $invited = $this->getRepository('customer')->findOneBy(array(
+        $invited = $this->getRepository('customer')->findOneBy([
             'email' => 'customer3@customer.com',
-        ));
+        ]);
 
         $referralCouponManager = $this
             ->get('elcodi.manager.referral_coupon');
@@ -359,7 +359,7 @@ class ReferralCouponManagerTest extends WebTestCase
 
         $referralCouponManager
             ->checkCouponAssignment($referrer, $hash, ElcodiReferralProgramRuleTypes::TYPE_ON_FIRST_PURCHASE)
-            ->checkCouponsUsed($referrer, new ArrayCollection(array($referralLine->getReferrerAssignedCoupon())));
+            ->checkCouponsUsed($referrer, new ArrayCollection([$referralLine->getReferrerAssignedCoupon()]));
 
         $this->assertTrue($referralLine->getReferrerCouponUsed());
         $this->assertFalse($referralLine->isClosed());
@@ -380,7 +380,7 @@ class ReferralCouponManagerTest extends WebTestCase
 
         $referralCouponManager
             ->checkCouponAssignment($invited, $hash, ElcodiReferralProgramRuleTypes::TYPE_ON_FIRST_PURCHASE)
-            ->checkCouponsUsed($invited, new ArrayCollection(array($referralLine->getInvitedAssignedCoupon())));
+            ->checkCouponsUsed($invited, new ArrayCollection([$referralLine->getInvitedAssignedCoupon()]));
 
         $this->assertTrue($referralLine->getInvitedCouponUsed());
         $this->assertTrue($referralLine->isClosed());

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralHashManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralHashManagerTest.php
@@ -55,13 +55,13 @@ class ReferralHashManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiLanguageBundle',
             'ElcodiUserBundle',
             'ElcodiCurrencyBundle',
             'ElcodiCouponBundle',
             'ElcodiReferralProgramBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralProgramManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralProgramManagerTest.php
@@ -64,13 +64,13 @@ class ReferralProgramManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiLanguageBundle',
             'ElcodiUserBundle',
             'ElcodiCurrencyBundle',
             'ElcodiCouponBundle',
             'ElcodiReferralProgramBundle',
-        );
+        ];
     }
 
     /**
@@ -127,18 +127,18 @@ class ReferralProgramManagerTest extends WebTestCase
          */
         $referralHash = $this
             ->getRepository('referral_hash')
-            ->findOneBy(array(
+            ->findOneBy([
                 'referrer' => $referrer,
-            ));
+            ]);
 
         /**
          * @var $referralLine ReferralLine
          */
         $referralLines = $this
             ->getRepository('referral_line')
-            ->findBy(array(
+            ->findBy([
                 'referralHash' => $referralHash,
-            ));
+            ]);
 
         $this->assertCount(5, $referralLines);
         foreach ($referralLines as $referralLine) {

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralRuleManagerTest.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/Services/ReferralRuleManagerTest.php
@@ -56,13 +56,13 @@ class ReferralRuleManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiLanguageBundle',
             'ElcodiUserBundle',
             'ElcodiCurrencyBundle',
             'ElcodiCouponBundle',
             'ElcodiReferralProgramBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ReferralProgramBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -74,7 +74,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle(),
             new \Elcodi\Bundle\TaxBundle\ElcodiTaxBundle(),
             new \Elcodi\Bundle\ZoneBundle\ElcodiZoneBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -86,8 +86,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerReferralProgram';
     }
 }

--- a/src/Elcodi/Bundle/RuleBundle/DependencyInjection/ElcodiRuleExtension.php
+++ b/src/Elcodi/Bundle/RuleBundle/DependencyInjection/ElcodiRuleExtension.php
@@ -41,7 +41,7 @@ class ElcodiRuleExtension extends AbstractExtension implements EntitiesOverridab
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/RuleBundle/Tests/Functional/Services/RuleManagerTest.php
+++ b/src/Elcodi/Bundle/RuleBundle/Tests/Functional/Services/RuleManagerTest.php
@@ -60,9 +60,9 @@ class RuleManagerTest extends WebTestCase
      */
     protected function loadFixturesBundles()
     {
-        return array(
+        return [
             'ElcodiRuleBundle',
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Bundle/RuleBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/RuleBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -51,7 +51,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\RuleBundle\ElcodiRuleBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -63,8 +63,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerRule';
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/DependencyInjection/ElcodiShippingExtension.php
+++ b/src/Elcodi/Bundle/ShippingBundle/DependencyInjection/ElcodiShippingExtension.php
@@ -41,7 +41,7 @@ class ElcodiShippingExtension extends AbstractExtension implements EntitiesOverr
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -69,7 +69,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle(),
             new \Elcodi\Bundle\StateTransitionMachineBundle\ElcodiStateTransitionMachineBundle(),
             new \Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -81,8 +81,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerShipping';
     }
 }

--- a/src/Elcodi/Bundle/SitemapBundle/DependencyInjection/ElcodiSitemapExtension.php
+++ b/src/Elcodi/Bundle/SitemapBundle/DependencyInjection/ElcodiSitemapExtension.php
@@ -42,7 +42,7 @@ class ElcodiSitemapExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**
@@ -113,7 +113,7 @@ class ElcodiSitemapExtension extends AbstractExtension
         foreach ($blocks as $blockName => $block) {
             $container
                 ->register(
-                    'elcodi.sitemap_entity_loader.'.$blockName,
+                    'elcodi.sitemap_entity_loader.' . $blockName,
                     '%elcodi.core.sitemap.loader.entity_loader.class%'
                 )
                 ->addArgument(new Reference($block['transformer']))
@@ -141,7 +141,7 @@ class ElcodiSitemapExtension extends AbstractExtension
         foreach ($profiles as $profileName => $profile) {
             $definition = $container
                 ->register(
-                    'elcodi.sitemap_profile.'.$profileName,
+                    'elcodi.sitemap_profile.' . $profileName,
                     '%elcodi.core.sitemap.loader.profile.class%'
                 )
                 ->addArgument($profileName)
@@ -151,7 +151,7 @@ class ElcodiSitemapExtension extends AbstractExtension
             foreach ($profile['blocks'] as $profileBlockName) {
                 $definition->addMethodCall(
                     'addEntityLoader',
-                    [new Reference('elcodi.sitemap_entity_loader.'.$profileBlockName)]
+                    [new Reference('elcodi.sitemap_entity_loader.' . $profileBlockName)]
                 );
             }
         }
@@ -174,11 +174,11 @@ class ElcodiSitemapExtension extends AbstractExtension
         foreach ($profiles as $profileName => $profile) {
             $container
                 ->register(
-                    'elcodi.sitemap_dumper.'.$profileName,
+                    'elcodi.sitemap_dumper.' . $profileName,
                     '%elcodi.sitemap_dumper.class%'
                 )
                 ->addArgument(new Reference($profile['render']))
-                ->addArgument(new Reference('elcodi.sitemap_profile.'.$profileName))
+                ->addArgument(new Reference('elcodi.sitemap_profile.' . $profileName))
                 ->addArgument(new Reference('elcodi.event_dispatcher.sitemap'))
                 ->setPublic(true)
                 ->addTag('elcodi.sitemap_dumper');
@@ -210,7 +210,7 @@ class ElcodiSitemapExtension extends AbstractExtension
         foreach ($sitemapDumpers as $sitemapDumperId => $tags) {
             $sitemapDumperChain->addMethodCall(
                 'addSitemapDumper',
-                array(new Reference($sitemapDumperId))
+                [new Reference($sitemapDumperId)]
             );
         }
 
@@ -232,10 +232,10 @@ class ElcodiSitemapExtension extends AbstractExtension
         foreach ($profiles as $profileName => $profile) {
             $container
                 ->register(
-                    'elcodi.sitemap_command.'.$profileName,
+                    'elcodi.sitemap_command.' . $profileName,
                     '%elcodi.core.sitemap.command.dump_sitemap.class%'
                 )
-                ->addArgument(new Reference('elcodi.sitemap_dumper.'.$profileName))
+                ->addArgument(new Reference('elcodi.sitemap_dumper.' . $profileName))
                 ->setPublic(true)
                 ->addTag('console.command');
         }

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/DependencyInjection/ElcodiStateTransitionMachineExtension.php
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/DependencyInjection/ElcodiStateTransitionMachineExtension.php
@@ -41,7 +41,7 @@ class ElcodiStateTransitionMachineExtension extends AbstractExtension implements
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/TaxBundle/DependencyInjection/ElcodiTaxExtension.php
+++ b/src/Elcodi/Bundle/TaxBundle/DependencyInjection/ElcodiTaxExtension.php
@@ -41,7 +41,7 @@ class ElcodiTaxExtension extends AbstractExtension implements EntitiesOverridabl
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/TaxBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/TaxBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -51,7 +51,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\CoreBundle\ElcodiCoreBundle(),
             new \Elcodi\Bundle\BambooBundle\ElcodiBambooBundle(),
             new \Elcodi\Bundle\TaxBundle\ElcodiTaxBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -63,8 +63,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerTax';
     }
 }

--- a/src/Elcodi/Bundle/TemplateBundle/DependencyInjection/ElcodiTemplateExtension.php
+++ b/src/Elcodi/Bundle/TemplateBundle/DependencyInjection/ElcodiTemplateExtension.php
@@ -38,7 +38,7 @@ class ElcodiTemplateExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/TestCommonBundle/Functional/Abstracts/AbstractElcodiKernel.php
+++ b/src/Elcodi/Bundle/TestCommonBundle/Functional/Abstracts/AbstractElcodiKernel.php
@@ -58,7 +58,7 @@ abstract class AbstractElcodiKernel extends Kernel
     {
         $classInfo = new \ReflectionClass($this);
         $dir =  dirname($classInfo->getFileName());
-        $loader->load($dir.'/config.yml');
+        $loader->load($dir . '/config.yml');
     }
 
     /**
@@ -68,11 +68,11 @@ abstract class AbstractElcodiKernel extends Kernel
      */
     public function getCacheDir()
     {
-        return  sys_get_temp_dir().
-        DIRECTORY_SEPARATOR.
-        'Elcodi'.
-        DIRECTORY_SEPARATOR.
-        $this->getContainerClass().'/Cache/';
+        return  sys_get_temp_dir() .
+        DIRECTORY_SEPARATOR .
+        'Elcodi' .
+        DIRECTORY_SEPARATOR .
+        $this->getContainerClass() . '/Cache/';
     }
 
     /**
@@ -82,10 +82,10 @@ abstract class AbstractElcodiKernel extends Kernel
      */
     public function getLogDir()
     {
-        return  sys_get_temp_dir().
-        DIRECTORY_SEPARATOR.
-        'Elcodi'.
-        DIRECTORY_SEPARATOR.
-        $this->getContainerClass().'/Log/';
+        return  sys_get_temp_dir() .
+        DIRECTORY_SEPARATOR .
+        'Elcodi' .
+        DIRECTORY_SEPARATOR .
+        $this->getContainerClass() . '/Log/';
     }
 }

--- a/src/Elcodi/Bundle/TestCommonBundle/Functional/WebTestCase.php
+++ b/src/Elcodi/Bundle/TestCommonBundle/Functional/WebTestCase.php
@@ -77,12 +77,12 @@ abstract class WebTestCase extends BaseWebTestCase
     public function tearDown()
     {
         if (static::$application) {
-            static::$application->run(new ArrayInput(array(
+            static::$application->run(new ArrayInput([
                 'command'          => 'doctrine:database:drop',
                 '--no-interaction' => true,
                 '--force'          => true,
                 '--quiet'          => true,
-            )));
+            ]));
         }
     }
 
@@ -161,24 +161,24 @@ abstract class WebTestCase extends BaseWebTestCase
             return $this;
         }
 
-        static::$application->run(new ArrayInput(array(
+        static::$application->run(new ArrayInput([
             'command'          => 'doctrine:database:drop',
             '--no-interaction' => true,
             '--force'          => true,
             '--quiet'          => true,
-        )));
+        ]));
 
-        static::$application->run(new ArrayInput(array(
+        static::$application->run(new ArrayInput([
             'command'          => 'doctrine:database:create',
             '--no-interaction' => true,
             '--quiet'          => true,
-        )));
+        ]));
 
-        static::$application->run(new ArrayInput(array(
+        static::$application->run(new ArrayInput([
             'command'          => 'doctrine:schema:create',
             '--no-interaction' => true,
             '--quiet'          => true,
-        )));
+        ]));
 
         $this->loadFixtures();
 
@@ -205,15 +205,15 @@ abstract class WebTestCase extends BaseWebTestCase
 
         $bundles = static::$kernel->getBundles();
         $formattedBundles = array_map(function ($bundle) use ($bundles) {
-            return $bundles[$bundle]->getPath().'/DataFixtures/ORM/';
+            return $bundles[$bundle]->getPath() . '/DataFixtures/ORM/';
         }, $this->loadFixturesBundles());
 
-        self::$application->run(new ArrayInput(array(
+        self::$application->run(new ArrayInput([
             'command'          => 'doctrine:fixtures:load',
             '--no-interaction' => true,
             '--fixtures'       => $formattedBundles,
             '--quiet'          => true,
-        )));
+        ]));
 
         return $this;
     }
@@ -230,7 +230,7 @@ abstract class WebTestCase extends BaseWebTestCase
     protected static function getKernelClass()
     {
         $namespaceExploded = explode('\\Tests\\Functional\\', get_called_class(), 2);
-        $kernelClass = $namespaceExploded[0].'\\Tests\\Functional\\app\\AppKernel';
+        $kernelClass = $namespaceExploded[0] . '\\Tests\\Functional\\app\\AppKernel';
 
         return $kernelClass;
     }
@@ -247,7 +247,7 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return KernelInterface A KernelInterface instance
      */
-    protected static function createKernel(array $options = array())
+    protected static function createKernel(array $options = [])
     {
         static::$class = static::getKernelClass();
 
@@ -255,6 +255,6 @@ abstract class WebTestCase extends BaseWebTestCase
         $bundleName = explode('Elcodi\\', $namespaceExploded[0], 2)[1];
         $bundleName = str_replace('\\', '_', $bundleName);
 
-        return new static::$class($bundleName.'Test', true);
+        return new static::$class($bundleName . 'Test', true);
     }
 }

--- a/src/Elcodi/Bundle/UserBundle/DependencyInjection/ElcodiUserExtension.php
+++ b/src/Elcodi/Bundle/UserBundle/DependencyInjection/ElcodiUserExtension.php
@@ -41,7 +41,7 @@ class ElcodiUserExtension extends AbstractExtension implements EntitiesOverridab
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
@@ -31,7 +31,7 @@ class AppKernel extends AbstractElcodiKernel
      */
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
 
             /**
              * Symfony bundles
@@ -69,7 +69,7 @@ class AppKernel extends AbstractElcodiKernel
             new \Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle(),
             new \Elcodi\Bundle\TaxBundle\ElcodiTaxBundle(),
             new \Elcodi\Bundle\ZoneBundle\ElcodiZoneBundle(),
-        );
+        ];
 
         return $bundles;
     }
@@ -81,8 +81,8 @@ class AppKernel extends AbstractElcodiKernel
      */
     protected function getContainerClass()
     {
-        return  $this->name.
-                ucfirst($this->environment).
+        return  $this->name .
+                ucfirst($this->environment) .
                 'DebugProjectContainerUser';
     }
 }

--- a/src/Elcodi/Bundle/ZoneBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/ZoneBundle/CompilerPass/MappingCompilerPass.php
@@ -41,7 +41,6 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
                 'elcodi.entity.zone.class',
                 'elcodi.entity.zone.mapping_file',
                 'elcodi.entity.zone.enabled'
-            )
-        ;
+            );
     }
 }

--- a/src/Elcodi/Bundle/ZoneBundle/DependencyInjection/ElcodiZoneExtension.php
+++ b/src/Elcodi/Bundle/ZoneBundle/DependencyInjection/ElcodiZoneExtension.php
@@ -41,7 +41,7 @@ class ElcodiZoneExtension extends AbstractExtension implements EntitiesOverridab
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Component/Banner/Entity/Banner.php
+++ b/src/Elcodi/Component/Banner/Entity/Banner.php
@@ -210,6 +210,6 @@ class Banner implements BannerInterface
      */
     public function __toString()
     {
-        return $this->getId().' - '.$this->getName();
+        return $this->getId() . ' - ' . $this->getName();
     }
 }

--- a/src/Elcodi/Component/Banner/Entity/BannerZone.php
+++ b/src/Elcodi/Component/Banner/Entity/BannerZone.php
@@ -258,6 +258,6 @@ class BannerZone implements BannerZoneInterface
             $isoLang = $this->getLanguage()->getIso();
         }
 
-        return $this->getName().' - '.$isoLang;
+        return $this->getName() . ' - ' . $isoLang;
     }
 }

--- a/src/Elcodi/Component/Banner/Repository/BannerRepository.php
+++ b/src/Elcodi/Component/Banner/Repository/BannerRepository.php
@@ -39,9 +39,9 @@ class BannerRepository extends EntityRepository
      */
     public function getBannerByZone($bannerZoneCode, LanguageInterface $language = null)
     {
-        $parameters = array(
+        $parameters = [
             'code' => $bannerZoneCode,
-        );
+        ];
 
         if (!is_null($language)) {
             $parameters['language'] = $language;

--- a/src/Elcodi/Component/Cart/Tests/UnitTest/Services/CartManagerTest.php
+++ b/src/Elcodi/Component/Cart/Tests/UnitTest/Services/CartManagerTest.php
@@ -155,9 +155,9 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
     {
         $cart = new Cart();
         $cartLine = new CartLine();
-        $cart->setCartLines(new ArrayCollection(array(
+        $cart->setCartLines(new ArrayCollection([
             $cartLine,
-        )));
+        ]));
         $cartLine->setCart($cart);
 
         $this->assertCount(1, $cart->getCartLines());
@@ -191,9 +191,9 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
     {
         $cart = new Cart();
         $cartLine = new CartLine();
-        $cart->setCartLines(new ArrayCollection(array(
+        $cart->setCartLines(new ArrayCollection([
             $cartLine,
-        )));
+        ]));
         $cartLine->setCart($cart);
 
         $this->assertCount(1, $cart->getCartLines());
@@ -234,9 +234,9 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
         $product = $this->getMock('Elcodi\Component\Product\Entity\Interfaces\ProductInterface');
         $cartLine->setQuantity($initialQuantity);
         $cartLine->setProduct($product);
-        $cart->setCartLines(new ArrayCollection(array(
+        $cart->setCartLines(new ArrayCollection([
             $cartLine,
-        )));
+        ]));
 
         $this->cartManager->editCartLine($cartLine, $product, $newQuantity);
         $this->assertEquals($finalQuantity, $cartLine->getQuantity());
@@ -247,14 +247,14 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
      */
     public function dataEditCartLine()
     {
-        return array(
-            array(null, null, null),
-            array(1, null, 1),
-            array(1, false, 1),
-            array(1, 1, 1),
-            array(null, 1, 1),
-            array(1, 2, 2),
-        );
+        return [
+            [null, null, null],
+            [1, null, 1],
+            [1, false, 1],
+            [1, 1, 1],
+            [null, 1, 1],
+            [1, 2, 2],
+        ];
     }
 
     /**
@@ -269,9 +269,9 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
         $cartLine = new CartLine();
         $cartLine->setCart($cart);
         $cartLine->setQuantity($initialQuantity);
-        $cart->setCartLines(new ArrayCollection(array(
+        $cart->setCartLines(new ArrayCollection([
             $cartLine,
-        )));
+        ]));
 
         $this->cartManager->increaseCartLineQuantity($cartLine, $quantityToIncrease);
         $this->assertEquals($finalQuantity, $cartLine->getQuantity());
@@ -282,12 +282,12 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
      */
     public function dataIncreaseCartLineQuantity()
     {
-        return array(
-            array(1, null, 1),
-            array(1, false, 1),
-            array(1, 1, 2),
-            array(null, 1, 1),
-        );
+        return [
+            [1, null, 1],
+            [1, false, 1],
+            [1, 1, 2],
+            [null, 1, 1],
+        ];
     }
 
     /**
@@ -302,9 +302,9 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
         $cartLine = new CartLine();
         $cartLine->setCart($cart);
         $cartLine->setQuantity($initialQuantity);
-        $cart->setCartLines(new ArrayCollection(array(
+        $cart->setCartLines(new ArrayCollection([
             $cartLine,
-        )));
+        ]));
 
         $this->cartManager->decreaseCartLineQuantity($cartLine, $quantityToIncrease);
         $this->assertEquals($finalQuantity, $cartLine->getQuantity());
@@ -315,11 +315,11 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
      */
     public function dataDecreaseCartLineQuantityNotRemove()
     {
-        return array(
-            array(2, null, 2),
-            array(2, false, 2),
-            array(3, 1, 2),
-        );
+        return [
+            [2, null, 2],
+            [2, false, 2],
+            [3, 1, 2],
+        ];
     }
 
     /**
@@ -334,9 +334,9 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
         $cartLine = new CartLine();
         $cartLine->setCart($cart);
         $cartLine->setQuantity($initialQuantity);
-        $cart->setCartLines(new ArrayCollection(array(
+        $cart->setCartLines(new ArrayCollection([
             $cartLine,
-        )));
+        ]));
 
         $this->cartManager->decreaseCartLineQuantity($cartLine, $quantityToIncrease);
         $this->assertEmpty($cart->getCartLines());
@@ -347,10 +347,10 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
      */
     public function dataDecreaseCartLineQuantityRemove()
     {
-        return array(
-            array(1, 1),
-            array(1, 2),
-        );
+        return [
+            [1, 1],
+            [1, 2],
+        ];
     }
 
     /**
@@ -472,7 +472,7 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
         $cart
             ->expects($this->any())
             ->method('getCartLines')
-            ->willReturn(new ArrayCollection(array($cartLine)));
+            ->willReturn(new ArrayCollection([$cartLine]));
 
         $cartManager
             ->expects($this->never())
@@ -508,7 +508,7 @@ class CartManagerTest extends PHPUnit_Framework_TestCase
         $cart = new Cart();
         $cartLine = new CartLine();
         $cartLine->setPurchasable($product);
-        $cart->setCartLines(new ArrayCollection(array($cartLine)));
+        $cart->setCartLines(new ArrayCollection([$cartLine]));
         $cartLine->setCart($cart);
 
         $this->assertCount(1, $cart->getCartLines());

--- a/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
+++ b/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
@@ -164,10 +164,10 @@ class CartCouponManager
     {
         $coupon = $this
             ->couponRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'code'    => $couponCode,
                 'enabled' => true,
-            ));
+            ]);
 
         if (false === $coupon instanceof CouponInterface) {
             throw new CouponNotAvailableException();
@@ -210,9 +210,9 @@ class CartCouponManager
     {
         $coupon = $this
             ->couponRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'code' => $couponCode,
-            ));
+            ]);
 
         if (!($coupon instanceof CouponInterface)) {
             return false;
@@ -233,10 +233,10 @@ class CartCouponManager
     {
         $cartCoupons = $this
             ->cartCouponRepository
-            ->findBy(array(
+            ->findBy([
                 'cart'   => $cart,
                 'coupon' => $coupon,
-            ));
+            ]);
 
         if (empty($cartCoupons)) {
             return false;

--- a/src/Elcodi/Component/Comment/Services/CommentCache.php
+++ b/src/Elcodi/Component/Comment/Services/CommentCache.php
@@ -254,17 +254,17 @@ class CommentCache extends AbstractCacheWrapper
             }
 
             if ($parentCommentId && !isset($commentTree[$parentCommentId])) {
-                $commentTree[$parentCommentId] = array(
+                $commentTree[$parentCommentId] = [
                     'entity'   => null,
-                    'children' => array(),
-                );
+                    'children' => [],
+                ];
             }
 
             if (!isset($commentTree[$commentId])) {
-                $commentTree[$commentId] = array(
+                $commentTree[$commentId] = [
                     'entity'   => null,
-                    'children' => array(),
-                );
+                    'children' => [],
+                ];
             }
 
             $commentVotePackage = $this
@@ -317,7 +317,7 @@ class CommentCache extends AbstractCacheWrapper
         $source = str_replace('.', '_', $source);
         $context = str_replace('.', '_', $context);
 
-        return $this->key.'.'.$source.'.'.$context;
+        return $this->key . '.' . $source . '.' . $context;
     }
 
     /**

--- a/src/Elcodi/Component/Configuration/Command/ConfigurationDeleteCommand.php
+++ b/src/Elcodi/Component/Configuration/Command/ConfigurationDeleteCommand.php
@@ -84,7 +84,7 @@ class ConfigurationDeleteCommand extends Command
         $formatter = $this->getHelper('formatter');
         $formattedLine = $formatter->formatSection(
             'OK',
-            'Deleted configuration "'.$configurationIdentifier.'"'
+            'Deleted configuration "' . $configurationIdentifier . '"'
         );
 
         $output->writeln($formattedLine);

--- a/src/Elcodi/Component/Configuration/Command/ConfigurationSetCommand.php
+++ b/src/Elcodi/Component/Configuration/Command/ConfigurationSetCommand.php
@@ -91,7 +91,7 @@ class ConfigurationSetCommand extends Command
         $formatter = $this->getHelper('formatter');
         $formattedLine = $formatter->formatSection(
             'OK',
-            'Saved configuration "'.$configurationIdentifier.'"'
+            'Saved configuration "' . $configurationIdentifier . '"'
         );
 
         $output->writeln($formattedLine);

--- a/src/Elcodi/Component/Configuration/ExpressionLanguage/ConfigurationExpressionLanguageProvider.php
+++ b/src/Elcodi/Component/Configuration/ExpressionLanguage/ConfigurationExpressionLanguageProvider.php
@@ -30,7 +30,7 @@ class ConfigurationExpressionLanguageProvider implements ExpressionFunctionProvi
      */
     public function getFunctions()
     {
-        return array(
+        return [
             new ExpressionFunction('elcodi_config', function ($name) {
                 return sprintf(
                     '$this->get(\'elcodi.manager.configuration\')->get(%s)',
@@ -41,6 +41,6 @@ class ConfigurationExpressionLanguageProvider implements ExpressionFunctionProvi
                     ->get('elcodi.manager.configuration')
                     ->get($name);
             }),
-        );
+        ];
     }
 }

--- a/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
+++ b/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
@@ -204,7 +204,7 @@ class ConfigurationManager extends AbstractCacheWrapper
 
             if (empty($configurationValue) && !$configurationElement['can_be_empty']) {
                 $message = $configurationElement['empty_message']
-                    ?: 'The configuration element "'.$configurationIdentifier.'" cannot be resolved';
+                    ?: 'The configuration element "' . $configurationIdentifier . '" cannot be resolved';
 
                 throw new Exception($message);
             }

--- a/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
+++ b/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
@@ -54,9 +54,9 @@ class ConfigurationExtension extends Twig_Extension
      */
     public function getFunctions()
     {
-        return array(
-            new Twig_SimpleFunction('elcodi_config', array($this, 'getParameter')),
-        );
+        return [
+            new Twig_SimpleFunction('elcodi_config', [$this, 'getParameter']),
+        ];
     }
 
     /**

--- a/src/Elcodi/Component/Core/Mailer/Abstracts/AbstractMailer.php
+++ b/src/Elcodi/Component/Core/Mailer/Abstracts/AbstractMailer.php
@@ -96,7 +96,7 @@ abstract class AbstractMailer
     protected function renderEmail(
         $subject,
         $receiverEmail,
-        array $context = array()
+        array $context = []
     ) {
         $message = Swift_Message::newInstance()
             ->setSubject($subject)

--- a/src/Elcodi/Component/Core/Tests/UnitTest/Encoder/JsonEncoderTest.php
+++ b/src/Elcodi/Component/Core/Tests/UnitTest/Encoder/JsonEncoderTest.php
@@ -66,7 +66,7 @@ class JsonEncoderTest extends PHPUnit_Framework_TestCase
             [true, 'true'],
             [false, 'false'],
             ['foo', '"foo"'],
-            [array('foo'), '["foo"]'],
+            [['foo'], '["foo"]'],
         ];
     }
 }

--- a/src/Elcodi/Component/Core/Tests/UnitTest/Encoder/PHPEncoderTest.php
+++ b/src/Elcodi/Component/Core/Tests/UnitTest/Encoder/PHPEncoderTest.php
@@ -66,7 +66,7 @@ class PHPEncoderTest extends PHPUnit_Framework_TestCase
             [true, 'b:1;'],
             [false, 'b:0;'],
             ['foo', 's:3:"foo";'],
-            [array('foo'), 'a:1:{i:0;s:3:"foo";}'],
+            [['foo'], 'a:1:{i:0;s:3:"foo";}'],
             ['', 's:0:"";'],
         ];
     }

--- a/src/Elcodi/Component/Core/Tests/UnitTest/Services/ManagerProviderTest.php
+++ b/src/Elcodi/Component/Core/Tests/UnitTest/Services/ManagerProviderTest.php
@@ -64,9 +64,9 @@ class ManagerProviderTest extends PHPUnit_Framework_TestCase
         $this->objectManager = $this
             ->getMock('Doctrine\Common\Persistence\ObjectManager');
 
-        $parametersBag = new ParameterBag(array(
+        $parametersBag = new ParameterBag([
             $this->entityParameter => $this->entityNamespace,
-        ));
+        ]);
 
         $managerRegistry = $this
             ->getMockBuilder('Symfony\Bridge\Doctrine\ManagerRegistry')

--- a/src/Elcodi/Component/Coupon/Factory/CouponFactory.php
+++ b/src/Elcodi/Component/Coupon/Factory/CouponFactory.php
@@ -57,8 +57,7 @@ class CouponFactory extends AbstractPurchasableFactory
             ->setPriority(0)
             ->setEnabled(false)
             ->setCreatedAt($now)
-            ->setValidFrom($now)
-        ;
+            ->setValidFrom($now);
 
         return $coupon;
     }

--- a/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/DummyProviderAdapter.php
+++ b/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/DummyProviderAdapter.php
@@ -32,7 +32,7 @@ class DummyProviderAdapter implements CurrencyExchangeRatesProviderAdapterInterf
      *
      * @return array
      */
-    public function getExchangeRates(array $symbols = array(), $base = null)
+    public function getExchangeRates(array $symbols = [], $base = null)
     {
         return [];
     }

--- a/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/Interfaces/CurrencyExchangeRatesProviderAdapterInterface.php
+++ b/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/Interfaces/CurrencyExchangeRatesProviderAdapterInterface.php
@@ -30,7 +30,7 @@ interface CurrencyExchangeRatesProviderAdapterInterface
      *
      * @return array exchange rates
      */
-    public function getExchangeRates(array $symbols = array(), $base = null);
+    public function getExchangeRates(array $symbols = [], $base = null);
 
     /**
      * Gets a list of all available currencies

--- a/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/OpenExchangeRatesProviderAdapter.php
+++ b/src/Elcodi/Component/Currency/Adapter/CurrencyExchangeRatesProvider/OpenExchangeRatesProviderAdapter.php
@@ -94,7 +94,7 @@ class OpenExchangeRatesProviderAdapter implements CurrencyExchangeRatesProviderA
 
         $request = $this->client->createRequest(
             'GET',
-            $this->endPoint.'/convert/'.$value.'/'.$symbolFrom.'/'.$symbolTo,
+            $this->endPoint . '/convert/' . $value . '/' . $symbolFrom . '/' . $symbolTo,
             ['query' => $query]
         );
 
@@ -110,7 +110,7 @@ class OpenExchangeRatesProviderAdapter implements CurrencyExchangeRatesProviderA
      *
      * @return array
      */
-    public function getExchangeRates(array $symbols = array(), $base = null)
+    public function getExchangeRates(array $symbols = [], $base = null)
     {
         $query = [
             'app_id' => $this->appId,
@@ -123,7 +123,7 @@ class OpenExchangeRatesProviderAdapter implements CurrencyExchangeRatesProviderA
 
         $request = $this->client->createRequest(
             'GET',
-            $this->endPoint.'/latest.json',
+            $this->endPoint . '/latest.json',
             ['query' => $query]
         );
 
@@ -137,7 +137,7 @@ class OpenExchangeRatesProviderAdapter implements CurrencyExchangeRatesProviderA
     {
         $request = $this->client->createRequest(
             'GET',
-            $this->endPoint.'/currencies.json',
+            $this->endPoint . '/currencies.json',
             ['query' => ['app_id' => $this->appId]]
         );
 
@@ -159,7 +159,7 @@ class OpenExchangeRatesProviderAdapter implements CurrencyExchangeRatesProviderA
             //send the req and return the json
             return $response->json();
         } catch (Exception $e) {
-            return array('error' => $request->getResponse()->json());
+            return ['error' => $request->getResponse()->json()];
         }
     }
 
@@ -174,7 +174,7 @@ class OpenExchangeRatesProviderAdapter implements CurrencyExchangeRatesProviderA
     {
         $request = $this->client->createRequest(
             'GET',
-            $this->endPoint.'/historical/'.$date->format('Y-m-d').'.json',
+            $this->endPoint . '/historical/' . $date->format('Y-m-d') . '.json',
             [
                 'query' => [
                         'app_id' => $this->appId,

--- a/src/Elcodi/Component/Currency/Populator/CurrencyExchangeRatesPopulator.php
+++ b/src/Elcodi/Component/Currency/Populator/CurrencyExchangeRatesPopulator.php
@@ -131,7 +131,7 @@ class CurrencyExchangeRatesPopulator
             ]);
 
         //extract target currency codes
-        $currenciesCodes = array();
+        $currenciesCodes = [];
         foreach ($currencies as $activeCurrency) {
             if ($activeCurrency->getIso() != $this->defaultCurrency) {
                 $currenciesCodes[] = $activeCurrency->getIso();

--- a/src/Elcodi/Component/Currency/Services/CurrencyExchangeRatesProvider.php
+++ b/src/Elcodi/Component/Currency/Services/CurrencyExchangeRatesProvider.php
@@ -67,10 +67,10 @@ class CurrencyExchangeRatesProvider
      *
      * @return array in the form of 'ISOCODE' => (float) exchange rate
      */
-    public function getExchangeRates($fromCode, $toCodes = array())
+    public function getExchangeRates($fromCode, $toCodes = [])
     {
         if (!is_array($toCodes)) {
-            $toCodes = array($toCodes);
+            $toCodes = [$toCodes];
         }
 
         if (empty($this->exchangeRates)) {
@@ -83,7 +83,7 @@ class CurrencyExchangeRatesProvider
 
         $baseExchangeRate = $this->exchangeRates[$fromCode];
 
-        $exchangeRates = array();
+        $exchangeRates = [];
         foreach ($toCodes as $code) {
             $exchangeRates[$code] = ($this->exchangeRates[$code] / $baseExchangeRate);
         }

--- a/src/Elcodi/Component/Currency/Tests/UnitTest/Twig/PrintMoneyExtensionTest.php
+++ b/src/Elcodi/Component/Currency/Tests/UnitTest/Twig/PrintMoneyExtensionTest.php
@@ -90,8 +90,7 @@ class PrintMoneyExtensionTest extends PHPUnit_Framework_TestCase
         $locale
             ->expects($this->any())
             ->method('getIso')
-            ->willReturn('es_ES')
-        ;
+            ->willReturn('es_ES');
 
         $priceExtension = new PrintMoneyExtension(
             $this->getMock('Elcodi\Component\Currency\Services\CurrencyConverter', [], [], '', false),

--- a/src/Elcodi/Component/Currency/Twig/PrintMoneyExtension.php
+++ b/src/Elcodi/Component/Currency/Twig/PrintMoneyExtension.php
@@ -80,11 +80,11 @@ class PrintMoneyExtension extends Twig_Extension
      */
     public function getFilters()
     {
-        return array(
-            new Twig_SimpleFilter('print_convert_money', array($this, 'printConvertMoney')),
-            new Twig_SimpleFilter('print_money', array($this, 'printMoney')),
-            new Twig_SimpleFilter('print_money_from_value', array($this, 'printMoneyFromValue')),
-        );
+        return [
+            new Twig_SimpleFilter('print_convert_money', [$this, 'printConvertMoney']),
+            new Twig_SimpleFilter('print_money', [$this, 'printMoney']),
+            new Twig_SimpleFilter('print_money_from_value', [$this, 'printMoneyFromValue']),
+        ];
     }
 
     /**

--- a/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
+++ b/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
@@ -104,8 +104,8 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
         $this->locales = $locales;
         $this->masterLocale = $masterLocale;
         $this->fallback = $fallback;
-        $this->submittedDataPlain = array();
-        $this->translationsBackup = array();
+        $this->submittedDataPlain = [];
+        $this->translationsBackup = [];
     }
 
     /**
@@ -130,11 +130,11 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             FormEvents::PRE_SUBMIT   => 'preSubmit',
             FormEvents::POST_SUBMIT  => 'postSubmit',
             FormEvents::PRE_SET_DATA => 'preSetData',
-        );
+        ];
     }
 
     /**
@@ -176,9 +176,9 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
                     $this->locales,
                     $this->masterLocale,
                     $this->fallback
-                ), array(
+                ), [
                     'mapped' => false,
-                ));
+                ]);
         }
     }
 
@@ -229,11 +229,11 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
             $field = $this->submittedDataPlain[$formHash][$fieldName];
 
             foreach ($this->locales as $locale) {
-                $entityData['fields'][$fieldName][$locale] = $field[$locale.'_'.$fieldName];
+                $entityData['fields'][$fieldName][$locale] = $field[$locale . '_' . $fieldName];
             }
 
-            if ($this->masterLocale && isset($field[$this->masterLocale.'_'.$fieldName])) {
-                $masterLocaleData = $field[$this->masterLocale.'_'.$fieldName];
+            if ($this->masterLocale && isset($field[$this->masterLocale . '_' . $fieldName])) {
+                $masterLocaleData = $field[$this->masterLocale . '_' . $fieldName];
                 $setter = $fieldConfiguration['setter'];
                 $entity->$setter($masterLocaleData);
             }

--- a/src/Elcodi/Component/EntityTranslator/Form/Type/TranslatableFieldType.php
+++ b/src/Elcodi/Component/EntityTranslator/Form/Type/TranslatableFieldType.php
@@ -152,7 +152,7 @@ class TranslatableFieldType extends AbstractType
             ->getName();
 
         foreach ($this->locales as $locale) {
-            $translatedFieldName = $locale.'_'.$this->fieldName;
+            $translatedFieldName = $locale . '_' . $this->fieldName;
 
             $entityId = $this->entity->$entityIdGetter();
             $translationData = $entityId
@@ -166,7 +166,7 @@ class TranslatableFieldType extends AbstractType
                     )
                 : '';
 
-            $builder->add($translatedFieldName, $fieldType, array(
+            $builder->add($translatedFieldName, $fieldType, [
                 'required' => isset($fieldOptions['required'])
                     ? $this->evaluateRequired(
                         $fieldOptions['required'],
@@ -176,7 +176,7 @@ class TranslatableFieldType extends AbstractType
                 'mapped'   => false,
                 'label'    => $fieldOptions['label'],
                 'data'     => $translationData,
-            ));
+            ]);
         }
     }
 

--- a/src/Elcodi/Component/EntityTranslator/Services/CachedEntityTranslationProvider.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/CachedEntityTranslationProvider.php
@@ -70,7 +70,7 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
         $this->entityTranslatorProvider = $entityTranslationProvider;
         $this->entityTranslationRepository = $entityTranslationRepository;
         $this->cachePrefix = $cachePrefix;
-        $this->translationsToBeFlushed = array();
+        $this->translationsToBeFlushed = [];
     }
 
     /**
@@ -225,10 +225,10 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
         $entityField,
         $locale
     ) {
-        return $this->cachePrefix.'_'.
-        $entityType.'_'.
-        $entityId.'_'.
-        $entityField.'_'.
+        return $this->cachePrefix . '_' .
+        $entityType . '_' .
+        $entityId . '_' .
+        $entityField . '_' .
         $locale;
     }
 }

--- a/src/Elcodi/Component/EntityTranslator/Services/EntityTranslationChangesBag.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/EntityTranslationChangesBag.php
@@ -34,7 +34,7 @@ class EntityTranslationChangesBag
      */
     public function __construct()
     {
-        $this->changes = array();
+        $this->changes = [];
     }
 
     /**

--- a/src/Elcodi/Component/EntityTranslator/Services/EntityTranslationProvider.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/EntityTranslationProvider.php
@@ -72,7 +72,7 @@ class EntityTranslationProvider implements EntityTranslationProviderInterface
         $this->entityTranslationRepository = $entityTranslationRepository;
         $this->entityTranslationFactory = $entityTranslationFactory;
         $this->entityTranslationObjectManager = $entityTranslationObjectManager;
-        $this->translationsToBeFlushed = array();
+        $this->translationsToBeFlushed = [];
     }
 
     /**
@@ -93,12 +93,12 @@ class EntityTranslationProvider implements EntityTranslationProviderInterface
     ) {
         $translation = $this
             ->entityTranslationRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'entityType'  => $entityType,
                 'entityId'    => $entityId,
                 'entityField' => $entityField,
                 'locale'      => $locale,
-            ));
+            ]);
 
         return $translation instanceof EntityTranslationInterface
             ? $translation->getTranslation()
@@ -125,12 +125,12 @@ class EntityTranslationProvider implements EntityTranslationProviderInterface
     ) {
         $translation = $this
             ->entityTranslationRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'entityType'  => $entityType,
                 'entityId'    => $entityId,
                 'entityField' => $entityField,
                 'locale'      => $locale,
-            ));
+            ]);
 
         if (!($translation instanceof EntityTranslationInterface)) {
             $translation = $this
@@ -164,7 +164,7 @@ class EntityTranslationProvider implements EntityTranslationProviderInterface
             ->entityTranslationObjectManager
             ->flush($this->translationsToBeFlushed);
 
-        $this->translationsToBeFlushed = array();
+        $this->translationsToBeFlushed = [];
 
         return $this;
     }

--- a/src/Elcodi/Component/EntityTranslator/Services/EntityTranslatorBuilder.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/EntityTranslatorBuilder.php
@@ -190,7 +190,7 @@ class EntityTranslatorBuilder
                 }
 
                 throw new TranslationDefinitionException(
-                    'Field '.$classNamespace.' not found, or methods ['.$fieldConfiguration['getter'].', '.$fieldConfiguration['setter'].'] not found inside the class'
+                    'Field ' . $classNamespace . ' not found, or methods [' . $fieldConfiguration['getter'] . ', ' . $fieldConfiguration['setter'] . '] not found inside the class'
                 );
             }
         }

--- a/src/Elcodi/Component/EntityTranslator/Tests/Services/TranslatorBuilderTest.php
+++ b/src/Elcodi/Component/EntityTranslator/Tests/Services/TranslatorBuilderTest.php
@@ -31,27 +31,27 @@ class TranslatorBuilderTest extends PHPUnit_Framework_TestCase
      */
     public function testCompileOk()
     {
-        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', array(), array(), '', false);
-        $translatorFactory = $this->getMock('Elcodi\Component\EntityTranslator\Factory\EntityTranslatorFactory', array(), array(), '', false);
-        $translator = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslator', array(), array(), '', false);
+        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', [], [], '', false);
+        $translatorFactory = $this->getMock('Elcodi\Component\EntityTranslator\Factory\EntityTranslatorFactory', [], [], '', false);
+        $translator = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslator', [], [], '', false);
 
         $translatorFactory
             ->expects($this->once())
             ->method('create')
             ->will($this->returnValue($translator));
 
-        $configuration = array(
-            'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => array(
+        $configuration = [
+            'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => [
                 'alias'    => 'product',
                 'idGetter' => 'getId',
-                'fields'   => array(
-                    'name' => array(
+                'fields'   => [
+                    'name' => [
                         'setter' => 'setName',
                         'getter' => 'getName',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $translatorBuilder = new EntityTranslatorBuilder(
             $entityTranslationProvider,
@@ -72,8 +72,8 @@ class TranslatorBuilderTest extends PHPUnit_Framework_TestCase
      */
     public function testCompileException($configuration)
     {
-        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', array(), array(), '', false);
-        $translatorFactory = $this->getMock('Elcodi\Component\EntityTranslator\Factory\EntityTranslatorFactory', array(), array(), '', false);
+        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', [], [], '', false);
+        $translatorFactory = $this->getMock('Elcodi\Component\EntityTranslator\Factory\EntityTranslatorFactory', [], [], '', false);
 
         $translatorBuilder = new EntityTranslatorBuilder(
             $entityTranslationProvider,
@@ -92,69 +92,69 @@ class TranslatorBuilderTest extends PHPUnit_Framework_TestCase
         return [
             [
                 [
-                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\NonExistingProduct' => array(
+                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\NonExistingProduct' => [
                         'alias'    => 'product',
                         'getterId' => 'getId',
-                        'fields'   => array(
-                            'name' => array(
+                        'fields'   => [
+                            'name' => [
                                 'setter' => 'setName',
                                 'getter' => 'getName',
-                            ),
-                        ),
-                    ),
+                            ],
+                        ],
+                    ],
                 ],
             ],
             [
                 [
-                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => array(
+                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => [
                         'alias'    => 'product',
                         'getterId' => 'nonExistingGetId',
-                        'fields'   => array(
-                            'name' => array(
+                        'fields'   => [
+                            'name' => [
                                 'setter' => 'setName',
                                 'getter' => 'getName',
-                            ),
-                        ),
-                    ),
+                            ],
+                        ],
+                    ],
                 ],
             ],
             [
                 [
-                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => array(
+                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => [
                         'alias'  => '',
-                        'fields' => array(
-                            'name' => array(
+                        'fields' => [
+                            'name' => [
                                 'setter' => 'setName',
                                 'getter' => 'getName',
-                            ),
-                        ),
-                    ),
+                            ],
+                        ],
+                    ],
                 ],
             ],
             [
                 [
-                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => array(
+                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => [
                         'alias'  => 'product',
-                        'fields' => array(
-                            'name' => array(
+                        'fields' => [
+                            'name' => [
                                 'setter' => 'nonExistingSetName',
                                 'getter' => 'getName',
-                            ),
-                        ),
-                    ),
+                            ],
+                        ],
+                    ],
                 ],
             ],
             [
                 [
-                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => array(
+                    'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => [
                         'alias'  => 'product',
-                        'fields' => array(
-                            'name' => array(
+                        'fields' => [
+                            'name' => [
                                 'setter' => 'setName',
                                 'getter' => 'nonExistingGetName',
-                            ),
-                        ),
-                    ),
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];

--- a/src/Elcodi/Component/EntityTranslator/Tests/Services/TranslatorTest.php
+++ b/src/Elcodi/Component/EntityTranslator/Tests/Services/TranslatorTest.php
@@ -32,7 +32,7 @@ class TranslatorTest extends PHPUnit_Framework_TestCase
      */
     public function testTranslate()
     {
-        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', array(), array(), '', false);
+        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', [], [], '', false);
         $entityTranslationProvider
             ->expects($this->once())
             ->method('getTranslation')
@@ -44,18 +44,18 @@ class TranslatorTest extends PHPUnit_Framework_TestCase
             )
             ->will($this->returnValue('translatedProductName'));
 
-        $configuration = array(
-            'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => array(
+        $configuration = [
+            'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => [
                 'alias'    => 'product',
                 'idGetter' => 'getId',
-                'fields'   => array(
-                    'name' => array(
+                'fields'   => [
+                    'name' => [
                         'setter' => 'setName',
                         'getter' => 'getName',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $translator = new EntityTranslator(
             $entityTranslationProvider,
@@ -78,56 +78,56 @@ class TranslatorTest extends PHPUnit_Framework_TestCase
      */
     public function testSave()
     {
-        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', array(), array(), '', false);
+        $entityTranslationProvider = $this->getMock('Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider', [], [], '', false);
         $entityTranslationProvider
             ->expects($this->exactly(4))
             ->method('setTranslation')
-            ->withConsecutive(array(
+            ->withConsecutive([
                 $this->equalTo('product'),
                 $this->equalTo('1'),
                 $this->equalTo('name'),
                 $this->equalTo('el nombre'),
                 $this->equalTo('es'),
-            ), array(
+            ], [
                 $this->equalTo('product'),
                 $this->equalTo('1'),
                 $this->equalTo('description'),
                 $this->equalTo('la descripción'),
                 $this->equalTo('es'),
-            ), array(
+            ], [
                 $this->equalTo('product'),
                 $this->equalTo('1'),
                 $this->equalTo('name'),
                 $this->equalTo('the name'),
                 $this->equalTo('en'),
-            ), array(
+            ], [
                 $this->equalTo('product'),
                 $this->equalTo('1'),
                 $this->equalTo('description'),
                 $this->equalTo('the description'),
                 $this->equalTo('en'),
-            ));
+            ]);
 
         $entityTranslationProvider
             ->expects($this->once())
             ->method('flushTranslations');
 
-        $configuration = array(
-            'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => array(
+        $configuration = [
+            'Elcodi\Component\EntityTranslator\Tests\Fixtures\TranslatableProduct' => [
                 'alias'    => 'product',
                 'idGetter' => 'getId',
-                'fields'   => array(
-                    'name'        => array(
+                'fields'   => [
+                    'name'        => [
                         'setter' => 'setName',
                         'getter' => 'getName',
-                    ),
-                    'description' => array(
+                    ],
+                    'description' => [
                         'setter' => 'setDescription',
                         'getter' => 'getDescription',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $translator = new EntityTranslator(
             $entityTranslationProvider,
@@ -141,16 +141,16 @@ class TranslatorTest extends PHPUnit_Framework_TestCase
             ->setName('wrong name')
             ->setDescription('wrong description');
 
-        $translator->save($product, array(
-            'es' => array(
+        $translator->save($product, [
+            'es' => [
                 'name'        => 'el nombre',
                 'description' => 'la descripción',
-            ),
-            'en' => array(
+            ],
+            'en' => [
                 'name'         => 'the name',
                 'description'  => 'the description',
                 'anotherfield' => 'some value',
-            ),
-        ));
+            ],
+        ]);
     }
 }

--- a/src/Elcodi/Component/Geo/Formatter/AddressFormatter.php
+++ b/src/Elcodi/Component/Geo/Formatter/AddressFormatter.php
@@ -56,7 +56,7 @@ class AddressFormatter
             ->getHierarchy($cityLocationId);
         $cityHierarchyAsc = array_reverse($cityHierarchy);
 
-        $addressArray = array(
+        $addressArray = [
             'id'               => $address->getId(),
             'name'             => $address->getName(),
             'recipientName'    => $address->getRecipientName(),
@@ -67,7 +67,7 @@ class AddressFormatter
             'phone'            => $address->getPhone(),
             'mobile'           => $address->getMobile(),
             'comment'          => $address->getComments(),
-        );
+        ];
 
         foreach ($cityHierarchyAsc as $cityLocationNode) {
             /**

--- a/src/Elcodi/Component/Geo/Populator/Adapters/GeonamesPopulatorAdapter.php
+++ b/src/Elcodi/Component/Geo/Populator/Adapters/GeonamesPopulatorAdapter.php
@@ -94,13 +94,13 @@ class GeonamesPopulatorAdapter implements PopulatorInterface
      */
     protected function downloadFile($countryCode)
     {
-        $tempname = sys_get_temp_dir().'/elcodi-locator-geonames-'.$countryCode.'.zip';
+        $tempname = sys_get_temp_dir() . '/elcodi-locator-geonames-' . $countryCode . '.zip';
         if (!file_exists($tempname)) {
             $dirname = dirname($tempname);
             if (!file_exists($dirname)) {
                 mkdir($dirname, 0777, true);
             }
-            $downloadUrl = 'http://download.geonames.org/export/zip/'.$countryCode.'.zip';
+            $downloadUrl = 'http://download.geonames.org/export/zip/' . $countryCode . '.zip';
             copy($downloadUrl, $tempname);
         }
 
@@ -171,7 +171,7 @@ class GeonamesPopulatorAdapter implements PopulatorInterface
             $state = $this
                 ->locationBuilder
                 ->addLocation(
-                    $country->getId().'_'.$stateId,
+                    $country->getId() . '_' . $stateId,
                     $columns[3],
                     $stateId,
                     'state',
@@ -182,7 +182,7 @@ class GeonamesPopulatorAdapter implements PopulatorInterface
             $province = $this
                 ->locationBuilder
                 ->addLocation(
-                    $state->getId().'_'.$provinceId,
+                    $state->getId() . '_' . $provinceId,
                     $columns[5],
                     $provinceId,
                     'province',
@@ -193,7 +193,7 @@ class GeonamesPopulatorAdapter implements PopulatorInterface
             $city = $this
                 ->locationBuilder
                 ->addLocation(
-                    $province->getId().'_'.$cityId,
+                    $province->getId() . '_' . $cityId,
                     $columns[2],
                     $cityId,
                     'city',
@@ -204,7 +204,7 @@ class GeonamesPopulatorAdapter implements PopulatorInterface
             $this
                 ->locationBuilder
                 ->addLocation(
-                    $city->getId().'_'.$postalCodeId,
+                    $city->getId() . '_' . $postalCodeId,
                     $columns[1],
                     $postalCodeId,
                     'postalcode',
@@ -220,8 +220,8 @@ class GeonamesPopulatorAdapter implements PopulatorInterface
         $lexer->parse($pathname, $interpreter);
         $finished = new DateTime();
         $elapsed = $finished->diff($started);
-        $output->writeln('<header>[Geo]</header> <body>Processed '.$nbItems.' entries</body>');
-        $output->writeln('<header>[Geo]</header> <body>File processed in '.$elapsed->format('%s').' seconds</body>');
+        $output->writeln('<header>[Geo]</header> <body>Processed ' . $nbItems . ' entries</body>');
+        $output->writeln('<header>[Geo]</header> <body>File processed in ' . $elapsed->format('%s') . ' seconds</body>');
 
         return [$country];
     }

--- a/src/Elcodi/Component/Geo/Services/LocationApiProvider.php
+++ b/src/Elcodi/Component/Geo/Services/LocationApiProvider.php
@@ -84,7 +84,7 @@ class LocationApiProvider implements LocationProviderInterface
     {
         $url = $this
             ->apiUrls
-            ->getGetChildrenUrl().'?id='.$id;
+            ->getGetChildrenUrl() . '?id=' . $id;
 
         return $this->getDataFromApi($url);
     }
@@ -100,7 +100,7 @@ class LocationApiProvider implements LocationProviderInterface
     {
         $url = $this
             ->apiUrls
-            ->getGetParentsUrl().'?id='.$id;
+            ->getGetParentsUrl() . '?id=' . $id;
 
         return $this->getDataFromApi($url);
     }
@@ -116,7 +116,7 @@ class LocationApiProvider implements LocationProviderInterface
     {
         $url = $this
             ->apiUrls
-            ->getGetLocationUrl().'?id='.$id;
+            ->getGetLocationUrl() . '?id=' . $id;
 
         return $this->getDataFromApi($url);
     }
@@ -133,7 +133,7 @@ class LocationApiProvider implements LocationProviderInterface
     {
         $url = $this
             ->apiUrls
-            ->getGetHierarchyUrl().'?id='.$id;
+            ->getGetHierarchyUrl() . '?id=' . $id;
 
         return $this->getDataFromApi($url);
     }
@@ -151,7 +151,7 @@ class LocationApiProvider implements LocationProviderInterface
     {
         $url = $this
             ->apiUrls
-            ->getInUrl().'?id='.$id.'&ids='.implode(',', $ids);
+            ->getInUrl() . '?id=' . $id . '&ids=' . implode(',', $ids);
 
         return $this->getDataFromApi($url);
     }

--- a/src/Elcodi/Component/Geo/Services/LocationBuilder.php
+++ b/src/Elcodi/Component/Geo/Services/LocationBuilder.php
@@ -48,7 +48,7 @@ class LocationBuilder
     {
         $this->locationFactory = $locationFactory;
 
-        $this->locations = array();
+        $this->locations = [];
     }
 
     /**

--- a/src/Elcodi/Component/Language/Services/LanguageManager.php
+++ b/src/Elcodi/Component/Language/Services/LanguageManager.php
@@ -57,9 +57,9 @@ class LanguageManager
         return new ArrayCollection(
             $this
                 ->languageRepository
-                ->findBy(array(
+                ->findBy([
                     'enabled' => true,
-                ))
+                ])
         );
     }
 

--- a/src/Elcodi/Component/Language/Services/LocaleManager.php
+++ b/src/Elcodi/Component/Language/Services/LocaleManager.php
@@ -89,7 +89,7 @@ class LocaleManager
      */
     public function initialize()
     {
-        setlocale(LC_ALL, $this->locale->getIso().'.'.$this->encoding);
+        setlocale(LC_ALL, $this->locale->getIso() . '.' . $this->encoding);
         $this->localeInfo = localeconv();
 
         return $this;

--- a/src/Elcodi/Component/Language/Twig/LanguageExtension.php
+++ b/src/Elcodi/Component/Language/Twig/LanguageExtension.php
@@ -63,9 +63,9 @@ class LanguageExtension extends Twig_Extension
      */
     public function getGlobals()
     {
-        return array(
+        return [
             'elcodi_languages' => $this->getLanguages(),
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Component/Media/Adapter/Resizer/ImageMagickResizeAdapter.php
+++ b/src/Elcodi/Component/Media/Adapter/Resizer/ImageMagickResizeAdapter.php
@@ -113,34 +113,34 @@ class ImageMagickResizeAdapter implements ResizeAdapterInterface
                 case ElcodiMediaImageResizeTypes::INSET:
 
                     $pb
-                        ->add($width.'x'.$height);
+                        ->add($width . 'x' . $height);
 
                     break;
 
                 case ElcodiMediaImageResizeTypes::INSET_FILL_WHITE:
                     $pb
-                        ->add($width.'x'.$height)
+                        ->add($width . 'x' . $height)
                         ->add('-gravity')
                         ->add('center')
                         ->add('-extent')
-                        ->add($width.'x'.$height);
+                        ->add($width . 'x' . $height);
 
                     break;
 
                 case ElcodiMediaImageResizeTypes::OUTBOUNDS_FILL_WHITE:
 
                     $pb
-                        ->add($width.'x'.$height.'');
+                        ->add($width . 'x' . $height . '');
 
                     break;
 
                 case ElcodiMediaImageResizeTypes::OUTBOUND_CROP:
                     $pb
-                        ->add($width.'x'.$height.'^')
+                        ->add($width . 'x' . $height . '^')
                         ->add('-gravity')
                         ->add('center')
                         ->add('-crop')
-                        ->add($width.'x'.$height.'+0+0');
+                        ->add($width . 'x' . $height . '+0+0');
 
                     break;
 
@@ -148,7 +148,7 @@ class ImageMagickResizeAdapter implements ResizeAdapterInterface
                 default:
 
                     $pb
-                        ->add($width.'x'.$height.'!');
+                        ->add($width . 'x' . $height . '!');
                     break;
             }
         }

--- a/src/Elcodi/Component/Media/Controller/ImageResizeController.php
+++ b/src/Elcodi/Component/Media/Controller/ImageResizeController.php
@@ -170,9 +170,9 @@ class ImageResizeController
             ->setContent($imageData);
 
         $response->headers->add(
-            array(
+            [
                 'Content-Type' => $image->getContentType(),
-            )
+            ]
         );
 
         return $response;

--- a/src/Elcodi/Component/Media/Router/ImageResizeRouterLoader.php
+++ b/src/Elcodi/Component/Media/Router/ImageResizeRouterLoader.php
@@ -81,9 +81,9 @@ class ImageResizeRouterLoader implements LoaderInterface
 
         $routes = new RouteCollection();
 
-        $routes->add($this->imageResizeControllerRouteName, new Route($this->imageResizeControllerRoute, array(
+        $routes->add($this->imageResizeControllerRouteName, new Route($this->imageResizeControllerRoute, [
             '_controller' => 'elcodi.controller.media_image_resize:resizeAction',
-        )));
+        ]));
 
         $this->loaded = true;
 

--- a/src/Elcodi/Component/Media/Router/ImageUploadRouterLoader.php
+++ b/src/Elcodi/Component/Media/Router/ImageUploadRouterLoader.php
@@ -80,9 +80,9 @@ class ImageUploadRouterLoader implements LoaderInterface
         }
 
         $routes = new RouteCollection();
-        $routes->add($this->imageUploadControllerRouteName, new Route($this->imageUploadControllerRoute, array(
+        $routes->add($this->imageUploadControllerRouteName, new Route($this->imageUploadControllerRoute, [
             '_controller' => 'elcodi.controller.media_image_upload:uploadAction',
-        )));
+        ]));
 
         $this->loaded = true;
 

--- a/src/Elcodi/Component/Media/Router/ImageViewRouterLoader.php
+++ b/src/Elcodi/Component/Media/Router/ImageViewRouterLoader.php
@@ -83,12 +83,12 @@ class ImageViewRouterLoader implements LoaderInterface
 
         $routes = new RouteCollection();
 
-        $routes->add($this->imageViewControllerRouteName, new Route($this->imageViewControllerRoute, array(
+        $routes->add($this->imageViewControllerRouteName, new Route($this->imageViewControllerRoute, [
             '_controller' => 'elcodi.controller.media_image_resize:resizeAction',
             'height'      => 0,
             'width'       => 0,
             'type'        => ElcodiMediaImageResizeTypes::NO_RESIZE,
-        )));
+        ]));
 
         $this->loaded = true;
 

--- a/src/Elcodi/Component/Media/Tests/UnitTest/Services/ImageManagerTest.php
+++ b/src/Elcodi/Component/Media/Tests/UnitTest/Services/ImageManagerTest.php
@@ -105,21 +105,21 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
      */
     public function regularImagesProvider()
     {
-        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR;
+        $tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
         $imageJpeg = imagecreate(1, 1);
         $white = imagecolorallocate($imageJpeg, 255, 255, 255);
         imagesetpixel($imageJpeg, 1, 1, $white);
-        imagejpeg($imageJpeg, $tmpDir.'test.jpg');
-        $jpegFilePath = $tmpDir.'test.jpg';
+        imagejpeg($imageJpeg, $tmpDir . 'test.jpg');
+        $jpegFilePath = $tmpDir . 'test.jpg';
 
-        $pngTransparentPixel = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3a'.
+        $pngTransparentPixel = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3a' .
             'AAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII';
-        file_put_contents($tmpDir.'test.png', base64_decode($pngTransparentPixel));
-        $pngFilePath = $tmpDir.'test.png';
+        file_put_contents($tmpDir . 'test.png', base64_decode($pngTransparentPixel));
+        $pngFilePath = $tmpDir . 'test.png';
 
         $gifTransparentPixel = 'R0lGODlhAQABAJAAAP8AAAAAACH5BAUQAAAALAAAAAABAAEAAAICBAEAOw';
-        file_put_contents($tmpDir.'test.gif', base64_decode($gifTransparentPixel));
-        $gifFilePath = $tmpDir.'test.gif';
+        file_put_contents($tmpDir . 'test.gif', base64_decode($gifTransparentPixel));
+        $gifFilePath = $tmpDir . 'test.gif';
 
         return [
             [$jpegFilePath],
@@ -133,21 +133,21 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
      */
     public function imagesAsOctetStreamProvider()
     {
-        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR;
+        $tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
         $imageJpeg = imagecreate(1, 1);
         $white = imagecolorallocate($imageJpeg, 255, 255, 255);
         imagesetpixel($imageJpeg, 1, 1, $white);
-        imagejpeg($imageJpeg, $tmpDir.'test.jpg');
-        $jpegFilePath = $tmpDir.'test.jpg';
+        imagejpeg($imageJpeg, $tmpDir . 'test.jpg');
+        $jpegFilePath = $tmpDir . 'test.jpg';
 
-        $pngTransparentPixel = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3a'.
+        $pngTransparentPixel = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3a' .
             'AAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII';
-        file_put_contents($tmpDir.'test.png', base64_decode($pngTransparentPixel));
-        $pngFilePath = $tmpDir.'test.png';
+        file_put_contents($tmpDir . 'test.png', base64_decode($pngTransparentPixel));
+        $pngFilePath = $tmpDir . 'test.png';
 
         $gifTransparentPixel = 'R0lGODlhAQABAJAAAP8AAAAAACH5BAUQAAAALAAAAAABAAEAAAICBAEAOw';
-        file_put_contents($tmpDir.'test.gif', base64_decode($gifTransparentPixel));
-        $gifFilePath = $tmpDir.'test.gif';
+        file_put_contents($tmpDir . 'test.gif', base64_decode($gifTransparentPixel));
+        $gifFilePath = $tmpDir . 'test.gif';
 
         $mockJpegOctet = $this
             ->getMockBuilder('\Symfony\Component\HttpFoundation\File\File')

--- a/src/Elcodi/Component/Media/Transformer/FileIdentifierTransformer.php
+++ b/src/Elcodi/Component/Media/Transformer/FileIdentifierTransformer.php
@@ -34,7 +34,7 @@ class FileIdentifierTransformer implements FileIdentifierTransformerInterface
      */
     public function transform(FileInterface $file)
     {
-        return $file->getId().'.'.
+        return $file->getId() . '.' .
         $file->getExtension();
     }
 }

--- a/src/Elcodi/Component/Media/Transformer/ImageEtagTransformer.php
+++ b/src/Elcodi/Component/Media/Transformer/ImageEtagTransformer.php
@@ -42,10 +42,10 @@ class ImageEtagTransformer implements ImageEtagTransformerInterface
         $type
     ) {
         return sha1(
-            $image->getId().".".
-            $image->getUpdatedAt()->getTimestamp().".".
-            $height.".".
-            $width.".".
+            $image->getId() . "." .
+            $image->getUpdatedAt()->getTimestamp() . "." .
+            $height . "." .
+            $width . "." .
             $type
         );
     }

--- a/src/Elcodi/Component/Media/Twig/ImageExtension.php
+++ b/src/Elcodi/Component/Media/Twig/ImageExtension.php
@@ -108,10 +108,10 @@ class ImageExtension extends Twig_Extension
      */
     public function getFilters()
     {
-        return array(
-            new Twig_SimpleFilter('resize', array($this, 'resize')),
-            new Twig_SimpleFilter('viewImage', array($this, 'viewImage')),
-        );
+        return [
+            new Twig_SimpleFilter('resize', [$this, 'resize']),
+            new Twig_SimpleFilter('viewImage', [$this, 'viewImage']),
+        ];
     }
 
     /**
@@ -126,13 +126,13 @@ class ImageExtension extends Twig_Extension
     {
         $generatedRoute = $this
             ->router
-            ->generate($this->imageResizeControllerRouteName, array(
+            ->generate($this->imageResizeControllerRouteName, [
                 'id'      => (int) $imageMedia->getId(),
                 'height'  => (int) $options['height'],
                 'width'   => (int) $options['width'],
                 'type'    => (int) $options['type'],
                 '_format' => $imageMedia->getExtension(),
-            ), $this->generateAbsolutePath);
+            ], $this->generateAbsolutePath);
 
         /*
          * Returning generated URL, with or without absolute path
@@ -152,10 +152,10 @@ class ImageExtension extends Twig_Extension
     {
         $generatedRoute = $this
             ->router
-            ->generate($this->imageViewControllerRouteName, array(
+            ->generate($this->imageViewControllerRouteName, [
                 'id'      => (int) $imageMedia->getId(),
                 '_format' => $imageMedia->getExtension(),
-            ), $this->generateAbsolutePath);
+            ], $this->generateAbsolutePath);
 
         return $this->randomizeBaseUrls($generatedRoute);
     }
@@ -186,7 +186,7 @@ class ImageExtension extends Twig_Extension
         $random = substr(mt_rand(), 0, 1) % count($hostNames);
         $hostName = $hostNames[$random];
 
-        return '//'.$hostName.$path;
+        return '//' . $hostName . $path;
     }
 
     /**

--- a/src/Elcodi/Component/Menu/Services/MenuManager.php
+++ b/src/Elcodi/Component/Menu/Services/MenuManager.php
@@ -150,7 +150,7 @@ class MenuManager extends AbstractCacheWrapper
      */
     protected function buildKey($key, $menuCode)
     {
-        return $key.'-'.$menuCode;
+        return $key . '-' . $menuCode;
     }
 
     /**

--- a/src/Elcodi/Component/Menu/Twig/PrintRouteExtension.php
+++ b/src/Elcodi/Component/Menu/Twig/PrintRouteExtension.php
@@ -60,7 +60,7 @@ class PrintRouteExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('generate_url', array($this, 'printUrl')),
+            new Twig_SimpleFunction('generate_url', [$this, 'printUrl']),
         ];
     }
 

--- a/src/Elcodi/Component/Metric/API/Twig/APIMetricExtension.php
+++ b/src/Elcodi/Component/Metric/API/Twig/APIMetricExtension.php
@@ -52,10 +52,10 @@ class APIMetricExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('metric_beacon_unique', array($this, 'getBeaconsUnique')),
-            new Twig_SimpleFunction('metric_beacon_total', array($this, 'getBeaconsTotal')),
-            new Twig_SimpleFunction('metric_accumulation', array($this, 'getAccumulation')),
-            new Twig_SimpleFunction('metric_distributions', array($this, 'getDistributions')),
+            new Twig_SimpleFunction('metric_beacon_unique', [$this, 'getBeaconsUnique']),
+            new Twig_SimpleFunction('metric_beacon_total', [$this, 'getBeaconsTotal']),
+            new Twig_SimpleFunction('metric_accumulation', [$this, 'getAccumulation']),
+            new Twig_SimpleFunction('metric_distributions', [$this, 'getDistributions']),
         ];
     }
 

--- a/src/Elcodi/Component/Metric/Core/Bucket/Abstracts/AbstractMetricsBucket.php
+++ b/src/Elcodi/Component/Metric/Core/Bucket/Abstracts/AbstractMetricsBucket.php
@@ -36,10 +36,10 @@ abstract class AbstractMetricsBucket
     protected function generateEntryKey($token, $event, $date)
     {
         return
-            $this->normalizeForKey($token).
-            '.'.
-            $this->normalizeForKey($event).
-            '.'.
+            $this->normalizeForKey($token) .
+            '.' .
+            $this->normalizeForKey($event) .
+            '.' .
             $this->normalizeForKey($date);
     }
 

--- a/src/Elcodi/Component/Metric/Core/Bucket/RedisMetricsBucket.php
+++ b/src/Elcodi/Component/Metric/Core/Bucket/RedisMetricsBucket.php
@@ -127,7 +127,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
         $this
             ->redis
             ->pfAdd(
-                $entryKey.'_unique',
+                $entryKey . '_unique',
                 $entry->getValue()
             );
 
@@ -148,7 +148,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
     ) {
         $this
             ->redis
-            ->incr($entryKey.'_total');
+            ->incr($entryKey . '_total');
 
         return $this;
     }
@@ -168,7 +168,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
         $this
             ->redis
             ->incrby(
-                $entryKey.'_accum',
+                $entryKey . '_accum',
                 (int) $entry->getValue()
             );
 
@@ -190,7 +190,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
         $this
             ->redis
             ->hincrby(
-                $entryKey.'_distr',
+                $entryKey . '_distr',
                 $entry->getValue(),
                 1
             );
@@ -220,7 +220,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
                 $token,
                 $event,
                 $date
-            ).'_unique';
+            ) . '_unique';
         }
 
         return (int) $this
@@ -250,7 +250,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
 
             $total += (int) $this
                 ->redis
-                ->get($key.'_total');
+                ->get($key . '_total');
         }
 
         return $total;
@@ -278,7 +278,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
 
             $total += (int) $this
                 ->redis
-                ->get($key.'_accum');
+                ->get($key . '_accum');
         }
 
         return $total;
@@ -312,7 +312,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
 
             $partials = $this
                 ->redis
-                ->hgetall($key.'_distr');
+                ->hgetall($key . '_distr');
 
             foreach ($partials as $key => $value) {
                 $distributions[$key] = isset($partialTotals[$key])

--- a/src/Elcodi/Component/Metric/Input/Router/MetricInputLoader.php
+++ b/src/Elcodi/Component/Metric/Input/Router/MetricInputLoader.php
@@ -81,9 +81,9 @@ class MetricInputLoader implements LoaderInterface
 
         $routes = new RouteCollection();
 
-        $routes->add($this->inputControllerRouteName, new Route($this->inputResizeControllerRoute, array(
+        $routes->add($this->inputControllerRouteName, new Route($this->inputResizeControllerRoute, [
             '_controller' => 'elcodi.controller.metric_input:addEntryAction',
-        )));
+        ]));
 
         $this->loaded = true;
 

--- a/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
+++ b/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
@@ -145,10 +145,10 @@ class NewsletterManager
             throw new NewsletterCannotBeRemovedException();
         }
 
-        $conditions = array(
+        $conditions = [
             'email' => $email,
             'hash'  => $hash,
-        );
+        ];
 
         if ($language instanceof LanguageInterface) {
             $conditions['language'] = $language;
@@ -198,9 +198,9 @@ class NewsletterManager
     {
         return $this
             ->newsletterSubscriptionRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'email' => $email,
-            ));
+            ]);
     }
 
     /**

--- a/src/Elcodi/Component/Page/Renderer/TemplatedPageRenderer.php
+++ b/src/Elcodi/Component/Page/Renderer/TemplatedPageRenderer.php
@@ -84,9 +84,9 @@ class TemplatedPageRenderer implements PageRendererInterface
         return $this
             ->engine
             ->render(
-                $templateName, array(
+                $templateName, [
                     'page' => $page,
-                )
+                ]
             );
     }
 

--- a/src/Elcodi/Component/Page/Repository/PageRepository.php
+++ b/src/Elcodi/Component/Page/Repository/PageRepository.php
@@ -39,10 +39,10 @@ class PageRepository extends EntityRepository
      */
     public function findOneByPath($path)
     {
-        return $this->findOneBy(array(
+        return $this->findOneBy([
             'path'    => $path,
             'enabled' => true,
-        ));
+        ]);
     }
 
     /**

--- a/src/Elcodi/Component/Page/Tests/Entity/PageTest.php
+++ b/src/Elcodi/Component/Page/Tests/Entity/PageTest.php
@@ -58,10 +58,10 @@ class PageTest extends \PHPUnit_Framework_TestCase
 
     public function persistentProvider()
     {
-        return array(
-            'The page is persistent'     => array(true),
-            'The page is not persistent' => array(false),
-        );
+        return [
+            'The page is persistent'     => [true],
+            'The page is not persistent' => [false],
+        ];
     }
 
     /**

--- a/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/EventAdapter.php
+++ b/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/EventAdapter.php
@@ -48,7 +48,7 @@ class EventAdapter extends Event implements EventInterface
      * @param array  $context Caller's context
      * @param string $content Original content
      */
-    public function __construct(array $context = array(), $content = '')
+    public function __construct(array $context = [], $content = '')
     {
         $this->content = $content;
         $this->context = $context;

--- a/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/HookSystemAdapter.php
+++ b/src/Elcodi/Component/Plugin/Adapter/EventDispatcher/HookSystemAdapter.php
@@ -71,7 +71,7 @@ class HookSystemAdapter implements HookSystemInterface
      *
      * @return mixed Content after transformation
      */
-    public function execute($hookName, $context = array(), $content = '')
+    public function execute($hookName, $context = [], $content = '')
     {
         $event = new EventAdapter($context, $content);
         $this->eventDispatcher->dispatch($hookName, $event);

--- a/src/Elcodi/Component/Plugin/Command/PluginsLoadCommand.php
+++ b/src/Elcodi/Component/Plugin/Command/PluginsLoadCommand.php
@@ -76,7 +76,7 @@ class PluginsLoadCommand extends Command
         foreach ($plugins as $plugin) {
             $formattedLine = $formatter->formatSection(
                 'OK',
-                'Plugin "'.$plugin['bundle'].'" installed'
+                'Plugin "' . $plugin['bundle'] . '" installed'
             );
 
             $output->writeln($formattedLine);

--- a/src/Elcodi/Component/Plugin/ExpressionLanguage/PluginExpressionLanguageProvider.php
+++ b/src/Elcodi/Component/Plugin/ExpressionLanguage/PluginExpressionLanguageProvider.php
@@ -30,7 +30,7 @@ class PluginExpressionLanguageProvider implements ExpressionFunctionProviderInte
      */
     public function getFunctions()
     {
-        return array(
+        return [
             new ExpressionFunction('elcodi_plugin', function ($pluginNamespace) {
                 return sprintf(
                     '$this->get(\'elcodi.plugin_manager\')->getPlugin(%s)',
@@ -41,6 +41,6 @@ class PluginExpressionLanguageProvider implements ExpressionFunctionProviderInte
                     ->get('elcodi.plugin_manager')
                     ->getPlugin($pluginNamespace);
             }),
-        );
+        ];
     }
 }

--- a/src/Elcodi/Component/Plugin/Interfaces/HookSystemInterface.php
+++ b/src/Elcodi/Component/Plugin/Interfaces/HookSystemInterface.php
@@ -43,5 +43,5 @@ interface HookSystemInterface
      *
      * @return mixed Content after transformation
      */
-    public function execute($hookName, $context = array(), $content = '');
+    public function execute($hookName, $context = [], $content = '');
 }

--- a/src/Elcodi/Component/Plugin/Services/PluginManager.php
+++ b/src/Elcodi/Component/Plugin/Services/PluginManager.php
@@ -145,7 +145,7 @@ class PluginManager
     protected function getPluginSpecification($bundlePath)
     {
         $yaml = new Parser();
-        $specificationFilePath = $bundlePath.'/plugin.yml';
+        $specificationFilePath = $bundlePath . '/plugin.yml';
 
         if (!file_exists($specificationFilePath)) {
             return [];

--- a/src/Elcodi/Component/Plugin/Templating/Traits/TemplatingTrait.php
+++ b/src/Elcodi/Component/Plugin/Templating/Traits/TemplatingTrait.php
@@ -56,7 +56,7 @@ trait TemplatingTrait
         array $extraContextParams = []
     ) {
         $event->setContent(
-            $event->getContent().
+            $event->getContent() .
             $this
                 ->twig
                 ->render(

--- a/src/Elcodi/Component/Product/Repository/CategoryRepository.php
+++ b/src/Elcodi/Component/Product/Repository/CategoryRepository.php
@@ -37,9 +37,9 @@ class CategoryRepository extends EntityRepository
         $categories = $this
             ->createQueryBuilder('c')
             ->where('c.root = :root')
-            ->setParameters(array(
+            ->setParameters([
                 'root' => true,
-            ))
+            ])
             ->getQuery()
             ->getResult();
 
@@ -80,9 +80,9 @@ class CategoryRepository extends EntityRepository
         $categories = $this
             ->createQueryBuilder('c')
             ->where('c.parent = :parent_category')
-            ->setParameters(array(
+            ->setParameters([
                 'parent_category' => $parentCategory,
-            ))
+            ])
             ->getQuery()
             ->getResult();
 

--- a/src/Elcodi/Component/Product/Services/CategoryTree.php
+++ b/src/Elcodi/Component/Product/Services/CategoryTree.php
@@ -81,17 +81,17 @@ class CategoryTree
             }
 
             if ($parentCategoryId && !isset($categoryTree[$parentCategoryId])) {
-                $categoryTree[$parentCategoryId] = array(
+                $categoryTree[$parentCategoryId] = [
                     'entity'   => null,
-                    'children' => array(),
-                );
+                    'children' => [],
+                ];
             }
 
             if (!isset($categoryTree[$categoryId])) {
-                $categoryTree[$categoryId] = array(
+                $categoryTree[$categoryId] = [
                     'entity'   => null,
-                    'children' => array(),
-                );
+                    'children' => [],
+                ];
             }
 
             $categoryTree[$categoryId]['entity'] = $category;

--- a/src/Elcodi/Component/Product/Twig/ProductExtension.php
+++ b/src/Elcodi/Component/Product/Twig/ProductExtension.php
@@ -41,7 +41,7 @@ class ProductExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('available_options', array($this, 'getAvailableOptions')),
+            new Twig_SimpleFunction('available_options', [$this, 'getAvailableOptions']),
         ];
     }
 
@@ -53,7 +53,7 @@ class ProductExtension extends Twig_Extension
     public function getFilters()
     {
         return [
-            new Twig_SimpleFilter('purchasable_name', array($this, 'getPurchasableName')),
+            new Twig_SimpleFilter('purchasable_name', [$this, 'getPurchasableName']),
         ];
     }
 
@@ -84,9 +84,9 @@ class ProductExtension extends Twig_Extension
                 /**
                  * @var ValueInterface $option
                  */
-                $productName .= $separator.
-                    $option->getAttribute()->getName().
-                    ' '.
+                $productName .= $separator .
+                    $option->getAttribute()->getName() .
+                    ' ' .
                     $option->getValue();
             }
         }

--- a/src/Elcodi/Component/ReferralProgram/Repository/ReferralLineRepository.php
+++ b/src/Elcodi/Component/ReferralProgram/Repository/ReferralLineRepository.php
@@ -41,11 +41,11 @@ class ReferralLineRepository extends EntityRepository
     {
         return new ArrayCollection(
             $this
-                ->findBy(array(
+                ->findBy([
                     'referrer' => $customer,
                     'enabled'  => true,
                     'closed'   => false,
-                ))
+                ])
         );
     }
 
@@ -61,11 +61,11 @@ class ReferralLineRepository extends EntityRepository
      */
     public function findOneByInvited(CustomerInterface $customer)
     {
-        return $this->findOneBy(array(
+        return $this->findOneBy([
             'invited' => $customer,
             'enabled' => true,
             'closed'  => false,
-        ));
+        ]);
     }
 
     /**
@@ -81,11 +81,11 @@ class ReferralLineRepository extends EntityRepository
      */
     public function findOneByReferralHashAndInvitedEmail(ReferralHash $referralHash, $invitedEmail)
     {
-        return $this->findOneBy(array(
+        return $this->findOneBy([
             'invitedEmail' => $invitedEmail,
             'referralHash' => $referralHash,
             'closed'       => false,
-        ));
+        ]);
     }
 
     /**
@@ -100,10 +100,10 @@ class ReferralLineRepository extends EntityRepository
      */
     public function findByInvitedEmail($invitedEmail)
     {
-        return new ArrayCollection($this->findBy(array(
+        return new ArrayCollection($this->findBy([
             'invitedEmail' => $invitedEmail,
             'enabled'      => true,
             'closed'       => false,
-        )));
+        ]));
     }
 }

--- a/src/Elcodi/Component/ReferralProgram/Repository/ReferralRuleRepository.php
+++ b/src/Elcodi/Component/ReferralProgram/Repository/ReferralRuleRepository.php
@@ -60,10 +60,10 @@ class ReferralRuleRepository extends EntityRepository
             )
             ->orderBy('r.id', 'DESC')
             ->setMaxResults(1)
-            ->setParameters(array(
+            ->setParameters([
                 'enabled'  => true,
                 'datetime' => $dateTime,
-            ))
+            ])
             ->getQuery()
             ->getResult();
 

--- a/src/Elcodi/Component/ReferralProgram/Router/ReferralProgramRoutesLoader.php
+++ b/src/Elcodi/Component/ReferralProgram/Router/ReferralProgramRoutesLoader.php
@@ -78,9 +78,9 @@ class ReferralProgramRoutesLoader implements LoaderInterface
         }
 
         $routes = new RouteCollection();
-        $routes->add($this->controllerRouteName, new Route($this->controllerRoute, array(
+        $routes->add($this->controllerRouteName, new Route($this->controllerRoute, [
             '_controller' => 'elcodi.controller.referral_program:trackAction',
-        )));
+        ]));
 
         $this->loaded = true;
 

--- a/src/Elcodi/Component/ReferralProgram/Services/ReferralHashManager.php
+++ b/src/Elcodi/Component/ReferralProgram/Services/ReferralHashManager.php
@@ -97,9 +97,9 @@ class ReferralHashManager
         /**
          * @var $referralHash ReferralHash
          */
-        $referralHash = $this->referralHashRepository->findOneBy(array(
+        $referralHash = $this->referralHashRepository->findOneBy([
             'referrer' => $customer,
-        ));
+        ]);
 
         if (!($referralHash instanceof ReferralHashInterface)) {
             $referralHash = $this->referralHashFactory->create();
@@ -124,8 +124,8 @@ class ReferralHashManager
      */
     public function getReferralHashByHash($hash)
     {
-        return $this->referralHashRepository->findOneBy(array(
+        return $this->referralHashRepository->findOneBy([
             'hash' => $hash,
-        ));
+        ]);
     }
 }

--- a/src/Elcodi/Component/ReferralProgram/Services/ReferralProgramManager.php
+++ b/src/Elcodi/Component/ReferralProgram/Services/ReferralProgramManager.php
@@ -291,11 +291,11 @@ class ReferralProgramManager
             $referralLines = new ArrayCollection();
             $referralLine = $this
                 ->referralLineRepository
-                ->findOneBy(array(
+                ->findOneBy([
                     'enabled'      => true,
                     'closed'       => false,
                     'invitedEmail' => $invitedEmail,
-                ));
+                ]);
 
             if (!($referralLine instanceof ReferralLineInterface)) {
 
@@ -309,10 +309,10 @@ class ReferralProgramManager
 
                 $referralLines = $this
                     ->referralLineRepository
-                    ->findBy(array(
+                    ->findBy([
                         'closed'       => false,
                         'invitedEmail' => $invitedEmail,
-                    ));
+                    ]);
 
                 /**
                  * No result is found or more than one. It means than this user
@@ -424,10 +424,10 @@ class ReferralProgramManager
          * is enabled. If it is, we skip this email.
          */
         if ($this->purgeDisabledLines) {
-            $enabledReferralLine = $this->referralLineRepository->findOneBy(array(
+            $enabledReferralLine = $this->referralLineRepository->findOneBy([
                 'enabled'      => true,
                 'invitedEmail' => $invitation->getEmail(),
-            ));
+            ]);
 
             if ($enabledReferralLine instanceof ReferralLineInterface) {
                 return $this;
@@ -439,10 +439,10 @@ class ReferralProgramManager
          */
         $referralLine = $this
             ->referralLineRepository
-            ->findOneBy(array(
+            ->findOneBy([
                 'invitedEmail' => $invitation->getEmail(),
                 'referralHash' => $referralHash,
-            ));
+            ]);
         if ($referralLine instanceof ReferralLine) {
             throw new ReferralProgramLineExistsException();
         }

--- a/src/Elcodi/Component/ReferralProgram/Services/ReferralRouteManager.php
+++ b/src/Elcodi/Component/ReferralProgram/Services/ReferralRouteManager.php
@@ -65,8 +65,8 @@ class ReferralRouteManager
 
         return $this
             ->routeGenerator
-            ->generate($this->controllerRouteName, array(
+            ->generate($this->controllerRouteName, [
                 'hash' => $referralHash->getHash(),
-            ), true);
+            ], true);
     }
 }

--- a/src/Elcodi/Component/Shipping/Provider/ShippingRangeProvider.php
+++ b/src/Elcodi/Component/Shipping/Provider/ShippingRangeProvider.php
@@ -110,7 +110,7 @@ class ShippingRangeProvider
                 'enabled' => true,
             ]);
 
-        $satisfiedCarriers = array();
+        $satisfiedCarriers = [];
 
         foreach ($availableCarriers as $carrier) {
             $shippingRange = $this->getShippingRangeSatisfiedByCart(

--- a/src/Elcodi/Component/Shipping/Resolver/ShippingRangeResolver.php
+++ b/src/Elcodi/Component/Shipping/Resolver/ShippingRangeResolver.php
@@ -63,7 +63,7 @@ class ShippingRangeResolver
      */
     public function resolveShippingRanges(array $shippingRanges)
     {
-        $validShippingRanges = array();
+        $validShippingRanges = [];
 
         switch ($this->shippingRangeResolverStrategy) {
 
@@ -72,11 +72,11 @@ class ShippingRangeResolver
                 break;
 
             case ElcodiShippingResolverTypes::SHIPPING_RANGE_RESOLVER_LOWEST:
-                $validShippingRanges = array($this->getShippingRangeWithLowestPrice($shippingRanges));
+                $validShippingRanges = [$this->getShippingRangeWithLowestPrice($shippingRanges)];
                 break;
 
             case ElcodiShippingResolverTypes::SHIPPING_RANGE_RESOLVER_HIGHEST:
-                $validShippingRanges = array($this->getShippingRangeWithHighestPrice($shippingRanges));
+                $validShippingRanges = [$this->getShippingRangeWithHighestPrice($shippingRanges)];
                 break;
         }
 

--- a/src/Elcodi/Component/Shipping/Tests/UnitTest/Provider/ShippingRangeProviderTest.php
+++ b/src/Elcodi/Component/Shipping/Tests/UnitTest/Provider/ShippingRangeProviderTest.php
@@ -138,15 +138,15 @@ class ShippingRangeProviderTest extends PHPUnit_Framework_TestCase
 
         $shippingRangeProvider = $this
             ->getMockBuilder('Elcodi\Component\Shipping\Provider\ShippingRangeProvider')
-            ->setMethods(array(
+            ->setMethods([
                 'isShippingRangeZonesSatisfiedByCart',
-            ))
-            ->setConstructorArgs(array(
+            ])
+            ->setConstructorArgs([
                 $this->carrierRepository,
                 $this->currencyConverter,
                 $this->zoneMatcher,
                 $this->shippingRangeResolver,
-            ))
+            ])
             ->getMock();
 
         $shippingRangeProvider
@@ -202,15 +202,15 @@ class ShippingRangeProviderTest extends PHPUnit_Framework_TestCase
 
         $shippingRangeProvider = $this
             ->getMockBuilder('Elcodi\Component\Shipping\Provider\ShippingRangeProvider')
-            ->setMethods(array(
+            ->setMethods([
                 'isShippingRangeZonesSatisfiedByCart',
-            ))
-            ->setConstructorArgs(array(
+            ])
+            ->setConstructorArgs([
                 $this->carrierRepository,
                 $this->currencyConverter,
                 $this->zoneMatcher,
                 $this->shippingRangeResolver,
-            ))
+            ])
             ->getMock();
 
         $shippingRangeProvider
@@ -253,15 +253,15 @@ class ShippingRangeProviderTest extends PHPUnit_Framework_TestCase
 
         $shippingRangeProvider = $this
             ->getMockBuilder('Elcodi\Component\Shipping\Provider\ShippingRangeProvider')
-            ->setMethods(array(
+            ->setMethods([
                 'isShippingRangeZonesSatisfiedByCart',
-            ))
-            ->setConstructorArgs(array(
+            ])
+            ->setConstructorArgs([
                 $this->carrierRepository,
                 $this->currencyConverter,
                 $this->zoneMatcher,
                 $this->shippingRangeResolver,
-            ))
+            ])
             ->getMock();
 
         $shippingRangeProvider
@@ -287,15 +287,15 @@ class ShippingRangeProviderTest extends PHPUnit_Framework_TestCase
 
         $shippingRangeProvider = $this
             ->getMockBuilder('Elcodi\Component\Shipping\Provider\ShippingRangeProvider')
-            ->setMethods(array(
+            ->setMethods([
                 'isShippingRangeZonesSatisfiedByCart',
-            ))
-            ->setConstructorArgs(array(
+            ])
+            ->setConstructorArgs([
                 $this->carrierRepository,
                 $this->currencyConverter,
                 $this->zoneMatcher,
                 $this->shippingRangeResolver,
-            ))
+            ])
             ->getMock();
 
         $shippingRangeProvider
@@ -321,23 +321,23 @@ class ShippingRangeProviderTest extends PHPUnit_Framework_TestCase
             ->carrierRepository
             ->expects($this->any())
             ->method('findBy')
-            ->will($this->returnValue(array(
+            ->will($this->returnValue([
                 $this->getCarrierMock(100, 110, 40, 50),
                 $this->getCarrierMock(120, 300, 500, 1000),
                 $this->getCarrierMock(50, 101, 10, 10),
-            )));
+            ]));
 
         $shippingRangeProvider = $this
             ->getMockBuilder('Elcodi\Component\Shipping\Provider\ShippingRangeProvider')
-            ->setMethods(array(
+            ->setMethods([
                 'isShippingRangeZonesSatisfiedByCart',
-            ))
-            ->setConstructorArgs(array(
+            ])
+            ->setConstructorArgs([
                 $this->carrierRepository,
                 $this->currencyConverter,
                 $this->zoneMatcher,
                 $this->shippingRangeResolver,
-            ))
+            ])
             ->getMock();
 
         $shippingRangeProvider
@@ -375,10 +375,10 @@ class ShippingRangeProviderTest extends PHPUnit_Framework_TestCase
     ) {
         $carrier = $this->getMock('Elcodi\Component\Shipping\Entity\Interfaces\CarrierInterface');
 
-        $shippingRanges = array(
+        $shippingRanges = [
             $this->getShippingPriceRangeMock($fromPrice, $toPrice),
             $this->getShippingWeightRangeMock($fromWeight, $toWeight),
-        );
+        ];
 
         $carrier
             ->expects($this->any())

--- a/src/Elcodi/Component/Shipping/Tests/UnitTest/Resolver/ShippingRangeResolverTest.php
+++ b/src/Elcodi/Component/Shipping/Tests/UnitTest/Resolver/ShippingRangeResolverTest.php
@@ -98,11 +98,11 @@ class ShippingRangeResolverTest extends PHPUnit_Framework_TestCase
             ->method('getPrice')
             ->will($this->returnValue(Money::create(30, $this->currency)));
 
-        $this->shippingRanges = array(
+        $this->shippingRanges = [
             $cheapShippingRange,
             $mediumShippingRange,
             $expensiveShippingRange,
-        );
+        ];
     }
 
     /**

--- a/src/Elcodi/Component/Sitemap/Command/DumpSitemapCommand.php
+++ b/src/Elcodi/Component/Sitemap/Command/DumpSitemapCommand.php
@@ -55,8 +55,8 @@ class DumpSitemapCommand extends Command
         $sitemapProfileName = $this->getSitemapProfileName();
 
         $this
-            ->setName('elcodi:sitemap:'.$sitemapProfileName.':dump')
-            ->setDescription('Dumps sitemap '.$sitemapProfileName);
+            ->setName('elcodi:sitemap:' . $sitemapProfileName . ':dump')
+            ->setDescription('Dumps sitemap ' . $sitemapProfileName);
     }
 
     /**
@@ -75,9 +75,9 @@ class DumpSitemapCommand extends Command
             ->dump();
 
         $output->writeln(
-            '<header>[Sitemap]</header> <body>Sitemap '.
-            $this->getSitemapProfileName().
-            ' built in . '.$this->getSitemapProfilePath().' </body>'
+            '<header>[Sitemap]</header> <body>Sitemap ' .
+            $this->getSitemapProfileName() .
+            ' built in . ' . $this->getSitemapProfilePath() . ' </body>'
         );
     }
 

--- a/src/Elcodi/Component/Sitemap/Render/XmlRender.php
+++ b/src/Elcodi/Component/Sitemap/Render/XmlRender.php
@@ -34,22 +34,22 @@ class XmlRender implements SitemapRenderInterface
      */
     public function render(SitemapProfileInterface $sitemapProfile)
     {
-        $data = '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL;
-        $data .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'.PHP_EOL;
+        $data = '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL;
+        $data .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . PHP_EOL;
 
         foreach ($sitemapProfile->getEntityLoaders() as $entityLoader) {
             $transformer = $entityLoader->getTransformer();
             foreach ($entityLoader->load() as $entity) {
-                $data .= '    <url>'.PHP_EOL;
-                $data .= '        <loc>'.$transformer->getLoc($entity).'</loc>'.PHP_EOL;
-                $data .= '        <lastmod>'.$transformer->getLastMod($entity).'</lastmod>'.PHP_EOL;
-                $data .= '        <changefreq>'.$transformer->getChangeFreq($entity).'</changefreq>'.PHP_EOL;
-                $data .= '        <priority>'.$transformer->getPriority($entity).'</priority>'.PHP_EOL;
-                $data .= '    </url>'.PHP_EOL;
+                $data .= '    <url>' . PHP_EOL;
+                $data .= '        <loc>' . $transformer->getLoc($entity) . '</loc>' . PHP_EOL;
+                $data .= '        <lastmod>' . $transformer->getLastMod($entity) . '</lastmod>' . PHP_EOL;
+                $data .= '        <changefreq>' . $transformer->getChangeFreq($entity) . '</changefreq>' . PHP_EOL;
+                $data .= '        <priority>' . $transformer->getPriority($entity) . '</priority>' . PHP_EOL;
+                $data .= '    </url>' . PHP_EOL;
             }
         }
 
-        $data .= '</urlset>'.PHP_EOL;
+        $data .= '</urlset>' . PHP_EOL;
 
         return $data;
     }

--- a/src/Elcodi/Component/StateTransitionMachine/Definition/TransitionChain.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Definition/TransitionChain.php
@@ -34,7 +34,7 @@ class TransitionChain
      */
     public function __construct()
     {
-        $this->transitions = array();
+        $this->transitions = [];
     }
 
     /**

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/InconsistentTransitionConfigurationException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/InconsistentTransitionConfigurationException.php
@@ -34,7 +34,7 @@ class InconsistentTransitionConfigurationException extends Exception
      */
     public function __construct($state, $transition, $code = 0, Exception $previous = null)
     {
-        $message = 'Given state "'.$state.'" only one transition with name "'.$transition.'" can be defined.';
+        $message = 'Given state "' . $state . '" only one transition with name "' . $transition . '" can be defined.';
 
         parent::__construct($message, $code, $previous);
     }

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/InvalidPointOfEntryException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/InvalidPointOfEntryException.php
@@ -33,7 +33,7 @@ class InvalidPointOfEntryException extends Exception
      */
     public function __construct($state, $code = 0, Exception $previous = null)
     {
-        $message = 'Invalid point of entry "'.$state.'"';
+        $message = 'Invalid point of entry "' . $state . '"';
 
         parent::__construct($message, $code, $previous);
     }

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/StateNotValidException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/StateNotValidException.php
@@ -33,7 +33,7 @@ class StateNotValidException extends Exception
      */
     public function __construct($state, $code = 0, Exception $previous = null)
     {
-        $message = 'State "'.$state.'" is not valid or is unreachable';
+        $message = 'State "' . $state . '" is not valid or is unreachable';
 
         parent::__construct($message, $code, $previous);
     }

--- a/src/Elcodi/Component/StateTransitionMachine/Machine/LoggableMachine.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Machine/LoggableMachine.php
@@ -148,12 +148,12 @@ class LoggableMachine implements MachineInterface
             ->logger
             ->info(
                 'Transition {transition_name} in machine "{machine_id}" from "{state_from}" to "{state_to}"',
-                array(
+                [
                     'transition_name' => $transition->getName(),
                     'machine_id'      => $this->machine->getId(),
                     'state_from'      => $transition->getStart()->getName(),
                     'state_to'        => $transition->getFinal()->getName(),
-                )
+                ]
             );
     }
 }

--- a/src/Elcodi/Component/StateTransitionMachine/Machine/MachineBuilder.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Machine/MachineBuilder.php
@@ -122,7 +122,7 @@ class MachineBuilder
      */
     public function compile()
     {
-        $nodesVisited = array();
+        $nodesVisited = [];
 
         /**
          * Checking the configuration
@@ -301,7 +301,7 @@ class MachineBuilder
      */
     protected function checkTransitionDuplicates(TransitionChain $transitionChain)
     {
-        $states = array();
+        $states = [];
 
         /**
          * @var Transition $transition
@@ -318,7 +318,7 @@ class MachineBuilder
                     );
                 }
             } else {
-                $states[$startingStateName] = array();
+                $states[$startingStateName] = [];
             }
 
             $states[$startingStateName][$transitionName] = true;

--- a/src/Elcodi/Component/StateTransitionMachine/Machine/MachineManager.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Machine/MachineManager.php
@@ -294,14 +294,14 @@ class MachineManager
             ->eventDispatcher
             ->dispatch(
                 str_replace(
-                    array(
+                    [
                         '{machine_id}',
                         '{state_name}',
-                    ),
-                    array(
+                    ],
+                    [
                         $machine->getId(),
                         $transition->getStart()->getName(),
-                    ),
+                    ],
                     ElcodiStateTransitionMachineEvents::TRANSITION_FROM_STATE
                 ),
                 new TransitionEvent(
@@ -315,14 +315,14 @@ class MachineManager
             ->eventDispatcher
             ->dispatch(
                 str_replace(
-                    array(
+                    [
                         '{machine_id}',
                         '{state_name}',
-                    ),
-                    array(
+                    ],
+                    [
                         $machine->getId(),
                         $transition->getFinal()->getName(),
-                    ),
+                    ],
                     ElcodiStateTransitionMachineEvents::TRANSITION_TO_STATE
                 ),
                 new TransitionEvent(
@@ -336,14 +336,14 @@ class MachineManager
             ->eventDispatcher
             ->dispatch(
                 str_replace(
-                    array(
+                    [
                         '{machine_id}',
                         '{transition_name}',
-                    ),
-                    array(
+                    ],
+                    [
                         $machine->getId(),
                         $transition->getName(),
-                    ),
+                    ],
                     ElcodiStateTransitionMachineEvents::TRANSITION
                 ),
                 new TransitionEvent(

--- a/src/Elcodi/Component/Template/Command/TemplatesEnableCommand.php
+++ b/src/Elcodi/Component/Template/Command/TemplatesEnableCommand.php
@@ -96,7 +96,7 @@ class TemplatesEnableCommand extends Command
         $formatter = $this->getHelper('formatter');
         $formattedLine = $formatter->formatSection(
             'OK',
-            'Template "'.$templateName.'" enabled'
+            'Template "' . $templateName . '" enabled'
         );
 
         $output->writeln($formattedLine);

--- a/src/Elcodi/Component/Template/Command/TemplatesLoadCommand.php
+++ b/src/Elcodi/Component/Template/Command/TemplatesLoadCommand.php
@@ -75,7 +75,7 @@ class TemplatesLoadCommand extends Command
         foreach ($templates as $template) {
             $formattedLine = $formatter->formatSection(
                 'OK',
-                'Template "'.$template['bundle'].'" installed'
+                'Template "' . $template['bundle'] . '" installed'
             );
 
             $output->writeln($formattedLine);

--- a/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
+++ b/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
@@ -104,7 +104,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function getRoles()
     {
-        return array('IS_AUTHENTICATED_ANONYMOUSLY');
+        return ['IS_AUTHENTICATED_ANONYMOUSLY'];
     }
 
     /**
@@ -294,7 +294,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function getFullName()
     {
-        return trim($this->firstname.' '.$this->lastname);
+        return trim($this->firstname . ' ' . $this->lastname);
     }
 
     /**
@@ -384,6 +384,6 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function __sleep()
     {
-        return array('id', 'email');
+        return ['id', 'email'];
     }
 }

--- a/src/Elcodi/Component/User/Entity/AdminUser.php
+++ b/src/Elcodi/Component/User/Entity/AdminUser.php
@@ -32,6 +32,6 @@ class AdminUser extends AbstractUser implements AdminUserInterface
      */
     public function getRoles()
     {
-        return array('ROLE_ADMIN');
+        return ['ROLE_ADMIN'];
     }
 }

--- a/src/Elcodi/Component/User/Entity/Customer.php
+++ b/src/Elcodi/Component/User/Entity/Customer.php
@@ -109,7 +109,7 @@ class Customer extends AbstractUser implements CustomerInterface
      */
     public function getRoles()
     {
-        return array('ROLE_CUSTOMER');
+        return ['ROLE_CUSTOMER'];
     }
 
     /**

--- a/src/Elcodi/Component/User/Repository/AdminUserRepository.php
+++ b/src/Elcodi/Component/User/Repository/AdminUserRepository.php
@@ -36,8 +36,8 @@ class AdminUserRepository extends EntityRepository implements UserEmaileableInte
      */
     public function findOneByEmail($email)
     {
-        return $this->findOneBy(array(
+        return $this->findOneBy([
             'email' => $email,
-        ));
+        ]);
     }
 }

--- a/src/Elcodi/Component/User/Repository/CustomerRepository.php
+++ b/src/Elcodi/Component/User/Repository/CustomerRepository.php
@@ -36,9 +36,9 @@ class CustomerRepository extends EntityRepository implements UserEmaileableInter
      */
     public function findOneByEmail($email)
     {
-        return $this->findOneBy(array(
+        return $this->findOneBy([
             'email' => $email,
-        ));
+        ]);
     }
 
     /**

--- a/src/Elcodi/Component/User/Services/PasswordManager.php
+++ b/src/Elcodi/Component/User/Services/PasswordManager.php
@@ -129,9 +129,9 @@ class PasswordManager
 
         $recoverUrl = $this
             ->router
-            ->generate($recoverPasswordUrlName, array(
+            ->generate($recoverPasswordUrlName, [
                 $hashField => $recoveryHash,
-            ), true);
+            ], true);
 
         $event = new PasswordRememberEvent($user, $recoverUrl);
         $this->eventDispatcher->dispatch(ElcodiUserEvents::PASSWORD_REMEMBER, $event);

--- a/src/Elcodi/Plugin/DisqusBundle/DependencyInjection/ElcodiDisqusExtension.php
+++ b/src/Elcodi/Plugin/DisqusBundle/DependencyInjection/ElcodiDisqusExtension.php
@@ -38,7 +38,7 @@ class ElcodiDisqusExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Plugin/FacebookBundle/DependencyInjection/ElcodiFacebookExtension.php
+++ b/src/Elcodi/Plugin/FacebookBundle/DependencyInjection/ElcodiFacebookExtension.php
@@ -38,7 +38,7 @@ class ElcodiFacebookExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Plugin/GoogleAnalyticsBundle/DependencyInjection/ElcodiGoogleAnalyticsExtension.php
+++ b/src/Elcodi/Plugin/GoogleAnalyticsBundle/DependencyInjection/ElcodiGoogleAnalyticsExtension.php
@@ -38,7 +38,7 @@ class ElcodiGoogleAnalyticsExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Plugin/PinterestBundle/DependencyInjection/ElcodiPinterestExtension.php
+++ b/src/Elcodi/Plugin/PinterestBundle/DependencyInjection/ElcodiPinterestExtension.php
@@ -38,7 +38,7 @@ class ElcodiPinterestExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Plugin/ProductCsvBundle/DependencyInjection/ElcodiProductCsvExtension.php
+++ b/src/Elcodi/Plugin/ProductCsvBundle/DependencyInjection/ElcodiProductCsvExtension.php
@@ -45,7 +45,7 @@ class ElcodiProductCsvExtension extends AbstractExtension
      */
     protected function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/DependencyInjection/ElcodiStoreSetupWizardExtension.php
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/DependencyInjection/ElcodiStoreSetupWizardExtension.php
@@ -38,7 +38,7 @@ class ElcodiStoreSetupWizardExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Plugin/TwitterBundle/DependencyInjection/ElcodiTwitterExtension.php
+++ b/src/Elcodi/Plugin/TwitterBundle/DependencyInjection/ElcodiTwitterExtension.php
@@ -38,7 +38,7 @@ class ElcodiTwitterExtension extends AbstractExtension
      */
     public function getConfigFilesLocation()
     {
-        return __DIR__.'/../Resources/config';
+        return __DIR__ . '/../Resources/config';
     }
 
     /**

--- a/src/Elcodi/Plugin/TwitterBundle/Templating/ShareTweetRenderer.php
+++ b/src/Elcodi/Plugin/TwitterBundle/Templating/ShareTweetRenderer.php
@@ -111,7 +111,7 @@ class ShareTweetRenderer
             $text     = $product->getName();
             $category = $product->getPrincipalCategory();
             if ($category instanceof CategoryInterface) {
-                $text = $category->getName().' - '.$text;
+                $text = $category->getName() . ' - ' . $text;
             }
 
             $this->appendTemplate(


### PR DESCRIPTION
Cs fixer configuration proposal:
- Applied to `"src/"` folder
- Symfony level [(More info)](http://cs.sensiolabs.org/#usage)
- Extra fixers
  - Align double arrow symbols in consecutive lines.
  - Align equals symbols in consecutive lines.
  - Concatenation should be used with at least one whitespace around
  - Multi-line whitespace before closing semicolon are prohibited.
  - PHP array's should use the PHP 5.4 short-syntax.

@elcodi/owners I've also applied the fixers to the code, let me know if you think that we should apply a different config ;)
