### PR TITLE
Add events to menu generation

### DIFF
--- a/src/Elcodi/Bundle/MenuBundle/DependencyInjection/ElcodiMenuExtension.php
+++ b/src/Elcodi/Bundle/MenuBundle/DependencyInjection/ElcodiMenuExtension.php
@@ -107,6 +107,7 @@ class ElcodiMenuExtension extends AbstractExtension implements EntitiesOverridab
             'repositories',
             'objectManagers',
             'directors',
+            'eventListeners',
         ];
     }
 

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/eventListeners.yml
@@ -1,0 +1,11 @@
+services:
+
+    #
+    # Event Listeners
+    #
+    elcodi.event_listener.activate_menu_from_request:
+        class: Elcodi\Component\Menu\Listener\ActivateFromRequestListener
+        arguments:
+            - @request_stack
+        tags:
+            - { name: kernel.event_listener, event: menu.post_load }

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/eventListeners.yml
@@ -3,6 +3,11 @@ services:
     #
     # Event Listeners
     #
+    elcodi.event_listener.remove_disabled_menus:
+        class: Elcodi\Component\Menu\Listener\RemoveDisabledMenusListener
+        tags:
+            - { name: kernel.event_listener, event: menu.post_compilation }
+
     elcodi.event_listener.activate_menu_from_request:
         class: Elcodi\Component\Menu\Listener\ActivateFromRequestListener
         arguments:

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
@@ -9,5 +9,6 @@ services:
             - @elcodi.repository.menu
             - %elcodi.core.menu.cache_key%
         calls:
+            - [setEventDispatcher, [@event_dispatcher]]
             - [setCache, [@doctrine_cache.providers.elcodi_menus]]
             - [setEncoder, [@elcodi.json_encoder]]

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
@@ -7,8 +7,13 @@ services:
         class: Elcodi\Component\Menu\Services\MenuManager
         arguments:
             - @elcodi.repository.menu
+            - @elcodi.serializer.menu
             - %elcodi.core.menu.cache_key%
         calls:
             - [setEventDispatcher, [@event_dispatcher]]
             - [setCache, [@doctrine_cache.providers.elcodi_menus]]
             - [setEncoder, [@elcodi.json_encoder]]
+
+    elcodi.serializer.menu:
+        class: Elcodi\Component\Menu\Serializer\MenuArraySerializer
+        public: false

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuManagerTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuManagerTest.php
@@ -79,6 +79,7 @@ class MenuManagerTest extends WebTestCase
                     'name'       => 'vogue',
                     'code'       => 'vogue',
                     'url'        => null,
