### PR TITLE
eliminate keys on yaml when passing array of arguments

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -50,7 +50,7 @@ services:
     elcodi.event_listener.address_clone:
         class: %elcodi.event_listener.address_clone.class%
         arguments:
-            cart_repository: @elcodi.repository.cart
-            cart_object_manager: @elcodi.object_manager.cart
+            - @elcodi.repository.cart
+            - @elcodi.object_manager.cart
         tags:
             - { name: kernel.event_listener, event: address.onclone, method: updateCarts, priority: 0}

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/factories.yml
@@ -18,8 +18,8 @@ services:
     elcodi.factory.order:
         class: %elcodi.factory.order.class%
         arguments:
-            payment_machine_manager: @elcodi.order.payment_states_machine.manager
-            shipping_machine_manager: @elcodi.order.shipping_states_machine.manager
+            - @elcodi.order.payment_states_machine.manager
+            - @elcodi.order.shipping_states_machine.manager
         calls:
             - [setEntityNamespace, ["%elcodi.entity.order.class%"]]
 

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
@@ -6,17 +6,17 @@ services:
     elcodi.cart.manager:
         class: %elcodi.cart.manager.class%
         arguments:
-            cart_event_dispatcher: @elcodi.event_dispatcher.cart
-            cart_line_event_dispatcher: @elcodi.event_dispatcher.cart_line
-            cart_factory: @elcodi.factory.cart
-            cart_line_factory: @elcodi.factory.cart_line
+            - @elcodi.event_dispatcher.cart
+            - @elcodi.event_dispatcher.cart_line
+            - @elcodi.factory.cart
+            - @elcodi.factory.cart_line
 
     elcodi.session_manager.cart:
         class: %elcodi.session_manager.cart.class%
         arguments:
-            session: @session
-            session_field_name: %elcodi.core.cart.cart_session_field_name%
-            save_in_session: %elcodi.core.cart.cart_save_in_session%
+            - @session
+            - %elcodi.core.cart.cart_session_field_name%
+            - %elcodi.core.cart.cart_save_in_session%
 
     #
     # Wrappers
@@ -24,8 +24,8 @@ services:
     elcodi.wrapper.cart:
         class: %elcodi.wrapper.cart.class%
         arguments:
-            cart_event_dispatcher: @elcodi.event_dispatcher.cart
-            cart_session_manager: @elcodi.session_manager.cart
-            cart_repository: @elcodi.repository.cart
-            cart_factory: @elcodi.factory.cart
-            customer_wrapper: @elcodi.wrapper.customer
+            - @elcodi.event_dispatcher.cart
+            - @elcodi.session_manager.cart
+            - @elcodi.repository.cart
+            - @elcodi.factory.cart
+            - @elcodi.wrapper.customer

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/stateMachine.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/stateMachine.yml
@@ -6,10 +6,10 @@ services:
     elcodi.order.payment_states_machine.builder:
         class: %elcodi.state_transition_machine.machine_builder.class%
         arguments:
-            machine_factory: @elcodi.factory.state_transition_machine
-            identifier: %elcodi.order.payment_states_machine.identifier%
-            configuration: %elcodi.order.payment_states_machine.states%
-            point_of_entry: %elcodi.order.payment_states_machine.point_of_entry%
+            - @elcodi.factory.state_transition_machine
+            - %elcodi.order.payment_states_machine.identifier%
+            - %elcodi.order.payment_states_machine.states%
+            - %elcodi.order.payment_states_machine.point_of_entry%
 
     elcodi.order.payment_states_machine:
         class: %elcodi.state_transition_machine.machine.class%
@@ -19,9 +19,9 @@ services:
     elcodi.order.payment_states_machine.manager:
         class: %elcodi.state_transition_machine.machine_manager.class%
         arguments:
-            machine: @elcodi.order.payment_states_machine
-            event_dispatcher: @event_dispatcher
-            state_line_factory: @elcodi.factory.state_transition_machine_state_line
+            - @elcodi.order.payment_states_machine
+            - @event_dispatcher
+            - @elcodi.factory.state_transition_machine_state_line
 
 
     #
@@ -30,10 +30,10 @@ services:
     elcodi.order.shipping_states_machine.builder:
         class: %elcodi.state_transition_machine.machine_builder.class%
         arguments:
-            machine_factory: @elcodi.factory.state_transition_machine
-            identifier: %elcodi.order.shipping_states_machine.identifier%
-            configuration: %elcodi.order.shipping_states_machine.states%
-            point_of_entry: %elcodi.order.shipping_states_machine.point_of_entry%
+            - @elcodi.factory.state_transition_machine
+            - %elcodi.order.shipping_states_machine.identifier%
+            - %elcodi.order.shipping_states_machine.states%
+            - %elcodi.order.shipping_states_machine.point_of_entry%
 
     elcodi.order.shipping_states_machine:
         class: %elcodi.state_transition_machine.machine.class%
@@ -43,6 +43,6 @@ services:
     elcodi.order.shipping_states_machine.manager:
         class: %elcodi.state_transition_machine.machine_manager.class%
         arguments:
