### PR TITLE
[Plugin] Twig extension for plugin settings

### DIFF
--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
@@ -3,6 +3,13 @@ services:
     #
     # Twig extensions
     #
+    elcodi.twig_extension.plugin:
+        class: Elcodi\Component\Plugin\Twig\PluginExtension
+        arguments:
+            - @elcodi.plugin_manager
+        tags:
+            - { name: twig.extension }
+
     elcodi.twig_extension.plugin_hook:
         class: Elcodi\Component\Plugin\Twig\HookExtension
         arguments:

--- a/src/Elcodi/Component/Plugin/Twig/PluginExtension.php
+++ b/src/Elcodi/Component/Plugin/Twig/PluginExtension.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Plugin\Twig;
+
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+use Elcodi\Component\Plugin\Services\PluginManager;
+
+/**
+ * Class PluginExtension for Twig
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class PluginExtension extends Twig_Extension
+{
+    /**
+     * Plugin manager
+     *
+     * @var PluginManager
+     */
+    protected $pluginManager;
+
+    /**
+     * Constructor
+     *
+     * @param PluginManager $pluginManager Plugin manager
+     */
+    public function __construct(PluginManager $pluginManager)
+    {
+        $this->pluginManager = $pluginManager;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return [
+            new Twig_SimpleFunction(
+                'elcodi_plugin',
+                function ($namespace) {
+
+                    if (
+                        !$this
+                            ->pluginManager
+                            ->hasPlugin($namespace)
+                    ) {
+                        return false;
+                    }
+
+                    return $this
+                        ->pluginManager
+                        ->getPlugin($namespace);
+                }
+            ),
+        ];
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'plugin_extension';
+    }
+}


### PR DESCRIPTION
Extends twig with a `elcodi_plugin` function.
The only parameter is the namespace of the plugin bundle.
As the bundle has `\` in the name, be sure to double space them `\\`.
Return FALSE if the plugin does not exist, otherwise, the plugin settings.

Example:

```twig

{% set plugin = elcodi_plugin('Elcodi\\Plugin\\GoogleAnalyticsBundle') %}

{% if plugin && plugin.enabled %}
    {{ plugin.configuration.twitter_account }}
{% endif %}
```