### PR TITLE
Autologin on registration

### DIFF
--- a/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
@@ -15,10 +15,8 @@ services:
         class: Elcodi\Component\User\Services\CustomerManager
         arguments:
             - @elcodi.event_dispatcher.user
-            - @?security.context
 
     elcodi.manager.admin_user:
         class: Elcodi\Component\User\Services\AdminUserManager
         arguments:
             - @elcodi.event_dispatcher.user
-            - @?security.context

--- a/src/Elcodi/Component/User/EventListener/AutologinOnRegisterEventListener.php
+++ b/src/Elcodi/Component/User/EventListener/AutologinOnRegisterEventListener.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\User\EventListener;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+use Elcodi\Component\User\Event\UserRegisterEvent;
+
+/**
+ * Class AutologinOnRegisterEventListener
+ */
+class AutologinOnRegisterEventListener
+{
+    /**
+     * @var RequestStack
+     *
+     * Request stack
+     */
+    private $requestStack;
+
+    /**
+     * @var TokenStorageInterface
+     *
+     * Token storage
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var EventDispatcherInterface
+     *
+     * Event dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * @var string
+     *
+     * Provider key
+     */
+    protected $providerKey;
+
+    /**
+     * Constructor
+     *
+     * @param RequestStack             $requestStack Request stack
+     * @param TokenStorageInterface    $tokenStorage Token storage
+     * @param EventDispatcherInterface $dispatcher   Event dispatcher
+     * @param string                   $providerKey  Provider key
+     */
+    public function __construct(
+        RequestStack $requestStack,
+        TokenStorageInterface $tokenStorage,
+        EventDispatcherInterface $dispatcher,
+        $providerKey
+    ) {
+        $this->requestStack = $requestStack;
+        $this->tokenStorage = $tokenStorage;
+        $this->providerKey = $providerKey;
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * Autologin users after registration
+     *
+     * @param UserRegisterEvent $event User registered event
+     */
+    public function onUserRegister(UserRegisterEvent $event)
+    {
+        if (null === $this->tokenStorage->getToken()) {
+            return;
+        }
+
+        $user = $event->getUser();
+
+        $token = new UsernamePasswordToken(
+            $user,
+            null,
+            $this->providerKey,
+            $user->getRoles()
+        );
+
+        $this
+            ->tokenStorage
+            ->setToken($token);
+
+        $event = new InteractiveLoginEvent(
+            $this->requestStack->getMasterRequest(),
+            $token
+        );
+
+        $this
+            ->dispatcher
+            ->dispatch(
+                SecurityEvents::INTERACTIVE_LOGIN,
+                $event
+            );
+    }
+}

--- a/src/Elcodi/Component/User/Services/Abstracts/AbstractUserManager.php
+++ b/src/Elcodi/Component/User/Services/Abstracts/AbstractUserManager.php
@@ -17,9 +17,6 @@
 
 namespace Elcodi\Component\User\Services\Abstracts;
 
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-
 use Elcodi\Component\User\Entity\Interfaces\AbstractUserInterface;
 use Elcodi\Component\User\EventDispatcher\Interfaces\UserEventDispatcherInterface;
 
@@ -36,52 +33,25 @@ abstract class AbstractUserManager
     protected $userEventDispatcher;
 
     /**
-     * @var TokenStorageInterface
-     *
-     * Token storage
-     */
-    protected $tokenStorage;
-
-    /**
      * Construct method
      *
      * @param UserEventDispatcherInterface $userEventDispatcher User Event dispatcher
-     * @param TokenStorageInterface        $securityContext     Token storage
      */
-    public function __construct(
-        UserEventDispatcherInterface $userEventDispatcher,
-        TokenStorageInterface $securityContext = null
-    ) {
+    public function __construct(UserEventDispatcherInterface $userEventDispatcher)
+    {
         $this->userEventDispatcher = $userEventDispatcher;
-        $this->tokenStorage = $securityContext;
     }
 
     /**
      * Register new User into the web.
      * Creates new token given a user, with related Role set.
      *
-     * @param AbstractUserInterface $user        User to register
-     * @param string                $providerKey Provider key
+     * @param AbstractUserInterface $user User to register
      *
      * @return $this Self object
      */
-    public function register(AbstractUserInterface $user, $providerKey)
+    public function register(AbstractUserInterface $user)
     {
-        if (!($this->tokenStorage instanceof TokenStorageInterface)) {
-            return $this;
-        }
-
-        $token = new UsernamePasswordToken(
-            $user,
-            null,
-            $providerKey,
-            $user->getRoles()
-        );
-
-        $this
-            ->tokenStorage
-            ->setToken($token);
-
         $this
             ->userEventDispatcher
             ->dispatchOnUserRegisteredEvent($user);

--- a/src/Elcodi/Component/User/Services/AdminUserManager.php
+++ b/src/Elcodi/Component/User/Services/AdminUserManager.php
@@ -30,14 +30,14 @@ class AdminUserManager extends AbstractUserManager
      * Register new User into the web.
      * Creates new token given a user, with related Role set.
      *
-     * @param AbstractUserInterface $user        User to register
-     * @param string                $providerKey Provider key
-     *
+     * @param AbstractUserInterface $user User to register
      * @return $this Self object
+     * @internal param string $providerKey Provider key
+     *
      */
-    public function register(AbstractUserInterface $user, $providerKey)
+    public function register(AbstractUserInterface $user)
     {
-        parent::register($user, $providerKey);
+        parent::register($user);
 
         /**
          * @var AdminUserInterface $user

--- a/src/Elcodi/Component/User/Services/CustomerManager.php
+++ b/src/Elcodi/Component/User/Services/CustomerManager.php
@@ -30,14 +30,13 @@ class CustomerManager extends AbstractUserManager
      * Register new User into the web.
      * Creates new token given a user, with related Role set.
      *
-     * @param AbstractUserInterface $user        User to register
-     * @param string                $providerKey Provider key
+     * @param AbstractUserInterface $user User to register
      *
      * @return $this Self object
      */
-    public function register(AbstractUserInterface $user, $providerKey)
+    public function register(AbstractUserInterface $user)
     {
-        parent::register($user, $providerKey);
+        parent::register($user);
 
         /**
          * @var CustomerInterface $user


### PR DESCRIPTION
- Extract autologin after registration to an isolated listener.
- Dispatch missing `SecurityEvents::INTERACTIVE_LOGIN` after autologin.

Fixes https://github.com/elcodi/elcodi/issues/786