-            machine: @elcodi.order.shipping_states_machine
-            event_dispatcher: @event_dispatcher
-            state_line_factory: @elcodi.factory.state_transition_machine_state_line
+            - @elcodi.order.shipping_states_machine
+            - @event_dispatcher
+            - @elcodi.factory.state_transition_machine_state_line

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/transformers.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/transformers.yml
@@ -6,12 +6,12 @@ services:
     elcodi.transformer.cart_order:
         class: %elcodi.transformer.cart_order.class%
         arguments:
-            order_event_dispatcher: @elcodi.event_dispatcher.order
-            cart_line_order_line_transformer: @elcodi.transformer.cart_line_order_line
-            order_factory: @elcodi.factory.order
+            - @elcodi.event_dispatcher.order
+            - @elcodi.transformer.cart_line_order_line
+            - @elcodi.factory.order
 
     elcodi.transformer.cart_line_order_line:
         class: %elcodi.transformer.cart_line_order_line.class%
         arguments:
-            order_line_event_dispatcher:  @elcodi.event_dispatcher.order_line
-            order_factory: @elcodi.factory.order_line
+            - @elcodi.event_dispatcher.order_line
+            - @elcodi.factory.order_line

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
@@ -6,17 +6,17 @@ services:
     elcodi.manager.cart_coupon:
         class: %elcodi.manager.cart_coupon.class%
         arguments:
-            cart_coupon_event_dispatcher: @elcodi.event_dispatcher.cart_coupon
-            coupon_manager: @elcodi.manager.coupon
-            coupon_repository: @elcodi.repository.coupon
-            cart_coupon_repository: @elcodi.repository.cart_coupon
+            - @elcodi.event_dispatcher.cart_coupon
+            - @elcodi.manager.coupon
+            - @elcodi.repository.coupon
+            - @elcodi.repository.cart_coupon
 
     elcodi.manager.order_coupon:
         class: %elcodi.manager.order_coupon.class%
         arguments:
-            order_coupon_repository: @elcodi.repository.order_coupon
+            - @elcodi.repository.order_coupon
 
     elcodi.manager.cart_coupon_rule:
         class: %elcodi.manager.cart_coupon_rule.class%
         arguments:
-            rule_manager: @elcodi.manager.rule
+            - @elcodi.manager.rule

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/eventDispatchers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.event_dispatcher.comment:
         class: %elcodi.event_dispatcher.comment.class%
         arguments:
-            event_dispatcher: @event_dispatcher
+            - @event_dispatcher

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.event_listener.comment_cache_invalidation:
         class: %elcodi.event_listener.comment_cache_invalidation.class%
         arguments:
-            comment_cache: @elcodi.comment_cache
+            - @elcodi.comment_cache
         tags:
             - { name: kernel.event_listener, event: comment.onadd, method: onCommentChange, priority: 0 }
             - { name: kernel.event_listener, event: comment.onedit, method: onCommentChange, priority: 0 }

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/services.yml
@@ -6,14 +6,14 @@ services:
     elcodi.manager.comment:
         class: %elcodi.manager.comment.class%
         arguments:
-            comment_event_dispatcher: @elcodi.event_dispatcher.comment
-            comment_director: @elcodi.director.comment
-            comment_parser: @elcodi.comment_parser
+            - @elcodi.event_dispatcher.comment
+            - @elcodi.director.comment
+            - @elcodi.comment_parser
 
     elcodi.comment_parser:
         class: %elcodi.comment_parser.class%
         arguments:
-            parser_adapter: @elcodi.comment_parser_adapter
+            - @elcodi.comment_parser_adapter
 
     elcodi.comment_parser_adapter:
         class: Elcodi\Component\Core\Adapter\Parser\Interfaces\ParserAdapterInterface
@@ -22,9 +22,9 @@ services:
     elcodi.comment_cache:
         class: %elcodi.comment_cache.class%
         arguments:
-            comment_repository: @elcodi.repository.comment
-            comment_vote_manager: @elcodi.manager.comment_vote
-            cache_key: %elcodi.comment.cache_key%
+            - @elcodi.repository.comment
+            - @elcodi.manager.comment_vote
+            - %elcodi.comment.cache_key%
         calls:
             - [setCache, [@doctrine_cache.providers.elcodi_comments]]
             - [setEncoder, [@elcodi.json_encoder]]
@@ -32,5 +32,5 @@ services:
     elcodi.manager.comment_vote:
         class: %elcodi.manager.comment_vote.class%
         arguments:
-            comment_event_dispatcher: @elcodi.event_dispatcher.comment
-            vote_director: @elcodi.director.comment_vote
+            - @elcodi.event_dispatcher.comment
+            - @elcodi.director.comment_vote

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/commands.yml
@@ -6,20 +6,20 @@ services:
     elcodi.configuration_set_command:
         class: %elcodi.configuration_set_command.class%
         arguments:
-            template_loader: @elcodi.manager.configuration
+            - @elcodi.manager.configuration
         tags:
             -  { name: console.command }
 
     elcodi.configuration_get_command:
         class: %elcodi.configuration_get_command.class%
         arguments:
-            template_loader: @elcodi.manager.configuration
+            - @elcodi.manager.configuration
         tags:
             -  { name: console.command }
 
     elcodi.configuration_delete_command:
         class: %elcodi.configuration_delete_command.class%
         arguments:
-            template_loader: @elcodi.manager.configuration
+            - @elcodi.manager.configuration
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
@@ -7,10 +7,10 @@ services:
         class: %elcodi.manager.configuration.class%
         lazy: true
         arguments:
-            configuration_object_manager: @elcodi.object_manager.configuration
-            configuration_repository: @elcodi.repository.configuration
-            configuration_factory: @elcodi.factory.configuration
-            container_parameters: @elcodi.container_parameters
-            configuration_elements: %elcodi.core.configuration.elements%
+            - @elcodi.object_manager.configuration
+            - @elcodi.repository.configuration
+            - @elcodi.factory.configuration
+            - @elcodi.container_parameters
+            - %elcodi.core.configuration.elements%
         calls:
             - [setCache, [@doctrine_cache.providers.elcodi_configurations]]

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.configuration:
         class: %elcodi.twig_extension.configuration.class%
         arguments:
-            configuration_manager: @elcodi.manager.configuration
+            - @elcodi.manager.configuration
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/eventDispatchers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.event_dispatcher.abstract:
         abstract: true
         arguments:
-            event_dispatcher: @event_dispatcher
+            - @event_dispatcher

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/providers.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/providers.yml
@@ -11,19 +11,19 @@ services:
     elcodi.provider.manager:
         class: %elcodi.provider.manager.class%
         arguments:
-            manager: @doctrine
-            parameters_bag: @elcodi.container_parameters
+            - @doctrine
+            - @elcodi.container_parameters
 
     elcodi.provider.repository:
         class: %elcodi.provider.repository.class%
         arguments:
-            manager_provider: @elcodi.provider.manager
-            parameters_bag: @elcodi.container_parameters
+            - @elcodi.provider.manager
+            - @elcodi.container_parameters
 
     elcodi.mapping_provider:
         class: %elcodi.mapping_provider.class%
         arguments:
-            mapping_implementations: %elcodi.mapping_implementations%
+            - %elcodi.mapping_implementations%
 
     elcodi.referrer_provider:
         class: %elcodi.referrer_provider.class%

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/eventListeners.yml
@@ -6,6 +6,6 @@ services:
     elcodi.event_listener.make_coupon_used:
         class: %elcodi.event_listener.make_coupon_used.class%
         arguments:
-            coupon_object_manager: elcodi.object_manager.coupon
+            - @elcodi.object_manager.coupon
         tags:
             - { name: kernel.event_listener, event: coupon.onused, method: makeUse, priority: 0 }

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/services.yml
@@ -6,5 +6,5 @@ services:
     elcodi.manager.coupon:
         class: %elcodi.manager.coupon.class%
         arguments:
-            coupon_factory: @elcodi.factory.coupon
-            coupon_code_generator: @elcodi.generator.random_string
+            - @elcodi.factory.coupon
+            - @elcodi.generator.random_string

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
@@ -6,6 +6,6 @@ services:
     elcodi.command.populate_currency_rates:
         class: %elcodi.command.populate_currency_rates.class%
         arguments:
-            currency_rates_populator: @elcodi.populator.currency_exchange_rate
+            - @elcodi.populator.currency_exchange_rate
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/currencyExchangeRatesProviderAdapters.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/currencyExchangeRatesProviderAdapters.yml
@@ -9,10 +9,10 @@ services:
     elcodi.adapter.currency_exchange_rate.open_exchange:
         class: %elcodi.adapter.currency_exchange_rate.open_exchange.class%
         arguments:
-            guzzle_client: @elcodi.core.currency.guzzle_client
-            api_id: %elcodi.core.currency.rates_provider_api_id%
-            end_point: %elcodi.core.currency.rates_provider_endpoint%
-            base_currency: %elcodi.core.currency.rates_provider_currency_base%
+            - @elcodi.core.currency.guzzle_client
+            - %elcodi.core.currency.rates_provider_api_id%
+            - %elcodi.core.currency.rates_provider_endpoint%
+            - %elcodi.core.currency.rates_provider_currency_base%
 
     elcodi.adapter.currency_exchange_rate.dummy:
         class: %elcodi.adapter.currency_exchange_rate.dummy.class%

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
@@ -11,7 +11,7 @@ services:
         class: %elcodi.abstract_factory.purchasable.class%
         abstract: true
         arguments:
-            currency_wrapper: @elcodi.wrapper.currency
+            - @elcodi.wrapper.currency
 
     #
     # Factory for Currency entities

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
@@ -6,21 +6,21 @@ services:
     elcodi.manager.currency:
         class: %elcodi.manager.currency.class%
         arguments:
