### PR TITLE
Added back overridable host in image url routes

### DIFF
--- a/src/Elcodi/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -45,22 +45,16 @@ class Configuration extends AbstractConfiguration
                         ))
                     ->end()
                 ->end()
+
                 ->scalarNode('filesystem')
                     ->defaultValue('gaufrette.local_filesystem')
                 ->end()
                 ->arrayNode('images')
                     ->addDefaultsIfNotSet()
                     ->children()
-
-                        ->arrayNode('domain_sharding')
-                            ->canBeEnabled()
-                            ->children()
-                                ->arrayNode('base_urls')
-                                    ->prototype('scalar')->end()
-                                ->end()
-                            ->end()
+                        ->scalarNode('generated_route_host')
+                            ->defaultValue('')
                         ->end()
-
                         ->arrayNode('view')
                             ->addDefaultsIfNotSet()
                             ->children()
@@ -122,6 +116,7 @@ class Configuration extends AbstractConfiguration
                             ->end()
                         ->end()
                     ->end()
+
                 ->end()
             ->end();
     }

--- a/src/Elcodi/Bundle/MediaBundle/DependencyInjection/ElcodiMediaExtension.php
+++ b/src/Elcodi/Bundle/MediaBundle/DependencyInjection/ElcodiMediaExtension.php
@@ -113,8 +113,7 @@ class ElcodiMediaExtension extends AbstractExtension implements EntitiesOverrida
 
             'elcodi.core.media.filesystem'                             => $config['filesystem'],
 
-            'elcodi.core.media.images.domain_sharding.enabled'         => $config['images']['domain_sharding']['enabled'],
-            'elcodi.core.media.images.domain_sharding.base_urls'       => $config['images']['domain_sharding']['base_urls'],
+            'elcodi.core.media.generated_route_host'                   => $config['images']['generated_route_host'],
 
             'elcodi.core.media.image_view_controller_route_name'       => $config['images']['view']['controller_route_name'],
             'elcodi.core.media.image_view_controller_route'            => $config['images']['view']['controller_route'],

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
@@ -9,5 +9,6 @@ services:
             - @router
             - %elcodi.core.media.image_resize_controller_route_name%
             - %elcodi.core.media.image_view_controller_route_name%
+            - %elcodi.core.media.generated_route_host%
         tags:
             - { name: twig.extension }


### PR DESCRIPTION
PR #700 removed pseudo-randomization of static url (to me more exact, the **host** part of them) for media routes, such as resizing and viewing images.
Although it correctly removed the "sharding" of the hostnames, it also removed *entirely* the possibility to override the host in generated image-resize URLs, which is critical when working with CDNs. For example: mapping `http://www.elcodi.com/images/2536` to `http://cdn.elcodi.com/images/2536`

This PR adds back this feature, and also removes what's left of the *old* pseudo-random configuration