### PR TITLE
getConvertedAmount Method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "doctrine/doctrine-cache-bundle": "~1.0",
         "mmoreram/simple-doctrine-mapping": "~0.1",
 
-        "sebastian/money": "1.5.*",
+        "sebastian/money": "~1.3",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "ircmaxell/password-compat": "~1.0",
         "guzzlehttp/guzzle": "~5.2",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "doctrine/doctrine-cache-bundle": "~1.0",
         "mmoreram/simple-doctrine-mapping": "~0.1",
 
-        "sebastian/money": "~1.3",
+        "sebastian/money": "1.5.*",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "ircmaxell/password-compat": "~1.0",
         "guzzlehttp/guzzle": "~5.2",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "doctrine/doctrine-cache-bundle": "~1.0",
         "mmoreram/simple-doctrine-mapping": "~0.1",
 
-        "sebastian/money": "~1.3",
+        "sebastian/money": "~1.5",
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "ircmaxell/password-compat": "~1.0",
         "guzzlehttp/guzzle": "~5.2",

--- a/src/Elcodi/Component/Currency/Entity/Money.php
+++ b/src/Elcodi/Component/Currency/Entity/Money.php
@@ -131,6 +131,16 @@ class Money implements MoneyInterface
     }
 
     /**
+     * Gets the monetary value represented by this object converted to its base units
+     *
+     * @return float
+     */
+    public function getConvertedAmount()
+    {
+        return $this->wrappedMoney->getConvertedAmount();
+    }
+
+    /**
      * Compares current Money object to another
      *
      * Will return -1, 0, 1 if the amount of this Money object

--- a/src/Elcodi/Component/Currency/Entity/Money.php
+++ b/src/Elcodi/Component/Currency/Entity/Money.php
@@ -137,7 +137,9 @@ class Money implements MoneyInterface
      */
     public function getConvertedAmount()
     {
-        return $this->wrappedMoney->getConvertedAmount();
+        return $this
+            ->wrappedMoney
+            ->getConvertedAmount();
     }
 
     /**

--- a/src/Elcodi/Component/Currency/composer.json
+++ b/src/Elcodi/Component/Currency/composer.json
@@ -35,7 +35,7 @@
         "doctrine/common": "~2.4",
         "doctrine/orm": "~2.4",
         "symfony/http-foundation": "~2.6",
-        "sebastian/money": "~1.3",
+        "sebastian/money": "~1.5",
         "twig/twig": "~1.16",
 
         "elcodi/core": "~0.5.0"


### PR DESCRIPTION
Due last Sebastianbergman/Money update, getConvertedAmount method is now available.

use SebastianBergmann\Money\Currency;
use SebastianBergmann\Money\Money;

// Create Money object that represents 1 EUR
$m = new Money(100, new Currency('EUR'));

// Access the Money object's monetary value
print $m->getAmount();

// Access the Money object's monetary value converted to its base units
print $m->getConvertedAmount();

The code above produces the output shown below:
100
1.00