-            currency_repository: @elcodi.repository.currency
-            exchange_rates_repository: @elcodi.repository.currency_exchange_rate
-            currency_base: %elcodi.core.currency.rates_provider_currency_base%
+            - @elcodi.repository.currency
+            - @elcodi.repository.currency_exchange_rate
+            - %elcodi.core.currency.rates_provider_currency_base%
 
     elcodi.session_manager.currency:
         class: %elcodi.session_manager.currency.class%
         arguments:
-            session: @session
-            session_field_name: %elcodi.core.currency.session_field_name%
+            - @session
+            - %elcodi.core.currency.session_field_name%
 
     elcodi.converter.currency:
         class: %elcodi.converter.currency.class%
         arguments:
-            currency_manager: @elcodi.manager.currency
-            currency_base: %elcodi.core.currency.rates_provider_currency_base%
+            - @elcodi.manager.currency
+            - %elcodi.core.currency.rates_provider_currency_base%
 
     elcodi.populator.currency_exchange_rate:
         class: %elcodi.populator.currency_exchange_rate.class%

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/autoloadEventListeners.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/autoloadEventListeners.yml
@@ -7,7 +7,7 @@ services:
         class: %elcodi.event_listener.entity_translator_entity.class%
         lazy: true
         arguments:
-            container: @service_container
-            locale: @elcodi.locale
+            - @service_container
+            - @elcodi.locale
         tags:
             - { name: doctrine.event_listener, event: postLoad }

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventDispatchers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.event_dispatcher.entity_translator:
         class: %elcodi.event_dispatcher.entity_translator.class%
         arguments:
-            event_dispatcher: @event_dispatcher
+            - @event_dispatcher

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventListeners.yml
@@ -6,12 +6,12 @@ services:
     elcodi.event_listener.entity_translator_form:
         class: %elcodi.event_listener.entity_translator_form.class%
         arguments:
-            translation_provider: @elcodi.entity_translation_provider
-            configuration: %elcodi.core.entity_translator.configuration%
-            locales: @elcodi.languages_iso_array
-            master_locale: %elcodi.core.entity_translator.language_master_locale%
-            fallback: %elcodi.core.entity_translator.language_fallback%
-            changes_bag: @elcodi.entity_translator_changes
+            - @elcodi.entity_translation_provider
+            - %elcodi.core.entity_translator.configuration%
+            - @elcodi.languages_iso_array
+            - %elcodi.core.entity_translator.language_master_locale%
+            - %elcodi.core.entity_translator.language_fallback%
+            - @elcodi.entity_translator_changes
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: saveEntityTranslations }
 

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/services.yml
@@ -4,16 +4,16 @@ services:
         class: %elcodi.services.entity_translation_provider.class%
         lazy: true
         arguments:
-            translation_repository: @elcodi.repository.entity_translation
-            translation_factory: @elcodi.factory.entity_translation
-            translation_object_manager: @elcodi.object_manager.entity_translation
+            - @elcodi.repository.entity_translation
+            - @elcodi.factory.entity_translation
+            - @elcodi.object_manager.entity_translation
 
     elcodi.services.cached_entity_translation_provider:
         class: %elcodi.services.cached_entity_translation_provider.class%
         arguments:
-            translation_provider: @elcodi.services.entity_translation_provider
-            translation_repository: @elcodi.repository.entity_translation
-            cache_prefix: %elcodi.core.entity_translator.cache_prefix%
+            - @elcodi.services.entity_translation_provider
+            - @elcodi.repository.entity_translation
+            - %elcodi.core.entity_translator.cache_prefix%
         calls:
             - [setCache, [@doctrine_cache.providers.elcodi_translations]]
         tags:
@@ -28,10 +28,10 @@ services:
     elcodi.entity_translator_builder:
         class: %elcodi.entity_translator_builder.class%
         arguments:
-            translation_provider: @elcodi.entity_translation_provider
-            translator_factory: @elcodi.factory.entity_translator
-            configuration: %elcodi.core.entity_translator.configuration%
-            fallback: %elcodi.core.entity_translator.language_fallback%
+            - @elcodi.entity_translation_provider
+            - @elcodi.factory.entity_translator
+            - %elcodi.core.entity_translator.configuration%
+            - %elcodi.core.entity_translator.language_fallback%
 
     elcodi.entity_translator:
         class: %elcodi.entity_translator.class%

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/controllers.yml
@@ -6,5 +6,5 @@ services:
     elcodi.controller.location_api:
         class: %elcodi.controller.location_api.class%
         arguments:
-            request_stack: @request_stack
-            location_manager: @elcodi.location_provider.service
+            - @request_stack
+            - @elcodi.location_provider.service

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/formatters.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/formatters.yml
@@ -6,4 +6,4 @@ services:
     elcodi.formatter.address:
         class: %elcodi.formatter.address.class%
         arguments:
-            location_provider: @elcodi.location_provider
+            - @elcodi.location_provider

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/services.yml
@@ -6,14 +6,14 @@ services:
     elcodi.location_provider.service:
         class: %elcodi.location_provider.service.class%
         arguments:
-            location_repository: @elcodi.repository.location
-            location_to_location_data_transformer: @elcodi.transformer.location_to_location_data
+            - @elcodi.repository.location
+            - @elcodi.transformer.location_to_location_data
 
     elcodi.location_provider.api:
         class: %elcodi.location_provider.api.class%
         arguments:
-            location_data_factory: @elcodi.factory.location_data
-            location_api_urls: @elcodi.location_api_urls
+            - @elcodi.factory.location_data
+            - @elcodi.location_api_urls
 
     elcodi.location_api_urls:
         class: %elcodi.location_api_urls.class%
@@ -28,10 +28,10 @@ services:
     elcodi.location_builder:
         class: %elcodi.location_builder.class%
         arguments:
-            location_factory: @elcodi.factory.location
+            - @elcodi.factory.location
 
     elcodi.manager.address:
         class: %elcodi.manager.address.class%
         arguments:
-            address_object_manager: @elcodi.object_manager.address
-            address_event_dispatcher: @elcodi.event_dispatcher.address
+            - @elcodi.object_manager.address
+            - @elcodi.event_dispatcher.address

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/transformers.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/transformers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.transformer.location_to_location_data:
         class: %elcodi.transformer.location_to_location_data.class%
         arguments:
-            location_data_factory: @elcodi.factory.location_data
+            - @elcodi.factory.location_data

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/services.yml
@@ -6,8 +6,8 @@ services:
     elcodi.provider.locale:
         class: %elcodi.provider.locale.class%
         arguments:
-            request_stack: @request_stack
-            default_locale: %locale%
+            - @request_stack
+            - %locale%
 
     elcodi.provider.locale.locale:
         class: %elcodi.entity.locale.class%
@@ -21,12 +21,12 @@ services:
     elcodi.manager.language:
         class: %elcodi.manager.language.class%
         arguments:
-            language_repository: @elcodi.repository.language
+            - @elcodi.repository.language
 
     elcodi.manager.locale:
         class: %elcodi.manager.locale.class%
         arguments:
-            locale: @elcodi.provider.locale.locale
+            - @elcodi.provider.locale.locale
         calls:
             - [initialize, []]
 

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/controllers.yml
@@ -6,19 +6,19 @@ services:
     elcodi.controller.media_image_resize:
         class: %elcodi.controller.media_image_resize.class%
         arguments:
-            request_stack: @request_stack
-            image_repository: @elcodi.repository.image
-            image_manager: @elcodi.manager.media_image
-            image_etag_transformer: @elcodi.transformer.media_image_etag
-            image_view_max_age: %elcodi.core.media.image_view_max_age%
-            image_view_shared_max_age: %elcodi.core.media.image_view_shared_max_age%
+            - @request_stack
+            - @elcodi.repository.image
+            - @elcodi.manager.media_image
+            - @elcodi.transformer.media_image_etag
+            - %elcodi.core.media.image_view_max_age%
+            - %elcodi.core.media.image_view_shared_max_age%
 
     elcodi.controller.media_image_upload:
         class: %elcodi.controller.media_image_upload.class%
         arguments:
-            request_stack: @request_stack
-            image_uploader: @elcodi.image_uploader
-            router: @router
-            image_upload_field_name: %elcodi.core.media.image_upload_field_name%
-            image_view_controller_route_name: %elcodi.core.media.image_view_controller_route_name%
-            image_resize_controller_route_name: %elcodi.core.media.image_resize_controller_route_name%
+            - @request_stack
+            - @elcodi.image_uploader
+            - @router
+            - %elcodi.core.media.image_upload_field_name%
+            - %elcodi.core.media.image_view_controller_route_name%
+            - %elcodi.core.media.image_resize_controller_route_name%

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/services.yml
@@ -6,23 +6,23 @@ services:
     elcodi.manager.media_image:
         class: %elcodi.manager.media_image.class%
         arguments:
-            image_factory: @elcodi.factory.image
-            file_manager: @elcodi.manager.media_file
-            resize_adapter: @elcodi.core.media.resize.default
+            - @elcodi.factory.image
+            - @elcodi.manager.media_file
+            - @elcodi.core.media.resize.default
 
     elcodi.manager.media_file:
         class: %elcodi.manager.media_file.class%
         arguments:
-            filesystem: @elcodi.core.media.filesystem.default
-            file_transformer: @elcodi.transformer.media_file_identifier
+            - @elcodi.core.media.filesystem.default
+            - @elcodi.transformer.media_file_identifier
 
     elcodi.image_uploader:
         class: %elcodi.image_uploader.class%
         arguments:
-            image_object_manager: @elcodi.object_manager.image
-            file_manager: @elcodi.manager.media_file
-            image_manager: @elcodi.manager.media_image
-            media_event_dispatcher: @elcodi.event_dispatcher.media
+            - @elcodi.object_manager.image
+            - @elcodi.manager.media_file
+            - @elcodi.manager.media_image
+            - @elcodi.event_dispatcher.media
 
     #
     # Resize
