### PR TITLE
Disable default registerCommands method

### DIFF
--- a/src/Elcodi/Bundle/AttributeBundle/ElcodiAttributeBundle.php
+++ b/src/Elcodi/Bundle/AttributeBundle/ElcodiAttributeBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\AttributeBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiAttributeBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/AttributeBundle/composer.json
+++ b/src/Elcodi/Bundle/AttributeBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/BambooBundle/ElcodiBambooBundle.php
+++ b/src/Elcodi/Bundle/BambooBundle/ElcodiBambooBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\BambooBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -35,5 +36,17 @@ class ElcodiBambooBundle extends Bundle
     public function getContainerExtension()
     {
         return new ElcodiBambooExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/BambooBundle/composer.json
+++ b/src/Elcodi/Bundle/BambooBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/swiftmailer-bundle": "~2.3",

--- a/src/Elcodi/Bundle/BannerBundle/ElcodiBannerBundle.php
+++ b/src/Elcodi/Bundle/BannerBundle/ElcodiBannerBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\BannerBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiBannerBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\MediaBundle\ElcodiMediaBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/BannerBundle/composer.json
+++ b/src/Elcodi/Bundle/BannerBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/CartBundle/ElcodiCartBundle.php
+++ b/src/Elcodi/Bundle/CartBundle/ElcodiCartBundle.php
@@ -17,13 +17,13 @@
 
 namespace Elcodi\Bundle\CartBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Elcodi\Bundle\CartBundle\CompilerPass\MappingCompilerPass;
 use Elcodi\Bundle\CartBundle\DependencyInjection\ElcodiCartExtension;
-use Elcodi\Bundle\CoreBundle\ElcodiCoreBundle;
 use Elcodi\Bundle\CoreBundle\Interfaces\DependentBundleInterface;
 
 /**
@@ -67,5 +67,17 @@ class ElcodiCartBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/CartBundle/composer.json
+++ b/src/Elcodi/Bundle/CartBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/CartCouponBundle/ElcodiCartCouponBundle.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/ElcodiCartCouponBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\CartCouponBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -63,5 +64,17 @@ class ElcodiCartCouponBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CartCouponBundle/composer.json
@@ -36,6 +36,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/CommentBundle/ElcodiCommentBundle.php
+++ b/src/Elcodi/Bundle/CommentBundle/ElcodiCommentBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\CommentBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -61,5 +62,17 @@ class ElcodiCommentBundle extends Bundle implements DependentBundleInterface
             '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/CommentBundle/composer.json
+++ b/src/Elcodi/Bundle/CommentBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/ConfigurationBundle/ElcodiConfigurationBundle.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/ElcodiConfigurationBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\ConfigurationBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -63,5 +64,17 @@ class ElcodiConfigurationBundle extends Bundle implements DependentBundleInterfa
             '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/ConfigurationBundle/composer.json
+++ b/src/Elcodi/Bundle/ConfigurationBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6,>=2.6.3",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/CoreBundle/ElcodiCoreBundle.php
+++ b/src/Elcodi/Bundle/CoreBundle/ElcodiCoreBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\CoreBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -39,5 +40,17 @@ class ElcodiCoreBundle extends Bundle
     public function getContainerExtension()
     {
         return new ElcodiCoreExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/CoreBundle/composer.json
+++ b/src/Elcodi/Bundle/CoreBundle/composer.json
@@ -36,6 +36,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/event-dispatcher": "~2.6",

--- a/src/Elcodi/Bundle/CouponBundle/ElcodiCouponBundle.php
+++ b/src/Elcodi/Bundle/CouponBundle/ElcodiCouponBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\CouponBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -62,5 +63,17 @@ class ElcodiCouponBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/CouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CouponBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/CurrencyBundle/ElcodiCurrencyBundle.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/ElcodiCurrencyBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\CurrencyBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -61,5 +62,17 @@ class ElcodiCurrencyBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/composer.json
+++ b/src/Elcodi/Bundle/CurrencyBundle/composer.json
@@ -39,12 +39,12 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/proxy-manager-bridge": "~2.6, >=2.6.3",
         "symfony/twig-bundle": "~2.6",
         "ocramius/proxy-manager": "~1.0",
-
         "mmoreram/simple-doctrine-mapping": "~0.1",
 
         "elcodi/core-bundle": "~0.5.0",

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/ElcodiEntityTranslatorBundle.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/ElcodiEntityTranslatorBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\EntityTranslatorBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -62,5 +63,17 @@ class ElcodiEntityTranslatorBundle extends Bundle implements DependentBundleInte
             '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
@@ -36,6 +36,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.4, >2.4.6",
+        "symfony/console": "~2.4",
         "symfony/config": "~2.4",
         "symfony/dependency-injection": "~2.4",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/ElcodiFixturesBoosterBundle.php
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/ElcodiFixturesBoosterBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\FixturesBoosterBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -48,5 +49,17 @@ class ElcodiFixturesBoosterBundle extends Bundle implements DependentBundleInter
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/GeoBundle/ElcodiGeoBundle.php
+++ b/src/Elcodi/Bundle/GeoBundle/ElcodiGeoBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\GeoBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiGeoBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/GeoBundle/composer.json
+++ b/src/Elcodi/Bundle/GeoBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/proxy-manager-bridge": "~2.6, >=2.6.3",

--- a/src/Elcodi/Bundle/LanguageBundle/ElcodiLanguageBundle.php
+++ b/src/Elcodi/Bundle/LanguageBundle/ElcodiLanguageBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\LanguageBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiLanguageBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/LanguageBundle/composer.json
+++ b/src/Elcodi/Bundle/LanguageBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/MediaBundle/ElcodiMediaBundle.php
+++ b/src/Elcodi/Bundle/MediaBundle/ElcodiMediaBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\MediaBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -61,5 +62,17 @@ class ElcodiMediaBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
             '\Knp\Bundle\GaufretteBundle\KnpGaufretteBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/composer.json
+++ b/src/Elcodi/Bundle/MediaBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/routing": "~2.6",
         "symfony/dependency-injection": "~2.6",

--- a/src/Elcodi/Bundle/MenuBundle/ElcodiMenuBundle.php
+++ b/src/Elcodi/Bundle/MenuBundle/ElcodiMenuBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\MenuBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -61,5 +62,17 @@ class ElcodiMenuBundle extends Bundle implements DependentBundleInterface
             '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/MenuBundle/composer.json
+++ b/src/Elcodi/Bundle/MenuBundle/composer.json
@@ -36,6 +36,7 @@
         "doctrine/doctrine-cache-bundle": "~1.0",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/twig-bundle": "~2.6",

--- a/src/Elcodi/Bundle/MetricBundle/ElcodiMetricBundle.php
+++ b/src/Elcodi/Bundle/MetricBundle/ElcodiMetricBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\MetricBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiMetricBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/MetricBundle/composer.json
+++ b/src/Elcodi/Bundle/MetricBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/NewsletterBundle/ElcodiNewsletterBundle.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/ElcodiNewsletterBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\NewsletterBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -61,5 +62,17 @@ class ElcodiNewsletterBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/NewsletterBundle/composer.json
+++ b/src/Elcodi/Bundle/NewsletterBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/PageBundle/ElcodiPageBundle.php
+++ b/src/Elcodi/Bundle/PageBundle/ElcodiPageBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\PageBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiPageBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/PageBundle/composer.json
+++ b/src/Elcodi/Bundle/PageBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/PluginBundle/ElcodiPluginBundle.php
+++ b/src/Elcodi/Bundle/PluginBundle/ElcodiPluginBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\PluginBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -62,5 +63,17 @@ class ElcodiPluginBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/PluginBundle/composer.json
+++ b/src/Elcodi/Bundle/PluginBundle/composer.json
@@ -22,9 +22,10 @@
     "require": {
         "php": ">=5.4",
 
+        "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
-        "symfony/http-kernel": "~2.6",
 
         "elcodi/core-bundle": "~0.5.0",
         "elcodi/plugin": "~0.5.0"

--- a/src/Elcodi/Bundle/ProductBundle/ElcodiProductBundle.php
+++ b/src/Elcodi/Bundle/ProductBundle/ElcodiProductBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\ProductBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -66,5 +67,17 @@ class ElcodiProductBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/ProductBundle/composer.json
+++ b/src/Elcodi/Bundle/ProductBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/expression-language": "~2.6",

--- a/src/Elcodi/Bundle/RuleBundle/ElcodiRuleBundle.php
+++ b/src/Elcodi/Bundle/RuleBundle/ElcodiRuleBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\RuleBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -70,5 +71,17 @@ class ElcodiRuleBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/RuleBundle/composer.json
+++ b/src/Elcodi/Bundle/RuleBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/expression-language": "~2.6",

--- a/src/Elcodi/Bundle/ShippingBundle/ElcodiShippingBundle.php
+++ b/src/Elcodi/Bundle/ShippingBundle/ElcodiShippingBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\ShippingBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -65,5 +66,17 @@ class ElcodiShippingBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\ZoneBundle\ElcodiZoneBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/composer.json
+++ b/src/Elcodi/Bundle/ShippingBundle/composer.json
@@ -30,12 +30,12 @@
         }
     ],
     "require": {
-
         "php": ">=5.4",
         "doctrine/common": "~2.4",
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/SitemapBundle/ElcodiSitemapBundle.php
+++ b/src/Elcodi/Bundle/SitemapBundle/ElcodiSitemapBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\SitemapBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -48,5 +49,17 @@ class ElcodiSitemapBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/SitemapBundle/composer.json
+++ b/src/Elcodi/Bundle/SitemapBundle/composer.json
@@ -30,12 +30,12 @@
         }
     ],
     "require": {
-
         "php": ">=5.4",
         "doctrine/common": "~2.4",
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
 

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/ElcodiStateTransitionMachineBundle.php
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/ElcodiStateTransitionMachineBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\StateTransitionMachineBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiStateTransitionMachineBundle extends Bundle implements DependentBund
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
@@ -33,6 +33,7 @@
         "php": ">=5.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
 
         "elcodi/core-bundle": "~0.5.0",

--- a/src/Elcodi/Bundle/TaxBundle/ElcodiTaxBundle.php
+++ b/src/Elcodi/Bundle/TaxBundle/ElcodiTaxBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\TaxBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -60,5 +61,17 @@ class ElcodiTaxBundle extends Bundle implements DependentBundleInterface
         return [
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/TaxBundle/composer.json
+++ b/src/Elcodi/Bundle/TaxBundle/composer.json
@@ -30,12 +30,12 @@
         }
     ],
     "require": {
-
         "php": ">=5.4",
         "doctrine/common": "~2.4",
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/TemplateBundle/ElcodiTemplateBundle.php
+++ b/src/Elcodi/Bundle/TemplateBundle/ElcodiTemplateBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\TemplateBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -49,5 +50,17 @@ class ElcodiTemplateBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/TemplateBundle/composer.json
+++ b/src/Elcodi/Bundle/TemplateBundle/composer.json
@@ -33,8 +33,9 @@
         "php": ">=5.4",
 
         "symfony/http-kernel": "~2.6",
-        "symfony/dependency-injection": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
+        "symfony/dependency-injection": "~2.6",
 
         "elcodi/core-bundle": "~0.5.0",
         "elcodi/configuration-bundle": "~0.5.0",

--- a/src/Elcodi/Bundle/TestCommonBundle/composer.json
+++ b/src/Elcodi/Bundle/TestCommonBundle/composer.json
@@ -34,8 +34,9 @@
         "doctrine/common": "~2.4",
         "doctrine/orm": "~2.4",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
-        "symfony/config": "~2.6",
+
         "symfony/http-kernel": "~2.6",
+        "symfony/config": "~2.6",
         "symfony/framework-bundle": "~2.6",
         "symfony/console": "~2.6",
         "symfony/browser-kit": "~2.6",

--- a/src/Elcodi/Bundle/UserBundle/ElcodiUserBundle.php
+++ b/src/Elcodi/Bundle/UserBundle/ElcodiUserBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\UserBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -63,5 +64,17 @@ class ElcodiUserBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\CartBundle\ElcodiCartBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/UserBundle/composer.json
+++ b/src/Elcodi/Bundle/UserBundle/composer.json
@@ -36,6 +36,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Bundle/ZoneBundle/ElcodiZoneBundle.php
+++ b/src/Elcodi/Bundle/ZoneBundle/ElcodiZoneBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Bundle\ZoneBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -61,5 +62,17 @@ class ElcodiZoneBundle extends Bundle implements DependentBundleInterface
             '\Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
             '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Bundle/ZoneBundle/composer.json
+++ b/src/Elcodi/Bundle/ZoneBundle/composer.json
@@ -35,6 +35,7 @@
         "doctrine/orm": "~2.4",
 
         "symfony/http-kernel": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~0.1",

--- a/src/Elcodi/Plugin/DisqusBundle/ElcodiDisqusBundle.php
+++ b/src/Elcodi/Plugin/DisqusBundle/ElcodiDisqusBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Plugin\DisqusBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -36,5 +37,17 @@ class ElcodiDisqusBundle extends Bundle implements PluginInterface
     public function getContainerExtension()
     {
         return new ElcodiDisqusExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Plugin/FacebookBundle/ElcodiFacebookBundle.php
+++ b/src/Elcodi/Plugin/FacebookBundle/ElcodiFacebookBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Plugin\FacebookBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -36,5 +37,17 @@ class ElcodiFacebookBundle extends Bundle implements PluginInterface
     public function getContainerExtension()
     {
         return new ElcodiFacebookExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Plugin/GoogleAnalyticsBundle/ElcodiGoogleAnalyticsBundle.php
+++ b/src/Elcodi/Plugin/GoogleAnalyticsBundle/ElcodiGoogleAnalyticsBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Plugin\GoogleAnalyticsBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -36,5 +37,17 @@ class ElcodiGoogleAnalyticsBundle extends Bundle implements PluginInterface
     public function getContainerExtension()
     {
         return new ElcodiGoogleAnalyticsExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Plugin/PinterestBundle/ElcodiPinterestBundle.php
+++ b/src/Elcodi/Plugin/PinterestBundle/ElcodiPinterestBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Plugin\PinterestBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -36,5 +37,17 @@ class ElcodiPinterestBundle extends Bundle implements PluginInterface
     public function getContainerExtension()
     {
         return new ElcodiPinterestExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Plugin/ProductCsvBundle/ElcodiProductCsvBundle.php
+++ b/src/Elcodi/Plugin/ProductCsvBundle/ElcodiProductCsvBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Plugin\ProductCsvBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -38,5 +39,17 @@ class ElcodiProductCsvBundle extends Bundle implements PluginInterface
     public function getContainerExtension()
     {
         return new ElcodiProductCsvExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Plugin/ProductCsvBundle/composer.json
+++ b/src/Elcodi/Plugin/ProductCsvBundle/composer.json
@@ -37,7 +37,7 @@
         "symfony/framework-bundle": "~2.6",
         "symfony/http-foundation": "~2.6",
         "symfony/http-kernel": "~2.6",
-        "symfony/twig-bridge": "~2.6",
+        "symfony/console": "~2.6",
         "symfony/twig-bridge": "~2.6",
         "twig/twig": "~1.16",
         "sensio/framework-extra-bundle": "~3.0",

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/ElcodiStoreSetupWizardBundle.php
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/ElcodiStoreSetupWizardBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Plugin\StoreSetupWizardBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -36,5 +37,17 @@ class ElcodiStoreSetupWizardBundle extends Bundle implements PluginInterface
     public function getContainerExtension()
     {
         return new ElcodiStoreSetupWizardExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }

--- a/src/Elcodi/Plugin/StoreSetupWizardBundle/composer.json
+++ b/src/Elcodi/Plugin/StoreSetupWizardBundle/composer.json
@@ -46,7 +46,6 @@
         "twig/twig": "~1.16",
         "sensio/framework-extra-bundle": "~3.0",
 
-        
         "elcodi/core-bundle": "~0.5.0",
         "elcodi/configuration-bundle": "~0.5.0",
         "elcodi/plugin-bundle": "~0.5.0",

--- a/src/Elcodi/Plugin/TwitterBundle/ElcodiTwitterBundle.php
+++ b/src/Elcodi/Plugin/TwitterBundle/ElcodiTwitterBundle.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Plugin\TwitterBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -36,5 +37,17 @@ class ElcodiTwitterBundle extends Bundle implements PluginInterface
     public function getContainerExtension()
     {
         return new ElcodiTwitterExtension();
+    }
+
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
     }
 }


### PR DESCRIPTION
Just a small improvement to prevent https://github.com/symfony/symfony/blob/2.6/src/Symfony/Component/HttpKernel/Bundle/Bundle.php#L173-197 from being executed on every bundle although we register all commands as services.