### PR TITLE
[Configuration] Integrate with ControllerExtraBundle

### DIFF
--- a/src/Elcodi/Bundle/ConfigurationBundle/Annotation/Configuration.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Annotation/Configuration.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\Annotation;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Abstracts\Annotation;
+
+/**
+ * Configuration annotation driver
+ *
+ * @Annotation
+ */
+class Configuration extends Annotation
+{
+    /**
+     * @var string
+     *
+     * Name of the parameter
+     */
+    public $name;
+
+    /**
+     * @var string
+     *
+     * Key from configuration
+     */
+    public $key;
+
+    /**
+     * @var string
+     *
+     * Default value
+     */
+    public $default = null;
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/ElcodiConfigurationExtension.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/DependencyInjection/ElcodiConfigurationExtension.php
@@ -17,7 +17,9 @@
 
 namespace Elcodi\Bundle\ConfigurationBundle\DependencyInjection;
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 use Elcodi\Bundle\CoreBundle\DependencyInjection\Abstracts\AbstractExtension;
 use Elcodi\Bundle\CoreBundle\DependencyInjection\Interfaces\EntitiesOverridableExtensionInterface;
@@ -95,8 +97,13 @@ class ElcodiConfigurationExtension extends AbstractExtension implements Entities
      */
     public function getConfigFiles(array $config)
     {
+        $isControllerExtraBundlePresent = interface_exists(
+            'Mmoreram\ControllerExtraBundle\Resolver\Interfaces\AnnotationResolverInterface'
+        );
+
         return [
             'classes',
+            ['annotationResolver', $isControllerExtraBundlePresent],
             'commands',
             'services',
             'factories',
@@ -106,6 +113,23 @@ class ElcodiConfigurationExtension extends AbstractExtension implements Entities
             'twig',
             'directors',
         ];
+    }
+
+    /**
+     * Hook after load the full container
+     *
+     * @param array            $config    Configuration
+     * @param ContainerBuilder $container Container
+     */
+    protected function postLoad(array $config, ContainerBuilder $container)
+    {
+        parent::postLoad($config, $container);
+
+        if (!$container->hasDefinition('elcodi.configuration.annotation_resolver')) {
+            return;
+        }
+
+        AnnotationRegistry::registerFile(__DIR__ . '/../Annotation/Configuration.php');
     }
 
     /**

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resolver/ConfigurationResolver.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resolver/ConfigurationResolver.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ConfigurationBundle\Resolver;
+
+use Mmoreram\ControllerExtraBundle\Annotation\Abstracts\Annotation;
+use Mmoreram\ControllerExtraBundle\Resolver\Interfaces\AnnotationResolverInterface;
+use ReflectionMethod;
+use Symfony\Component\HttpFoundation\Request;
+
+use Elcodi\Bundle\ConfigurationBundle\Annotation\Configuration as AnnotationConfiguration;
+use Elcodi\Component\Configuration\Exception\ConfigurationParameterNotFoundException;
+use Elcodi\Component\Configuration\Services\ConfigurationManager;
+
+/**
+ * ConfigurationResolver
+ *
+ * Resolve Configuration annotations
+ */
+class ConfigurationResolver implements AnnotationResolverInterface
+{
+    /**
+     * @var ConfigurationManager
+     *
+     * Configuration manager
+     */
+    protected $configurationManager;
+
+    /**
+     * @param $configurationManager ConfigurationManager
+     */
+    public function __construct(ConfigurationManager $configurationManager)
+    {
+        $this->configurationManager = $configurationManager;
+    }
+
+    /**
+     * Specific annotation evaluation
+     *
+     * @param Request          $request    Request
+     * @param Annotation       $annotation Annotation
+     * @param ReflectionMethod $method     Method
+     *
+     * @throws ConfigurationParameterNotFoundException
+     *
+     * @return $this self Object
+     */
+    public function evaluateAnnotation(
+        Request $request,
+        Annotation $annotation,
+        ReflectionMethod $method
+    ) {
+        if ($annotation instanceof AnnotationConfiguration) {
+            $value = $this->resolveValue($annotation);
+
+            $request
+                ->attributes
+                ->set($annotation->name, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Resolve configuration value from annotation
+     *
+     * @param AnnotationConfiguration $annotation
+     *
+     * @return mixed
+     *
+     * @throws ConfigurationParameterNotFoundException
+     */
+    protected function resolveValue(AnnotationConfiguration $annotation)
+    {
+        return $this
+            ->configurationManager
+            ->get(
+                $annotation->key,
+                $annotation->default
+            );
+    }
+}

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/annotationResolver.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/annotationResolver.yml
@@ -1,0 +1,11 @@
+services:
+
+    #
+    # Annotation resolver
+    #
+    elcodi.configuration.annotation_resolver:
+        class: Elcodi\Bundle\ConfigurationBundle\Resolver\ConfigurationResolver
+        arguments:
+            - @elcodi.manager.configuration
+        tags:
+            - { name: controller_extra.annotation }


### PR DESCRIPTION
Add a new `Configuration` annotation for `mmoreram/controller-extra-bundle`. If you don't have this bundle, does nothing.

```php
/**
 * @Configuration(
 *     name = "parameter",
 *     key = "key_from_configuration",
 *     default = "default_value"
 * )
 */
public function testAction($parameter)
{
    …
}
```

This extracts `key_from_configuration` current value from `Configuration` and sets `$parameter` with it, defaulting to `default_value` if it does not exist. In case no default value is supplied and configuration can't be found, throws an exception.