@@ -30,8 +30,8 @@ services:
     elcodi.core.media.resize.imagemagick:
         class: %elcodi.core.media.resize.imagemagick.class%
         arguments:
-            image_converter_bin_path: %elcodi.core.media.image_resize_converter_bin_path%
-            image_converter_default_profile: %elcodi.core.media.image_resize_converter_default_profile%
+            - %elcodi.core.media.image_resize_converter_bin_path%
+            - %elcodi.core.media.image_resize_converter_default_profile%
 
     #
     # Routes
@@ -39,23 +39,23 @@ services:
     elcodi.router.media_image_resize:
         class: %elcodi.router.media_image_resize.class%
         arguments:
-            image_resize_controller_route_name: %elcodi.core.media.image_resize_controller_route_name%
-            image_resize_controller_route: %elcodi.core.media.image_resize_controller_route%
+            - %elcodi.core.media.image_resize_controller_route_name%
+            - %elcodi.core.media.image_resize_controller_route%
         tags:
             - { name: routing.loader }
 
     elcodi.router.media_image_view:
         class: %elcodi.router.media_image_view.class%
         arguments:
-            image_view_controller_route_name: %elcodi.core.media.image_view_controller_route_name%
-            image_view_controller_route: %elcodi.core.media.image_view_controller_route%
+            - %elcodi.core.media.image_view_controller_route_name%
+            - %elcodi.core.media.image_view_controller_route%
         tags:
             - { name: routing.loader }
 
     elcodi.router.media_image_upload:
         class: %elcodi.router.media_image_upload.class%
         arguments:
-            image_upload_controller_route_name: %elcodi.core.media.image_upload_controller_route_name%
-            image_upload_controller_route: %elcodi.core.media.image_upload_controller_route%
+            - %elcodi.core.media.image_upload_controller_route_name%
+            - %elcodi.core.media.image_upload_controller_route%
         tags:
             - { name: routing.loader }

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
@@ -6,10 +6,10 @@ services:
     elcodi.twig_extension.media_image:
         class: %elcodi.twig_extension.media_image.class%
         arguments:
-            router: @router
-            image_resize_controller_route_name: %elcodi.core.media.image_resize_controller_route_name%
-            image_view_controller_route_name: %elcodi.core.media.image_view_controller_route_name%
-            images_domain_sharding_enabled: %elcodi.core.media.images.domain_sharding.enabled%
-            images_domain_sharding_base_urls: %elcodi.core.media.images.domain_sharding.base_urls%
+            - @router
+            - %elcodi.core.media.image_resize_controller_route_name%
+            - %elcodi.core.media.image_view_controller_route_name%
+            - %elcodi.core.media.images.domain_sharding.enabled%
+            - %elcodi.core.media.images.domain_sharding.base_urls%
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/symfonyRouter.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/symfonyRouter.yml
@@ -13,7 +13,7 @@ services:
     elcodi.adapter.menu_route_generator.symfony_routing:
         class: %elcodi.adapter.menu_route_generator.symfony_routing.class%
         arguments:
-            router: @router
+            - @router
 
     elcodi.adapter.menu_route_generator:
         alias: elcodi.adapter.menu_route_generator.symfony_routing

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
@@ -6,8 +6,8 @@ services:
     elcodi.manager.menu:
         class: %elcodi.manager.menu.class%
         arguments:
-            menu_repository: @elcodi.repository.menu
-            key: %elcodi.core.menu.cache_key%
+            - @elcodi.repository.menu
+            - %elcodi.core.menu.cache_key%
         calls:
             - [setCache, [@doctrine_cache.providers.elcodi_menus]]
             - [setEncoder, [@elcodi.json_encoder]]

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.menu_print_route:
         class: %elcodi.twig_extension.menu_print_route.class%
         arguments:
-            router: @router
+            - @router
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/buckets.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/buckets.yml
@@ -6,4 +6,4 @@ services:
     elcodi.redis_metrics_bucket:
         class: %elcodi.redis_metrics_bucket.class%
         arguments:
-            redis: @snc_redis.metric
+            - @snc_redis.metric

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/controllers.yml
@@ -6,5 +6,5 @@ services:
     elcodi.controller.metric_input:
         class: %elcodi.controller.metric_input.class%
         arguments:
-            request_stack: @request_stack
-            metric_manager: @elcodi.metric_manager
+            - @request_stack
+            - @elcodi.metric_manager

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/objectManagers.yml
@@ -8,4 +8,4 @@ services:
         factory_service: elcodi.provider.manager
         factory_method: getManagerByEntityNamespace
         arguments:
-            entity_namespace: %elcodi.entity.metric_entry.class%
+            - %elcodi.entity.metric_entry.class%

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/services.yml
@@ -6,9 +6,9 @@ services:
     elcodi.metric_manager:
         class: %elcodi.metric_manager.class%
         arguments:
-            metrics_bucket: @elcodi.metrics_bucket
-            entry_factory: @elcodi.factory.metric_entry
-            entry_object_manager: @elcodi.object_manager.entry
+            - @elcodi.metrics_bucket
+            - @elcodi.factory.metric_entry
+            - @elcodi.object_manager.entry
 
     #
     # Routes
