### PR TITLE
make uniform the namespacing for fqcn passed around

### DIFF
--- a/src/Elcodi/Bundle/AttributeBundle/ElcodiAttributeBundle.php
+++ b/src/Elcodi/Bundle/AttributeBundle/ElcodiAttributeBundle.php
@@ -59,7 +59,7 @@ class ElcodiAttributeBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/AttributeBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\AttributeBundle\ElcodiAttributeBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\AttributeBundle\ElcodiAttributeBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/BannerBundle/ElcodiBannerBundle.php
+++ b/src/Elcodi/Bundle/BannerBundle/ElcodiBannerBundle.php
@@ -57,9 +57,9 @@ class ElcodiBannerBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
-            '\Elcodi\Bundle\MediaBundle\ElcodiMediaBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
+            'Elcodi\Bundle\MediaBundle\ElcodiMediaBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\BannerBundle\ElcodiBannerBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\BannerBundle\ElcodiBannerBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/CartBundle/ElcodiCartBundle.php
+++ b/src/Elcodi/Bundle/CartBundle/ElcodiCartBundle.php
@@ -59,13 +59,13 @@ class ElcodiCartBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\UserBundle\ElcodiUserBundle',
-            '\Elcodi\Bundle\ProductBundle\ElcodiProductBundle',
-            '\Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
-            '\Elcodi\Bundle\StateTransitionMachineBundle\ElcodiStateTransitionMachineBundle',
-            '\Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle',
-            '\Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\UserBundle\ElcodiUserBundle',
+            'Elcodi\Bundle\ProductBundle\ElcodiProductBundle',
+            'Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
+            'Elcodi\Bundle\StateTransitionMachineBundle\ElcodiStateTransitionMachineBundle',
+            'Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle',
+            'Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\CartBundle\ElcodiCartBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\CartBundle\ElcodiCartBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/CartCouponBundle/ElcodiCartCouponBundle.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/ElcodiCartCouponBundle.php
@@ -59,10 +59,10 @@ class ElcodiCartCouponBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CartBundle\ElcodiCartBundle',
-            '\Elcodi\Bundle\CouponBundle\ElcodiCouponBundle',
-            '\Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CartBundle\ElcodiCartBundle',
+            'Elcodi\Bundle\CouponBundle\ElcodiCouponBundle',
+            'Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\CartCouponBundle\ElcodiCartCouponBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\CartCouponBundle\ElcodiCartCouponBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/CommentBundle/ElcodiCommentBundle.php
+++ b/src/Elcodi/Bundle/CommentBundle/ElcodiCommentBundle.php
@@ -59,8 +59,8 @@ class ElcodiCommentBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/CommentBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CommentBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\CommentBundle\ElcodiCommentBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\CommentBundle\ElcodiCommentBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/ConfigurationBundle/ElcodiConfigurationBundle.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/ElcodiConfigurationBundle.php
@@ -61,8 +61,8 @@ class ElcodiConfigurationBundle extends Bundle implements DependentBundleInterfa
     public static function getBundleDependencies()
     {
         return [
-            '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/CoreBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CoreBundle/Tests/Functional/app/AppKernel.php
@@ -35,10 +35,10 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/CoreBundle/Traits/BundleDependenciesResolver.php
+++ b/src/Elcodi/Bundle/CoreBundle/Traits/BundleDependenciesResolver.php
@@ -62,7 +62,7 @@ trait BundleDependenciesResolver
         foreach ($bundleNamespaces as $bundleNamespace) {
             $bundlesNamespacesStack[] = $bundleNamespace;
             $bundleNamespaceObj = new ReflectionClass($bundleNamespace);
-            if ($bundleNamespaceObj->implementsInterface('\Elcodi\Bundle\CoreBundle\Interfaces\DependentBundleInterface')) {
+            if ($bundleNamespaceObj->implementsInterface('Elcodi\Bundle\CoreBundle\Interfaces\DependentBundleInterface')) {
 
                 /**
                  * @var \Elcodi\Bundle\CoreBundle\Interfaces\DependentBundleInterface $bundleNamespace

--- a/src/Elcodi/Bundle/CouponBundle/ElcodiCouponBundle.php
+++ b/src/Elcodi/Bundle/CouponBundle/ElcodiCouponBundle.php
@@ -59,9 +59,9 @@ class ElcodiCouponBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
-            '\Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
+            'Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
@@ -79,17 +79,17 @@ class CouponFactoryTest extends WebTestCase
         $coupon = $this->get('elcodi.factory.coupon')->create();
 
         $this->assertInstanceOf(
-            '\Elcodi\Component\Currency\Entity\Money',
+            'Elcodi\Component\Currency\Entity\Money',
             $coupon->getPrice()
         );
 
         $this->assertInstanceOf(
-            '\Elcodi\Component\Currency\Entity\Money',
+            'Elcodi\Component\Currency\Entity\Money',
             $coupon->getAbsolutePrice()
         );
 
         $this->assertInstanceOf(
-            '\Elcodi\Component\Currency\Entity\Money',
+            'Elcodi\Component\Currency\Entity\Money',
             $coupon->getMinimumPurchase()
         );
     }

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\CouponBundle\ElcodiCouponBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\CouponBundle\ElcodiCouponBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/CurrencyBundle/ElcodiCurrencyBundle.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/ElcodiCurrencyBundle.php
@@ -59,8 +59,8 @@ class ElcodiCurrencyBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/CurrencyBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/ElcodiEntityTranslatorBundle.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/ElcodiEntityTranslatorBundle.php
@@ -59,9 +59,9 @@ class ElcodiEntityTranslatorBundle extends Bundle implements DependentBundleInte
     public static function getBundleDependencies()
     {
         return [
-            '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
-            '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
+            'Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/app/AppKernel.php
@@ -35,10 +35,10 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\EntityTranslatorBundle\ElcodiEntityTranslatorBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\EntityTranslatorBundle\ElcodiEntityTranslatorBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/ElcodiFixturesBoosterBundle.php
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/ElcodiFixturesBoosterBundle.php
@@ -47,7 +47,7 @@ class ElcodiFixturesBoosterBundle extends Bundle implements DependentBundleInter
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/GeoBundle/ElcodiGeoBundle.php
+++ b/src/Elcodi/Bundle/GeoBundle/ElcodiGeoBundle.php
@@ -59,7 +59,7 @@ class ElcodiGeoBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/GeoBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/GeoBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/LanguageBundle/ElcodiLanguageBundle.php
+++ b/src/Elcodi/Bundle/LanguageBundle/ElcodiLanguageBundle.php
@@ -59,7 +59,7 @@ class ElcodiLanguageBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/MediaBundle/ElcodiMediaBundle.php
+++ b/src/Elcodi/Bundle/MediaBundle/ElcodiMediaBundle.php
@@ -59,8 +59,8 @@ class ElcodiMediaBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
-            '\Knp\Bundle\GaufretteBundle\KnpGaufretteBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Knp\Bundle\GaufretteBundle\KnpGaufretteBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\MediaBundle\ElcodiMediaBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\MediaBundle\ElcodiMediaBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/MenuBundle/ElcodiMenuBundle.php
+++ b/src/Elcodi/Bundle/MenuBundle/ElcodiMenuBundle.php
@@ -59,8 +59,8 @@ class ElcodiMenuBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\MenuBundle\ElcodiMenuBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\MenuBundle\ElcodiMenuBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/MetricBundle/ElcodiMetricBundle.php
+++ b/src/Elcodi/Bundle/MetricBundle/ElcodiMetricBundle.php
@@ -59,7 +59,7 @@ class ElcodiMetricBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/NewsletterBundle/ElcodiNewsletterBundle.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/ElcodiNewsletterBundle.php
@@ -59,8 +59,8 @@ class ElcodiNewsletterBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\NewsletterBundle\ElcodiNewsletterBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\NewsletterBundle\ElcodiNewsletterBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/PageBundle/ElcodiPageBundle.php
+++ b/src/Elcodi/Bundle/PageBundle/ElcodiPageBundle.php
@@ -59,7 +59,7 @@ class ElcodiPageBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/PluginBundle/ElcodiPluginBundle.php
+++ b/src/Elcodi/Bundle/PluginBundle/ElcodiPluginBundle.php
@@ -61,7 +61,7 @@ class ElcodiPluginBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/ProductBundle/ElcodiProductBundle.php
+++ b/src/Elcodi/Bundle/ProductBundle/ElcodiProductBundle.php
@@ -59,13 +59,13 @@ class ElcodiProductBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
-            '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
-            '\Elcodi\Bundle\MediaBundle\ElcodiMediaBundle',
-            '\Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
-            '\Elcodi\Bundle\AttributeBundle\ElcodiAttributeBundle',
-            '\Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle',
+            'Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
+            'Elcodi\Bundle\MediaBundle\ElcodiMediaBundle',
+            'Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
+            'Elcodi\Bundle\AttributeBundle\ElcodiAttributeBundle',
+            'Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\ProductBundle\ElcodiProductBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\ProductBundle\ElcodiProductBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/RuleBundle/ElcodiRuleBundle.php
+++ b/src/Elcodi/Bundle/RuleBundle/ElcodiRuleBundle.php
@@ -69,7 +69,7 @@ class ElcodiRuleBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/RuleBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/RuleBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\RuleBundle\ElcodiRuleBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/ShippingBundle/ElcodiShippingBundle.php
+++ b/src/Elcodi/Bundle/ShippingBundle/ElcodiShippingBundle.php
@@ -59,12 +59,12 @@ class ElcodiShippingBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CartBundle\ElcodiCartBundle',
-            '\Elcodi\Bundle\TaxBundle\ElcodiTaxBundle',
-            '\Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
-            '\Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
-            '\Elcodi\Bundle\ZoneBundle\ElcodiZoneBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CartBundle\ElcodiCartBundle',
+            'Elcodi\Bundle\TaxBundle\ElcodiTaxBundle',
+            'Elcodi\Bundle\CurrencyBundle\ElcodiCurrencyBundle',
+            'Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
+            'Elcodi\Bundle\ZoneBundle\ElcodiZoneBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/ShippingBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\ShippingBundle\ElcodiShippingBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/SitemapBundle/ElcodiSitemapBundle.php
+++ b/src/Elcodi/Bundle/SitemapBundle/ElcodiSitemapBundle.php
@@ -47,7 +47,7 @@ class ElcodiSitemapBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/ElcodiStateTransitionMachineBundle.php
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/ElcodiStateTransitionMachineBundle.php
@@ -59,7 +59,7 @@ class ElcodiStateTransitionMachineBundle extends Bundle implements DependentBund
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/TaxBundle/ElcodiTaxBundle.php
+++ b/src/Elcodi/Bundle/TaxBundle/ElcodiTaxBundle.php
@@ -59,7 +59,7 @@ class ElcodiTaxBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/TaxBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/TaxBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\TaxBundle\ElcodiTaxBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\TaxBundle\ElcodiTaxBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/TemplateBundle/ElcodiTemplateBundle.php
+++ b/src/Elcodi/Bundle/TemplateBundle/ElcodiTemplateBundle.php
@@ -47,8 +47,8 @@ class ElcodiTemplateBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\ConfigurationBundle\ElcodiConfigurationBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/UserBundle/ElcodiUserBundle.php
+++ b/src/Elcodi/Bundle/UserBundle/ElcodiUserBundle.php
@@ -59,10 +59,10 @@ class ElcodiUserBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
-            '\Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
-            '\Elcodi\Bundle\CartBundle\ElcodiCartBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
+            'Elcodi\Bundle\LanguageBundle\ElcodiLanguageBundle',
+            'Elcodi\Bundle\CartBundle\ElcodiCartBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Elcodi/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
@@ -35,11 +35,11 @@ class AppKernel extends AbstractElcodiKernel
     public function registerBundles()
     {
         return $this->getBundleInstances([
-            '\Symfony\Bundle\FrameworkBundle\FrameworkBundle',
-            '\Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
-            '\Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
-            '\Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
-            '\Elcodi\Bundle\UserBundle\ElcodiUserBundle',
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle',
+            'Elcodi\Bundle\FixturesBoosterBundle\ElcodiFixturesBoosterBundle',
+            'Elcodi\Bundle\UserBundle\ElcodiUserBundle',
         ]);
     }
 

--- a/src/Elcodi/Bundle/ZoneBundle/ElcodiZoneBundle.php
+++ b/src/Elcodi/Bundle/ZoneBundle/ElcodiZoneBundle.php
@@ -59,8 +59,8 @@ class ElcodiZoneBundle extends Bundle implements DependentBundleInterface
     public static function getBundleDependencies()
     {
         return [
-            '\Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
-            '\Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
+            'Elcodi\Bundle\GeoBundle\ElcodiGeoBundle',
+            'Elcodi\Bundle\CoreBundle\ElcodiCoreBundle',
         ];
     }
 

--- a/src/Elcodi/Component/Core/Tests/UnitTest/Services/ManagerProviderTest.php
+++ b/src/Elcodi/Component/Core/Tests/UnitTest/Services/ManagerProviderTest.php
@@ -47,7 +47,7 @@ class ManagerProviderTest extends PHPUnit_Framework_TestCase
      *
      * Entity Namespace
      */
-    protected $entityNamespace = '\Elcodi\Entity\Namespace';
+    protected $entityNamespace = 'Elcodi\Entity\Namespace';
 
     /**
      * @var ObjectManager

--- a/src/Elcodi/Component/Currency/Tests/UnitTest/ValueObject/MoneyTest.php
+++ b/src/Elcodi/Component/Currency/Tests/UnitTest/ValueObject/MoneyTest.php
@@ -71,7 +71,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
 
         $twoHundredDollars = Money::create(200, $currencyMock);
 
-        $this->assertInstanceOf('\Elcodi\Component\Currency\Entity\Money', $twoHundredDollars);
+        $this->assertInstanceOf('Elcodi\Component\Currency\Entity\Money', $twoHundredDollars);
     }
 
     /**
@@ -80,7 +80,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     public function testGetCurrency()
     {
         $this->assertInstanceOf(
-            '\Elcodi\Component\Currency\Entity\Currency',
+            'Elcodi\Component\Currency\Entity\Currency',
             $this->oneHundredDollars->getCurrency()
         );
     }

--- a/src/Elcodi/Component/EntityTranslator/Tests/Services/TranslatorBuilderTest.php
+++ b/src/Elcodi/Component/EntityTranslator/Tests/Services/TranslatorBuilderTest.php
@@ -61,7 +61,7 @@ class TranslatorBuilderTest extends PHPUnit_Framework_TestCase
 
         );
         $translator = $translatorBuilder->compile();
-        $this->assertInstanceOf('\Elcodi\Component\EntityTranslator\Services\EntityTranslator', $translator);
+        $this->assertInstanceOf('Elcodi\Component\EntityTranslator\Services\EntityTranslator', $translator);
     }
 
     /**

--- a/src/Elcodi/Component/Media/Tests/UnitTest/Services/ImageManagerTest.php
+++ b/src/Elcodi/Component/Media/Tests/UnitTest/Services/ImageManagerTest.php
@@ -37,7 +37,7 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $mockImageFactory = $this
-            ->getMockBuilder('\Elcodi\Component\Media\Factory\ImageFactory')
+            ->getMockBuilder('Elcodi\Component\Media\Factory\ImageFactory')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -47,12 +47,12 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(new Image()));
 
         $mockFileManager = $this
-            ->getMockBuilder('\Elcodi\Component\Media\Services\FileManager')
+            ->getMockBuilder('Elcodi\Component\Media\Services\FileManager')
             ->disableOriginalConstructor()
             ->getMock();
 
         $mockResizeAdapter = $this->getMock(
-            '\Elcodi\Component\Media\Adapter\Resizer\Interfaces\ResizeAdapterInterface'
+            'Elcodi\Component\Media\Adapter\Resizer\Interfaces\ResizeAdapterInterface'
         );
 
         $imageManager = new ImageManager(
@@ -73,7 +73,7 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
     {
         $imageFile = new File($imagePath);
         $this->assertInstanceOf(
-            '\Elcodi\Component\Media\Entity\Interfaces\ImageInterface',
+            'Elcodi\Component\Media\Entity\Interfaces\ImageInterface',
             $this->imageManager->createImage($imageFile)
         );
     }
@@ -92,7 +92,7 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
         $image = $this->imageManager->createImage($imageFileObject);
 
         $this->assertInstanceOf(
-            '\Elcodi\Component\Media\Entity\Interfaces\ImageInterface',
+            'Elcodi\Component\Media\Entity\Interfaces\ImageInterface',
             $image
         );
         $this->assertEquals($finalMimeType, $image->getContentType());
@@ -150,7 +150,7 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
         $gifFilePath = $tmpDir . 'test.gif';
 
         $mockJpegOctet = $this
-            ->getMockBuilder('\Symfony\Component\HttpFoundation\File\File')
+            ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
             ->setConstructorArgs([$jpegFilePath])
             ->setMethods(['getMimeType'])
             ->getMock();
@@ -161,7 +161,7 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('application/octet-stream'));
 
         $mockPngOctet = $this
-            ->getMockBuilder('\Symfony\Component\HttpFoundation\File\File')
+            ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
             ->setConstructorArgs([$pngFilePath])
             ->setMethods(['getMimeType'])
             ->getMock();
@@ -172,7 +172,7 @@ class ImageManagerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('application/octet-stream'));
 
         $mockGifOctet = $this
-            ->getMockBuilder('\Symfony\Component\HttpFoundation\File\File')
+            ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
             ->setConstructorArgs([$gifFilePath])
             ->setMethods(['getMimeType'])
             ->getMock();


### PR DESCRIPTION
                   
|Q            |A  |
|---          |---|
|Bug Fix?     |no |
|New Feature? |no |
|BC Breaks?   |no |
|Deprecations?|no |
|Tests Pass?  |no |
|Fixed Tickets|new|
|License      |MIT|
                   

I think most of the php projects out there don't use the upfront backslash.  Usually one would copy paste from use statements which most likely don't have this backslash. This makes it easy and uniformize the project with this way.