+                    'enabled'    => true,
                     'activeUrls' => [],
                     'subnodes'   => [
                         2 => [
@@ -86,6 +87,7 @@ class MenuManagerTest extends WebTestCase
                             'name'       => 'him',
                             'code'       => 'him',
                             'url'        => 'elcodi.dev/him',
+                            'enabled'    => true,
                             'subnodes'   => [],
                             'activeUrls' => [],
                         ],
@@ -94,6 +96,7 @@ class MenuManagerTest extends WebTestCase
                             'name'       => 'her',
                             'code'       => 'her',
                             'url'        => 'elcodi.dev/her',
+                            'enabled'    => true,
                             'subnodes'   => [],
                             'activeUrls' => [
                                 'her_products_list_route',
@@ -119,6 +122,7 @@ class MenuManagerTest extends WebTestCase
                     'name'       => 'him',
                     'code'       => 'him',
                     'url'        => 'elcodi.dev/him',
+                    'enabled'    => true,
                     'subnodes'   => [],
                     'activeUrls' => [],
                 ],
@@ -127,6 +131,7 @@ class MenuManagerTest extends WebTestCase
                     'name'       => 'her',
                     'code'       => 'her',
                     'url'        => 'elcodi.dev/her',
+                    'enabled'    => true,
                     'subnodes'   => [],
                     'activeUrls' => [
                         'her_products_list_route',

--- a/src/Elcodi/Component/Menu/ElcodiMenuEvents.php
+++ b/src/Elcodi/Component/Menu/ElcodiMenuEvents.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Menu;
+
+/**
+ * Class ElcodiMenuEvents
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+final class ElcodiMenuEvents
+{
+    /**
+     * This event is fired after compiling a menu.
+     * When the menu is get from cache, this event is not fired.
+     *
+     * event.name : menu.post_compilation
+     * event.class : MenuEvent
+     */
+    const POST_COMPILATION = 'menu.post_compilation';
+
+    /**
+     * This event is fired after loading a menu, even if it comes from cache.
+     *
+     * event.name : menu.post_load
+     * event.class : MenuEvent
+     */
+    const POST_LOAD = 'menu.post_load';
+}

--- a/src/Elcodi/Component/Menu/Event/MenuEvent.php
+++ b/src/Elcodi/Component/Menu/Event/MenuEvent.php
@@ -20,6 +20,9 @@ namespace Elcodi\Component\Menu\Event;
 use RuntimeException;
 use Symfony\Component\EventDispatcher\Event;
 
+use Elcodi\Component\Menu\Entity\Menu\Interfaces\NodeInterface;
+use Elcodi\Component\Menu\Serializer\Interfaces\MenuSerializerInterface as MenuSerializer;
+
 /**
  * Class MenuEvent
  *
@@ -47,17 +50,25 @@ class MenuEvent extends Event
      * Collection of filters to run
      */
     protected $filters = [];
+    /**
+     * @var MenuSerializer
+     *
+     *
+     */
+    private $serializer;
 
     /**
      * Constructor
      *
-     * @param string $menuName Menu name
-     * @param array  $menu     Menu settings
+     * @param string         $menuName   Menu name
+     * @param array          $menu       Menu settings
+     * @param MenuSerializer $serializer Menu serializer
      */
-    public function __construct($menuName, array $menu)
+    public function __construct($menuName, array $menu, MenuSerializer $serializer)
     {
         $this->menuName = $menuName;
         $this->menu = $menu;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -78,6 +89,20 @@ class MenuEvent extends Event
     public function getMenu()
     {
         return $this->menu;
+    }
+
+    /**
+     * Add a new node to the menu
+     *
+     * @param NodeInterface $node Menu node to add
+     *
+     * @return $this Self object
+     */
+    public function addNode(NodeInterface $node)
+    {
+        $this->menu[] = $this->serializer->serialize($node);
+
+        return $this;
     }
 
     /**

--- a/src/Elcodi/Component/Menu/Event/MenuEvent.php
+++ b/src/Elcodi/Component/Menu/Event/MenuEvent.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Menu\Event;
+
+use RuntimeException;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class MenuEvent
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class MenuEvent extends Event
+{
+    /**
+     * @var string
+     *
+     * Menu name
+     */
+    protected $menuName;
+
+    /**
+     * @var array
+     *
+     * Menu settings in an array
+     */
+    protected $menu;
+
+    /**
+     * @var callable[]
+     *
+     * Collection of filters to run
+     */
+    protected $filters = [];
+
+    /**
+     * Constructor
+     *
+     * @param string $menuName Menu name
+     * @param array  $menu     Menu settings
+     */
+    public function __construct($menuName, array $menu)
+    {
+        $this->menuName = $menuName;
+        $this->menu = $menu;
+    }
+
+    /**
+     * Return current menu name
+     *
+     * @return string
+     */
+    public function getMenuName()
+    {
+        return $this->menuName;
+    }
+
+    /**
+     * Return current settings of the menu
+     *
+     * @return array
+     */
+    public function getMenu()
+    {
+        return $this->menu;
+    }
+
+    /**
+     * Add a filter to process each node in the menu
+     *
+     * @param callable $callback
+     *
+     * @return $this Self object
+     */
+    public function addFilter(callable $callback)
+    {
+        $this->filters[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Visit each node in the menu with the filters and return the result.
+     *
+     * @return array
+     */
+    public function getResult()
+    {
+        if (count($this->filters) === 0) {
+
+            return $this->menu;
+        }
+
+        return $this->visitChildren($this->menu);
+    }
+
+    /**
+     * Visit each children node with filters
+     *
+     * @param array $children Children nodes
+     *
+     * @return array $children Filtered children nodes
+     */
+    protected function visitChildren(array $children)
+    {
+        $subnodes = [];
+        foreach ($children as $childName => $childNode) {
+
+            foreach ($this->filters as $filter) {
+
+                $childNode = $filter($childNode);
+                if ($childNode === false) {
+                    continue 2;
+                }
+
+                if (!is_array($childNode)) {
+
+                    throw new RuntimeException(sprintf(
+                        'Menu filters should return an array, but "%s" was found.',
+                        gettype($childNode)
+                    ));
+                }
+            }
+
+            if (count($childNode['subnodes']) > 0) {
+                $childNode['subnodes'] = $this->visitChildren($childNode['subnodes']);
+            }
+
+            $subnodes[$childName] = $childNode;
+        }
+
+        return $subnodes;
+    }
+}

--- a/src/Elcodi/Component/Menu/Listener/ActivateFromRequestListener.php
+++ b/src/Elcodi/Component/Menu/Listener/ActivateFromRequestListener.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Menu\Listener;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+use Elcodi\Component\Menu\Event\MenuEvent;
+
+/**
+ * Class ActivateFromRequestListener
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class ActivateFromRequestListener
+{
+    /**
+     * @var RequestStack
+     *
+     * Current request stack
+     */
+    protected $requestStack;
+
+    /**
+     * Constructor
+     *
+     * @param RequestStack $requestStack request stack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Mark menu entries as active if matches the current route.
+     * Also mark entries as expanded if any subnode is the current route.
+     *
+     * @param MenuEvent $event
+     */
+    public function onMenuPostLoad(MenuEvent $event)
+    {
+        $masterRequest = $this
+            ->requestStack
+            ->getMasterRequest();
+
+        if (!$masterRequest) {
+            return;
+        }
+
+        $currentRoute = $masterRequest->get('_route');
+
+        $event->addFilter(function (array $item) use ($currentRoute) {
+
+            if (in_array($currentRoute, $item['activeUrls'])) {
+                $item['active'] = true;
+            }
+
+            return $item;
+        });
+
+        $event->addFilter(function (array $item) use ($currentRoute) {
+
+            $item['expanded'] = false;
+            foreach ($item['subnodes'] as $subnode) {
+                if (in_array($currentRoute, $subnode['activeUrls'])) {
+                    $item['expanded'] = true;
+                }
+            }
+
+            return $item;
+        });
+    }
+}

--- a/src/Elcodi/Component/Menu/Listener/RemoveDisabledMenusListener.php
+++ b/src/Elcodi/Component/Menu/Listener/RemoveDisabledMenusListener.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Menu\Listener;
+
+use Elcodi\Component\Menu\Event\MenuEvent;
+
+/**
+ * Class RemoveDisabledMenusListener
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class RemoveDisabledMenusListener
+{
+    /**
+     * Mark menu entries as active if matches the current route.
+     * Also mark entries as expanded if any subnode is the current route.
+     *
+     * @param MenuEvent $event
+     */
+    public function onMenuPostCompilation(MenuEvent $event)
+    {
+        $event->addFilter(function (array $item) {
+
+            if ($item['enabled'] === false) {
+                return false;
+            }
+
+            return $item;
+        });
+    }
+}

--- a/src/Elcodi/Component/Menu/Serializer/Interfaces/MenuSerializerInterface.php
+++ b/src/Elcodi/Component/Menu/Serializer/Interfaces/MenuSerializerInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Menu\Serializer\Interfaces;
+
+use Elcodi\Component\Menu\Entity\Menu\Interfaces\NodeInterface;
+use Elcodi\Component\Menu\Entity\Menu\Interfaces\SubnodesAwareInterface;
+
+/**
+ * Interface MenuSerializerInterface
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+interface MenuSerializerInterface
+{
+    /**
+     * Serialize menu node
+     *
+     * @param NodeInterface $node Node
+     *
+     * @return mixed Serialized node
+     */
+    public function serialize(NodeInterface $node);
+
+    /**
+     * Given a node, serialize every child
+     *
+     * @param SubnodesAwareInterface $node Node
+     *
+     * @return array Serialized nodes
+     */
+    public function serializeSubnodes(SubnodesAwareInterface $node);
+}