@@ -16,7 +16,7 @@ services:
     elcodi.core.metric.routes.input.loader:
         class: %elcodi.core.metric.routes.input.loader.class%
         arguments:
-            input_controller_route_name: %elcodi.core.metric.input_controller_route_name%
-            input_controller_route: %elcodi.core.metric.input_controller_route%
+            - %elcodi.core.metric.input_controller_route_name%
+            - %elcodi.core.metric.input_controller_route%
         tags:
             - { name: routing.loader }

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.api_metric_twig_extension:
         class: %elcodi.api_metric_twig_extension.class%
         arguments:
-            metric_bucket: @elcodi.metrics_bucket
+            - @elcodi.metrics_bucket
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.event_listener.newsletter:
         class: %elcodi.event_listener.newsletter.class%
         arguments:
-            newsletter_object_manager: @elcodi.object_manager.newsletter_subscription
+            - @elcodi.object_manager.newsletter_subscription
         tags:
             - { name: kernel.event_listener, event: newsletter.onsubscribe, method: onNewsletterSubscribeFlush, priority: 0 }
             - { name: kernel.event_listener, event: newsletter.onunsubscribe, method: onNewsletterUnsubscribeFlush, priority: 0 }

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/services.yml
@@ -6,8 +6,8 @@ services:
     elcodi.manager.newsletter:
         class: %elcodi.manager.newsletter.class%
         arguments:
-            newsletter_event_dispatcher: @elcodi.event_dispatcher.newsletter
-            validator: @validator
-            newsletter_subscription_factory: @elcodi.factory.newsletter_subscription
-            newsletter_subscription_repository: @elcodi.repository.newsletter_subscription
-            hash_generator: @elcodi.generator.sha1
+            - @elcodi.event_dispatcher.newsletter
+            - @validator
+            - @elcodi.factory.newsletter_subscription
+            - @elcodi.repository.newsletter_subscription
+            - @elcodi.generator.sha1

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/controllers.yml
@@ -6,6 +6,6 @@ services:
     elcodi.core.page.controller.page:
         class: %elcodi.controller.page.class%
         arguments:
-            page_repository: @elcodi.repository.page
-            request_stack: @request_stack
-            renderer: @elcodi.core.page.chain_renderer
+            - @elcodi.repository.page
+            - @request_stack
+            - @elcodi.core.page.chain_renderer

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/loaders.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/loaders.yml
@@ -6,6 +6,6 @@ services:
     elcodi.core.page.router.simple_loader.loader:
         class: %elcodi.core.page.router.simple_loader.class%
         arguments:
-            name: %elcodi.core.page.routing.route_name%
-            path: %elcodi.core.page.routing.route_path%
-            controller: %elcodi.core.page.routing.controller%
+            - %elcodi.core.page.routing.route_name%
+            - %elcodi.core.page.routing.route_path%
+            - %elcodi.core.page.routing.controller%

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/commands.yml
@@ -6,6 +6,6 @@ services:
     elcodi.plugins_load_command:
         class: %elcodi.plugins_load_command.class%
         arguments:
-            template_loader: @elcodi.plugin_manager
+            - @elcodi.plugin_manager
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
@@ -11,11 +11,11 @@ services:
     elcodi.template_manager:
         class: %elcodi.template_manager.class%
         arguments:
-            kernel: @kernel
-            configuration_manager: @elcodi.manager.configuration
+            - @kernel
+            - @elcodi.manager.configuration
 
     elcodi.plugin_manager:
         class: %elcodi.plugin_manager.class%
         arguments:
-            kernel: @kernel
-            configuration_manager: @elcodi.manager.configuration
+            - @kernel
+            - @elcodi.manager.configuration

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/services.yml
@@ -6,10 +6,10 @@ services:
     elcodi.provider.category_tree:
         class: %elcodi.provider.category_tree.class%
         arguments:
-            category_repository: @elcodi.repository.category
+            - @elcodi.repository.category
 
     elcodi.provider.product_collection:
         class: %elcodi.provider.product_collection.class%
         arguments:
-            product_repository: @elcodi.repository.product
-            use_stock: "@=elcodi_config('product.use_stock', false)"
+            - @elcodi.repository.product
+            - "@=elcodi_config('product.use_stock', false)"

--- a/src/Elcodi/Bundle/RuleBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Resources/config/services.yml
@@ -7,5 +7,5 @@ services:
         class: %elcodi.manager.rule.class%
         lazy: true
         arguments:
-            expression_language: @elcodi.expression_language
-            context_provider: @elcodi.expression_language_context_collector
+            - @elcodi.expression_language
+            - @elcodi.expression_language_context_collector

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/resolvers.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/resolvers.yml
@@ -6,5 +6,5 @@ services:
     elcodi.resolver.shipping_range:
         class: %elcodi.resolver.shipping_range.class%
         arguments:
