### PR TITLE
Reduced mapping code complexity with trait

### DIFF
--- a/src/Elcodi/Bundle/AttributeBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/AttributeBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\AttributeBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.attribute.manager',
-                'elcodi.entity.attribute.class',
-                'elcodi.entity.attribute.mapping_file',
-                'elcodi.entity.attribute.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.attribute_value.manager',
-                'elcodi.entity.attribute_value.class',
-                'elcodi.entity.attribute_value.mapping_file',
-                'elcodi.entity.attribute_value.enabled'
+                [
+                    'attribute',
+                    'attribute_value',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/BannerBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/BannerBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\BannerBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.banner.manager',
-                'elcodi.entity.banner.class',
-                'elcodi.entity.banner.mapping_file',
-                'elcodi.entity.banner.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.banner_zone.manager',
-                'elcodi.entity.banner_zone.class',
-                'elcodi.entity.banner_zone.mapping_file',
-                'elcodi.entity.banner_zone.enabled'
+                [
+                    'banner',
+                    'banner_zone',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/CartBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CartBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\CartBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,33 +39,14 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.cart.manager',
-                'elcodi.entity.cart.class',
-                'elcodi.entity.cart.mapping_file',
-                'elcodi.entity.cart.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.cart_line.manager',
-                'elcodi.entity.cart_line.class',
-                'elcodi.entity.cart_line.mapping_file',
-                'elcodi.entity.cart_line.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.order.manager',
-                'elcodi.entity.order.class',
-                'elcodi.entity.order.mapping_file',
-                'elcodi.entity.order.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.order_line.manager',
-                'elcodi.entity.order_line.class',
-                'elcodi.entity.order_line.mapping_file',
-                'elcodi.entity.order_line.enabled'
+                [
+                    'cart',
+                    'cart_line',
+                    'order',
+                    'order_line',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/CartCouponBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\CartCouponBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.cart_coupon.manager',
-                'elcodi.entity.cart_coupon.class',
-                'elcodi.entity.cart_coupon.mapping_file',
-                'elcodi.entity.cart_coupon.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.order_coupon.manager',
-                'elcodi.entity.order_coupon.class',
-                'elcodi.entity.order_coupon.mapping_file',
-                'elcodi.entity.order_coupon.enabled'
+                [
+                    'cart_coupon',
+                    'order_coupon',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/CommentBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CommentBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\CommentBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.comment.manager',
-                'elcodi.entity.comment.class',
-                'elcodi.entity.comment.mapping_file',
-                'elcodi.entity.comment.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.comment_vote.manager',
-                'elcodi.entity.comment_vote.class',
-                'elcodi.entity.comment_vote.mapping_file',
-                'elcodi.entity.comment_vote.enabled'
+                [
+                    'comment',
+                    'comment_vote',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/ConfigurationBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\ConfigurationBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.configuration.manager',
-                'elcodi.entity.configuration.class',
-                'elcodi.entity.configuration.mapping_file',
-                'elcodi.entity.configuration.enabled'
+                [
+                    'configuration',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/CoreBundle/CompilerPass/Traits/EntityMappingTrait.php
+++ b/src/Elcodi/Bundle/CoreBundle/CompilerPass/Traits/EntityMappingTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CoreBundle\CompilerPass\Traits;
+
+/**
+ * Trait EntityMappingTrait
+ */
+trait EntityMappingTrait
+{
+    /**
+     * Add entity mapping given the entity name, given that all entity
+     * definitions are built the same way and given as well that the method
+     * addEntityMapping exists and is accessible
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container Container
+     * @param array                                                   $entities  Name of the entities
+     *
+     * @return $this Self object
+     */
+    protected function addEntityMappings(
+        \Symfony\Component\DependencyInjection\ContainerBuilder $container,
+        array $entities
+    ) {
+        foreach ($entities as $entity) {
+            $this
+                ->addEntityMapping(
+                    $container,
+                    'elcodi.entity.' . $entity . '.manager',
+                    'elcodi.entity.' . $entity . '.class',
+                    'elcodi.entity.' . $entity . '.mapping_file',
+                    'elcodi.entity.' . $entity . '.enabled'
+                );
+        }
+
+        return $this;
+    }
+}

--- a/src/Elcodi/Bundle/CouponBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CouponBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\CouponBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.coupon.manager',
-                'elcodi.entity.coupon.class',
-                'elcodi.entity.coupon.mapping_file',
-                'elcodi.entity.coupon.enabled'
+                [
+                    'coupon',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/CurrencyBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\CurrencyBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.currency.manager',
-                'elcodi.entity.currency.class',
-                'elcodi.entity.currency.mapping_file',
-                'elcodi.entity.currency.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.currency_exchange_rate.manager',
-                'elcodi.entity.currency_exchange_rate.class',
-                'elcodi.entity.currency_exchange_rate.mapping_file',
-                'elcodi.entity.currency_exchange_rate.enabled'
+                [
+                    'currency',
+                    'currency_exchange_rate',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\EntityTranslatorBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -33,12 +37,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.entity_translation.manager',
-                'elcodi.entity.entity_translation.class',
-                'elcodi.entity.entity_translation.mapping_file',
-                'elcodi.entity.entity_translation.enabled'
+                [
+                    'entity_translation',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/GeoBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/GeoBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\GeoBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.address.manager',
-                'elcodi.entity.address.class',
-                'elcodi.entity.address.mapping_file',
-                'elcodi.entity.address.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.location.manager',
-                'elcodi.entity.location.class',
-                'elcodi.entity.location.mapping_file',
-                'elcodi.entity.location.enabled'
+                [
+                    'address',
+                    'location',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/LanguageBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/LanguageBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\LanguageBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.language.manager',
-                'elcodi.entity.language.class',
-                'elcodi.entity.language.mapping_file',
-                'elcodi.entity.language.enabled'
+                [
+                    'language',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/MediaBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/MediaBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\MediaBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.image.manager',
-                'elcodi.entity.image.class',
-                'elcodi.entity.image.mapping_file',
-                'elcodi.entity.image.enabled'
+                [
+                    'image',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/MenuBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/MenuBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\MenuBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.menu.manager',
-                'elcodi.entity.menu.class',
-                'elcodi.entity.menu.mapping_file',
-                'elcodi.entity.menu.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.menu_node.manager',
-                'elcodi.entity.menu_node.class',
-                'elcodi.entity.menu_node.mapping_file',
-                'elcodi.entity.menu_node.enabled'
+                [
+                    'menu',
+                    'menu_node',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/MetricBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/MetricBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\MetricBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.metric_entry.manager',
-                'elcodi.entity.metric_entry.class',
-                'elcodi.entity.metric_entry.mapping_file',
-                'elcodi.entity.metric_entry.enabled'
+                [
+                    'metric',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/NewsletterBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\NewsletterBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.newsletter_subscription.manager',
-                'elcodi.entity.newsletter_subscription.class',
-                'elcodi.entity.newsletter_subscription.mapping_file',
-                'elcodi.entity.newsletter_subscription.enabled'
+                [
+                    'newsletter_subscription',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/PageBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/PageBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\PageBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.page.manager',
-                'elcodi.entity.page.class',
-                'elcodi.entity.page.mapping_file',
-                'elcodi.entity.page.enabled'
+                [
+                    'page',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/ProductBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/ProductBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\ProductBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,33 +39,14 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.product.manager',
-                'elcodi.entity.product.class',
-                'elcodi.entity.product.mapping_file',
-                'elcodi.entity.product.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.product_variant.manager',
-                'elcodi.entity.product_variant.class',
-                'elcodi.entity.product_variant.mapping_file',
-                'elcodi.entity.product_variant.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.category.manager',
-                'elcodi.entity.category.class',
-                'elcodi.entity.category.mapping_file',
-                'elcodi.entity.category.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.manufacturer.manager',
-                'elcodi.entity.manufacturer.class',
-                'elcodi.entity.manufacturer.mapping_file',
-                'elcodi.entity.manufacturer.enabled'
+                [
+                    'product',
+                    'product_variant',
+                    'category',
+                    'manufacturer',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/RuleBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/RuleBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\RuleBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.rule.manager',
-                'elcodi.entity.rule.class',
-                'elcodi.entity.rule.mapping_file',
-                'elcodi.entity.rule.enabled'
+                [
+                    'rule',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/ShippingBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/ShippingBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\ShippingBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,19 +39,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.shipping_range.manager',
-                'elcodi.entity.shipping_range.class',
-                'elcodi.entity.shipping_range.mapping_file',
-                'elcodi.entity.shipping_range.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.carrier.manager',
-                'elcodi.entity.carrier.class',
-                'elcodi.entity.carrier.mapping_file',
-                'elcodi.entity.carrier.enabled'
+                [
+                    'shipping_range',
+                    'carrier',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\StateTransitionMachineBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.state_transition_machine.state_line.manager',
-                'elcodi.state_transition_machine.state_line.class',
-                'elcodi.state_transition_machine.state_line.mapping_file',
-                'elcodi.state_transition_machine.state_line.enabled'
+                [
+                    'state_transition_machine.state_line',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/DependencyInjection/ElcodiStateTransitionMachineExtension.php
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/DependencyInjection/ElcodiStateTransitionMachineExtension.php
@@ -77,10 +77,10 @@ class ElcodiStateTransitionMachineExtension extends AbstractExtension implements
     protected function getParametrizationValues(array $config)
     {
         return [
-            "elcodi.state_transition_machine.state_line.class" => $config['mapping']['state_line']['class'],
-            "elcodi.state_transition_machine.state_line.mapping_file" => $config['mapping']['state_line']['mapping_file'],
-            "elcodi.state_transition_machine.state_line.manager" => $config['mapping']['state_line']['manager'],
-            "elcodi.state_transition_machine.state_line.enabled" => $config['mapping']['state_line']['enabled'],
+            "elcodi.entity.state_transition_machine.state_line.class" => $config['mapping']['state_line']['class'],
+            "elcodi.entity.state_transition_machine.state_line.mapping_file" => $config['mapping']['state_line']['mapping_file'],
+            "elcodi.entity.state_transition_machine.state_line.manager" => $config['mapping']['state_line']['manager'],
+            "elcodi.entity.state_transition_machine.state_line.enabled" => $config['mapping']['state_line']['enabled'],
         ];
     }
 
@@ -108,7 +108,7 @@ class ElcodiStateTransitionMachineExtension extends AbstractExtension implements
     public function getEntitiesOverrides()
     {
         return [
-            'Elcodi\Component\StateTransitionMachine\Entity\Interfaces\StateLineInterface' => 'elcodi.state_transition_machine.state_line.class',
+            'Elcodi\Component\StateTransitionMachine\Entity\Interfaces\StateLineInterface' => 'elcodi.entity.state_transition_machine.state_line.class',
         ];
     }
 

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/classes.yml
@@ -3,7 +3,7 @@ parameters:
     #
     # Entities
     #
-    elcodi.state_transition_machine.state_line.class: Elcodi\Component\StateTransitionMachine\Entity\StateLine
+    elcodi.entity.state_transition_machine.state_line.class: Elcodi\Component\StateTransitionMachine\Entity\StateLine
 
     #
     # Factories

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/factories.yml
@@ -9,4 +9,4 @@ services:
     elcodi.factory.state_transition_machine_state_line:
         class: %elcodi.factory.state_transition_machine_state_line.class%
         calls:
-            - [setEntityNamespace, ["%elcodi.state_transition_machine.state_line.class%"]]
+            - [setEntityNamespace, ["%elcodi.entity.state_transition_machine.state_line.class%"]]

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/objectManagers.yml
@@ -5,4 +5,4 @@ services:
     #
     elcodi.object_manager.state_transition_machine_state_line:
         parent: elcodi.abstract_manager
-        arguments: [ %elcodi.state_transition_machine.state_line.class% ]
+        arguments: [ %elcodi.entity.state_transition_machine.state_line.class% ]

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/repositories.yml
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/repositories.yml
@@ -9,4 +9,4 @@ services:
     #
     elcodi.repository.state_transition_machine_state_line:
         parent: elcodi.abstract_repository
-        arguments: [ %elcodi.state_transition_machine.state_line.class% ]
+        arguments: [ %elcodi.entity.state_transition_machine.state_line.class% ]

--- a/src/Elcodi/Bundle/TaxBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/TaxBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\TaxBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -33,19 +37,12 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.tax.manager',
-                'elcodi.entity.tax.class',
-                'elcodi.entity.tax.mapping_file',
-                'elcodi.entity.tax.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.tax_group.manager',
-                'elcodi.entity.tax_group.class',
-                'elcodi.entity.tax_group.mapping_file',
-                'elcodi.entity.tax_group.enabled'
+                [
+                    'tax',
+                    'tax_group',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/UserBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/UserBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\UserBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,26 +39,13 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.abstract_user.manager',
-                'elcodi.entity.abstract_user.class',
-                'elcodi.entity.abstract_user.mapping_file',
-                'elcodi.entity.abstract_user.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.admin_user.manager',
-                'elcodi.entity.admin_user.class',
-                'elcodi.entity.admin_user.mapping_file',
-                'elcodi.entity.admin_user.enabled'
-            )
-            ->addEntityMapping(
-                $container,
-                'elcodi.entity.customer.manager',
-                'elcodi.entity.customer.class',
-                'elcodi.entity.customer.mapping_file',
-                'elcodi.entity.customer.enabled'
+                [
+                    'abstract_user',
+                    'admin_user',
+                    'customer',
+                ]
             );
     }
 }

--- a/src/Elcodi/Bundle/ZoneBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/ZoneBundle/CompilerPass/MappingCompilerPass.php
@@ -20,11 +20,15 @@ namespace Elcodi\Bundle\ZoneBundle\CompilerPass;
 use Mmoreram\SimpleDoctrineMapping\CompilerPass\Abstracts\AbstractMappingCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+use Elcodi\Bundle\CoreBundle\CompilerPass\Traits\EntityMappingTrait;
+
 /**
  * Class MappingCompilerPass
  */
 class MappingCompilerPass extends AbstractMappingCompilerPass
 {
+    use EntityMappingTrait;
+
     /**
      * You can modify the container here before it is dumped to PHP code.
      *
@@ -35,12 +39,11 @@ class MappingCompilerPass extends AbstractMappingCompilerPass
     public function process(ContainerBuilder $container)
     {
         $this
-            ->addEntityMapping(
+            ->addEntityMappings(
                 $container,
-                'elcodi.entity.zone.manager',
-                'elcodi.entity.zone.class',
-                'elcodi.entity.zone.mapping_file',
-                'elcodi.entity.zone.enabled'
+                [
+                    'zone',
+                ]
             );
     }
 }


### PR DESCRIPTION
* Using a Trait, placed in CoreBundle, now we can define the mapping of our application with less
code.
* Changed all entry points with this new method