--- a/src/Elcodi/Component/Menu/Serializer/MenuArraySerializer.php
+++ b/src/Elcodi/Component/Menu/Serializer/MenuArraySerializer.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Menu\Serializer;
+
+use Elcodi\Component\Menu\Entity\Menu\Interfaces\NodeInterface;
+use Elcodi\Component\Menu\Entity\Menu\Interfaces\SubnodesAwareInterface;
+use Elcodi\Component\Menu\Serializer\Interfaces\MenuSerializerInterface;
+
+/**
+ * Class MenuArraySerializer
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class MenuArraySerializer implements MenuSerializerInterface
+{
+    /**
+     * Serialize menu node
+     *
+     * @param NodeInterface $node Node
+     *
+     * @return mixed Serialized node
+     */
+    public function serialize(NodeInterface $node)
+    {
+        return [
+            'id'         => $node->getId(),
+            'name'       => $node->getName(),
+            'code'       => $node->getCode(),
+            'url'        => $node->getUrl(),
+            'activeUrls' => $node->getActiveUrls(),
+            'subnodes'   => $this->serializeSubnodes($node),
+        ];
+    }
+
+    /**
+     * Given a node, serialize every child
+     *
+     * @param SubnodesAwareInterface $node Node
+     *
+     * @return array Serialized nodes
+     */
+    public function serializeSubnodes(SubnodesAwareInterface $node)
+    {
+        $subnodes = [];
+        foreach ($node->getSubnodes() as $node) {
+            $subnodeId = $node->getId();
+            $subnodes[$subnodeId] = $this->serialize($node);
+        }
+
+        return $subnodes;
+    }
+}

