### PR TITLE
rename service from elcodi.cart.manager to elcodi.manager.cart

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/README.md
+++ b/src/Elcodi/Bundle/CartBundle/README.md
@@ -229,7 +229,7 @@ entity.
 [More info about the services classes on the component documentation](https://github.com/elcodi/Cart/blob/master/README.md#service-layer)
 
 ## Services
-- `@elcodi.cart.manager`: This service is thought to work with the cart, you can
+- `@elcodi.manager.cart`: This service is thought to work with the cart, you can
 do all the actions related with cart lines or products
 
 ## Transformer

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/classes.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/classes.yml
@@ -11,7 +11,7 @@ parameters:
     #
     # Services
     #
-    elcodi.cart.manager.class: Elcodi\Component\Cart\Services\CartManager
+    elcodi.manager.cart.class: Elcodi\Component\Cart\Services\CartManager
     elcodi.session_manager.cart.class: Elcodi\Component\Cart\Services\CartSessionManager
 
     #

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -8,7 +8,7 @@ services:
         arguments:
             - @elcodi.object_manager.cart
             - @elcodi.event_dispatcher.cart
-            - @elcodi.cart.manager
+            - @elcodi.manager.cart
             - @elcodi.wrapper.currency
             - @elcodi.converter.currency
             - "@=elcodi_config('product.use_stock', false)"

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
@@ -3,8 +3,8 @@ services:
     #
     # Services
     #
-    elcodi.cart.manager:
-        class: %elcodi.cart.manager.class%
+    elcodi.manager.cart:
+        class: %elcodi.manager.cart.class%
         arguments:
             cart_event_dispatcher: @elcodi.event_dispatcher.cart
             cart_line_event_dispatcher: @elcodi.event_dispatcher.cart_line

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/Abstracts/AbstractCartManagerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/Abstracts/AbstractCartManagerTest.php
@@ -37,7 +37,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
      */
     public function getServiceCallableName()
     {
-        return ['elcodi.cart.manager'];
+        return ['elcodi.manager.cart'];
     }
 
     /**
@@ -107,7 +107,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testAddLine()
     {
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -152,7 +152,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testRemoveLine()
     {
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -162,7 +162,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->removeLine($this->cart, $line);
 
         $this->assertRemovedLine($line);
@@ -176,7 +176,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testEmptyLines()
     {
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -186,7 +186,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->emptyLines($this->cart);
 
         $this->assertRemovedLine($line);
@@ -200,7 +200,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
     public function testEditCartLine()
     {
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -210,7 +210,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->editCartLine($line, $this->purchasable, 2);
 
         $this->assertSame(
@@ -257,7 +257,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $this->cartLine->setQuantity($quantityStart);
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -267,7 +267,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->setCartLineQuantity($line, $quantitySetted);
 
         $this->assertResults($quantityEnd);
@@ -295,7 +295,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->setQuantity($quantityStart);
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct(
                 $this->cart,
                 $line->getProduct(),
@@ -309,7 +309,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         }
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->increaseCartLineQuantity($this->cart->getCartLines()->last(), $quantityAdded);
 
         $this->assertResults($quantityEnd);
@@ -333,7 +333,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $this->cartLine->setQuantity($quantityStart);
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct(
                 $this->cart,
                 $this->cartLine->getProduct(),
@@ -343,7 +343,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $line = $this->cart->getCartLines()->last();
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->decreaseCartLineQuantity($line, $quantityRemoved);
 
         $this->assertResults($quantityEnd);
@@ -363,7 +363,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
         $quantityEnd
     ) {
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct($this->cart, $this->purchasable, $quantitySet);
 
         $this->assertResults($quantityEnd);

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
@@ -144,11 +144,11 @@ class CartManagerVariantTest extends AbstractCartManagerTest
     public function testAddSameVariantTwice()
     {
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct($this->cart, $this->purchasable, 1);
 
         $this
-            ->get('elcodi.cart.manager')
+            ->get('elcodi.manager.cart')
             ->addProduct($this->cart, $this->purchasable, 2);
 
         $this->assertEquals(1, $this->cart->getCartLines()->count());


### PR DESCRIPTION
                            
|Q            |A           |
|---          |---         |
|Bug Fix?     |no          |
|New Feature? |no          |
|BC Breaks?   |no          |
|Deprecations?|no          |
|Tests Pass?  |no          |
|Fixed Tickets|aids in #660|
|License      |MIT         |
                            

renames cart.manager -> manager.cart which makes sense according to the new specification/documentation standard of service naming