-            currency_converter: @elcodi.converter.currency
-            carrier_resolver_strategy: %elcodi.resolver.carrier.strategy%
+            - @elcodi.converter.currency
+            - %elcodi.resolver.carrier.strategy%

--- a/src/Elcodi/Bundle/TemplateBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/TemplateBundle/Resources/config/commands.yml
@@ -6,13 +6,13 @@ services:
     elcodi.templates_load_command:
         class: %elcodi.templates_load_command.class%
         arguments:
-            template_loader: @elcodi.template_manager
+            - @elcodi.template_manager
         tags:
             -  { name: console.command }
 
     elcodi.templates_enable_command:
         class: %elcodi.templates_enable_command.class%
         arguments:
-            configuration_manager: @elcodi.manager.configuration
+            - @elcodi.manager.configuration
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/TemplateBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/TemplateBundle/Resources/config/services.yml
@@ -6,5 +6,5 @@ services:
     elcodi.template_manager:
         class: %elcodi.template_manager.class%
         arguments:
-            kernel: @kernel
-            configuration_manager: @elcodi.manager.configuration
+            - @kernel
+            - @elcodi.manager.configuration

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.event_listener.authentication_success:
         class: %elcodi.event_listener.authentication_success.class%
         arguments:
-            cart_wrapper: @elcodi.wrapper.cart
-            cart_entity_manager: @elcodi.object_manager.cart
+            - @elcodi.wrapper.cart
+            - @elcodi.object_manager.cart
         tags:
             - { name: kernel.event_listener, event: security.authentication.success, method: onAuthenticationSuccess  }

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/providers.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/providers.yml
@@ -21,11 +21,11 @@ services:
         factory_service: security.encoder_factory
         factory_method: getEncoder
         arguments:
-            customer_instance: @elcodi.customer_provider_entity_instance
+            - @elcodi.customer_provider_entity_instance
 
     elcodi.provider.admin_user_provider:
         class: %elcodi.abstract_user_provider.class%
         factory_service: security.encoder_factory
         factory_method: getEncoder
         arguments:
-            customer_instance: @elcodi.admin_user_provider_entity_instance
+            - @elcodi.admin_user_provider_entity_instance

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
@@ -6,19 +6,19 @@ services:
     elcodi.manager.password:
         class: %elcodi.manager.password.class%
         arguments:
-            entity_manager: @doctrine.orm.entity_manager
-            router: @router
-            event_dispatcher: @event_dispatcher
-            recovery_hash_generator: @elcodi.generator.sha1
+            - @doctrine.orm.entity_manager
+            - @router
+            - @event_dispatcher
+            - @elcodi.generator.sha1
 
     elcodi.manager.customer:
         class: %elcodi.manager.customer.class%
         arguments:
-            event_dispatcher: @event_dispatcher
-            security_context: @?security.context
+            - @event_dispatcher
+            - @?security.context
 
     elcodi.manager.admin_user:
         class: %elcodi.manager.admin_user.class%
         arguments:
-            event_dispatcher: @event_dispatcher
-            security_context: @?security.context
+            - @event_dispatcher
+            - @?security.context

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/validator.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/validator.yml
@@ -6,6 +6,6 @@ services:
     elcodi.validator.city_exists:
         class: %elcodi.validator.city_exists.class%
         arguments:
-            location_provider: @elcodi.location_provider
+            - @elcodi.location_provider
         tags:
             - { name: validator.constraint_validator, alias: city_exists }

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/wrappers.yml
@@ -6,11 +6,11 @@ services:
     elcodi.wrapper.customer:
         class: %elcodi.wrapper.customer.class%
         arguments:
-            customer_factory: @elcodi.factory.customer
-            security_context: @?security.context
+            - @elcodi.factory.customer
+            - @?security.context
 
     elcodi.wrapper.admin_user:
         class: %elcodi.wrapper.admin_user.class%
         arguments:
-            admin_user_factory: @elcodi.factory.admin_user
-            security_context: @?security.context
+            - @elcodi.factory.admin_user
+            - @?security.context

--- a/src/Elcodi/Bundle/ZoneBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ZoneBundle/Resources/config/services.yml
@@ -6,10 +6,10 @@ services:
     elcodi.matcher.zone:
         class: %elcodi.matcher.zone.class%
         arguments:
-            location_manager: @elcodi.location_provider
+            - @elcodi.location_provider
 
     elcodi.finder.zone:
         class: %elcodi.finder.zone.class%
         arguments:
-            zone_repository: @elcodi.repository.zone
-            zone_matcher: @elcodi.matcher.zone
+            - @elcodi.repository.zone
+            - @elcodi.matcher.zone


### PR DESCRIPTION
                               
|Q            |A              |
|---          |---            |
|Bug Fix?     |no             |
|New Feature? |no             |
|BC Breaks?   |no             |
|Deprecations?|no             |
|Tests Pass?  |no             |
|Fixed Tickets|fix wrong usage|
|License      |MIT            |
                               

fix wrong usage of keys on service definitions arguments AND also fixes this hidden bug as well https://github.com/elcodi/elcodi/pull/715/files#r28051115