### PR TITLE
allow calls to php-cs-fixer with paths

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,17 +1,22 @@
 <?php
 
-return Symfony\CS\Config\Config::create()
+$config = Symfony\CS\Config\Config::create()
     // use SYMFONY_LEVEL:
     ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
     // and extra fixers:
-    ->fixers(array(
+    ->fixers([
         'concat_with_spaces',
         'multiline_spaces_before_semicolon',
         'short_array_syntax',
-        '-remove_lines_between_uses'
-    ))
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
-            ->in('src/')
-    )
-;
+        '-remove_lines_between_uses',
+    ]);
+
+if (null === $input->getArgument('path')) {
+    $config
+        ->finder(
+            Symfony\CS\Finder\DefaultFinder::create()
+                ->in('src/')
+        );
+}
+
+return $config;


### PR DESCRIPTION
I want to benefit from the feature of calling `bin/php-cs-fixer fix` with a filename, to not go through the processing of all files. Current `.php_cs` file does not allow this and always go through all `src/` files.

This PR fixes this. Something similar should be done in `elcodi/bamboo`.