--- a/src/Elcodi/Component/Menu/Serializer/MenuArraySerializer.php
+++ b/src/Elcodi/Component/Menu/Serializer/MenuArraySerializer.php
@@ -42,6 +42,7 @@ class MenuArraySerializer implements MenuSerializerInterface
             'name'       => $node->getName(),
             'code'       => $node->getCode(),
             'url'        => $node->getUrl(),
+            'enabled'    => $node->isEnabled(),
             'activeUrls' => $node->getActiveUrls(),
             'subnodes'   => $this->serializeSubnodes($node),
         ];

--- a/src/Elcodi/Component/Menu/Services/MenuManager.php
+++ b/src/Elcodi/Component/Menu/Services/MenuManager.php
@@ -256,6 +256,10 @@ class MenuManager extends AbstractCacheWrapper
      */
     protected function dispatchMenuEvent($eventName, $menuCode, array $menu)
     {
+        if (null === $this->dispatcher) {
+            return $menu;
+        }
+
         $event = new MenuEvent($menuCode, $menu, $this->serializer);
         $this
             ->dispatcher

--- a/src/Elcodi/Component/Menu/Services/MenuManager.php
+++ b/src/Elcodi/Component/Menu/Services/MenuManager.php
@@ -205,6 +205,10 @@ class MenuManager extends AbstractCacheWrapper
 
         $node
             ->getSubnodes()
+            ->filter(function (NodeInterface $node) {
+
+                return $node->isEnabled();
+            })
             ->map(function (NodeInterface $node) use (&$subnodes) {
 
                 $subnodeId = $node->getId();

--- a/src/Elcodi/Component/Menu/Tests/UnitTest/Services/MenuManagerTest.php
+++ b/src/Elcodi/Component/Menu/Tests/UnitTest/Services/MenuManagerTest.php
@@ -117,9 +117,11 @@ class MenuManagerTest extends PHPUnit_Framework_TestCase
         $menuName = 'admin';
         $keyName = 'menus-admin';
 
-        $menu = $this->getMockForAbstractClass(
+        $menuProphecy = $this->prophesize(
             'Elcodi\Component\Menu\Entity\Menu\Interfaces\MenuInterface'
         );
+
+        $menu = $menuProphecy->reveal();
 
         $expected = [
             'id'         => 1,


### PR DESCRIPTION
Dispatch events on menu generation to allow listeners to filter and add new entries.

Fixes https://github.com/elcodi/elcodi/issues/711

Two events are dispatched:
- `menu.post_compilation`: This runs only before caching the result.
- `menu.post_load`: This runs always, before returning the final result, cached or not.

Add some listeners:
- `RemoveDisabledMenusListener`: remove disabled entries after caching.
- `ActivateFromRequestListener`: activate and expand entries based on current url.
