### PR TITLE
ShippingRange should satisfy by empty address

### DIFF
--- a/src/Elcodi/Component/Shipping/Provider/ShippingRangeProvider.php
+++ b/src/Elcodi/Component/Shipping/Provider/ShippingRangeProvider.php
@@ -251,6 +251,7 @@ class ShippingRangeProvider
         $deliveryAddress = $cart->getDeliveryAddress();
 
         return
+            $deliveryAddress === null ||
             $this
                 ->zoneMatcher
                 ->isAddressContainedInZone(


### PR DESCRIPTION
If no delivery address is provided, every shipping range should be elegible.