### PR TITLE
Product category event listeners

### DIFF
--- a/src/Elcodi/Bundle/ProductBundle/DependencyInjection/ElcodiProductExtension.php
+++ b/src/Elcodi/Bundle/ProductBundle/DependencyInjection/ElcodiProductExtension.php
@@ -119,6 +119,7 @@ class ElcodiProductExtension extends AbstractExtension implements EntitiesOverri
             'objectManagers',
             'twig',
             'directors',
+            'eventListeners',
         ];
     }
 

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/eventListeners.yml
@@ -1,0 +1,16 @@
+services:
+
+    #
+    # Event Listeners
+    #
+    elcodi.event_listener.product_belongs_category:
+        class: Elcodi\Component\Product\EventListener\ProductBelongsPrincipalCategoryEventListener
+        tags:
+            - { name: doctrine.event_listener, event: preFlush, method: preFlush }
+
+    elcodi.event_listener.principal_category:
+        class: Elcodi\Component\Product\EventListener\ProductPrincipalCategoryEventListener
+        tags:
+            - { name: doctrine.event_listener, event: preFlush, method: preFlush }
+
+

--- a/src/Elcodi/Component/Product/EventListener/ProductBelongsPrincipalCategoryEventListener.php
+++ b/src/Elcodi/Component/Product/EventListener/ProductBelongsPrincipalCategoryEventListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Elcodi\Component\Product\EventListener;
+
+use Doctrine\ORM\Event\PreFlushEventArgs;
+use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
+
+/**
+ * Class ProductBelongsPrincipalCategoryEventListener
+ */
+class ProductBelongsPrincipalCategoryEventListener
+{
+    /**
+     * Before the flush we check that in case the product has a principal
+     * category, this product also belongs to this category
+     *
+     * @param PreFlushEventArgs $args The pre flush event arguments.
+     */
+    public function preFlush(PreFlushEventArgs $args)
+    {
+        $entityManager       = $args->getEntityManager();
+        $scheduledInsertions = $entityManager->getUnitOfWork()->getScheduledEntityInsertions();
+
+        foreach ($scheduledInsertions as $entity) {
+            if (
+                $entity instanceof ProductInterface
+            ) {
+                $principalCategory = $entity->getPrincipalCategory();
+                $categories        = $entity->getCategories();
+
+                if (
+                    !empty($principalCategory) &&
+                    !$categories->contains($principalCategory)
+                ) {
+                    $categories->add($principalCategory);
+                    $entity->setCategories($categories);
+                }
+            }
+        }
+    }
+}

--- a/src/Elcodi/Component/Product/EventListener/ProductPrincipalCategoryEventListener.php
+++ b/src/Elcodi/Component/Product/EventListener/ProductPrincipalCategoryEventListener.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Elcodi\Component\Product\EventListener;
+
+use Doctrine\ORM\Event\PreFlushEventArgs;
+use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
+
+/**
+ * Class ProductPrincipalCategoryEventListener
+ */
+class ProductPrincipalCategoryEventListener
+{
+    /**
+     * Before the flush we check that in case the product has any category at
+     * least has a principal category
+     *
+     * @param PreFlushEventArgs $args The pre flush event arguments.
+     */
+    public function preFlush(PreFlushEventArgs $args)
+    {
+        $entityManager       = $args->getEntityManager();
+        $scheduledInsertions = $entityManager->getUnitOfWork()->getScheduledEntityInsertions();
+
+        foreach ($scheduledInsertions as $entity) {
+            if (
+                $entity instanceof ProductInterface &&
+                !$entity->getPrincipalCategory()
+            ) {
+                $categories = $entity->getCategories();
+
+                if (0 < $categories->count()) {
+                    $entity->setPrincipalCategory($categories->first());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- When a new product is saved with "principal category" but the category does not has this product assigned it gets automatically assigned
- When a product is saved with a category assigned but does not have "principal category" the first category is assigned as "principal category"