### PR TITLE
Fix of order factory when an empty coupon

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/factories.yml
@@ -21,6 +21,7 @@ services:
         arguments:
             - @elcodi.order_payment_states_machine_manager
             - @elcodi.order_shipping_states_machine_manager
+            - @elcodi.wrapper.currency
         calls:
             - [setEntityNamespace, ["%elcodi.entity.order.class%"]]
             - [setDateTimeFactory, ["@elcodi.factory.datetime"]]

--- a/src/Elcodi/Component/Cart/Factory/OrderFactory.php
+++ b/src/Elcodi/Component/Cart/Factory/OrderFactory.php
@@ -20,6 +20,8 @@ namespace Elcodi\Component\Cart\Factory;
 use Doctrine\Common\Collections\ArrayCollection;
 
 use Elcodi\Component\Cart\Entity\Order;
+use Elcodi\Component\Currency\Entity\Money;
+use Elcodi\Component\Currency\Wrapper\CurrencyWrapper;
 use Elcodi\Component\Core\Factory\Abstracts\AbstractFactory;
 use Elcodi\Component\StateTransitionMachine\Entity\StateLineStack;
 use Elcodi\Component\StateTransitionMachine\Machine\MachineManager;
@@ -44,17 +46,25 @@ class OrderFactory extends AbstractFactory
     protected $shippingMachineManager;
 
     /**
+     * @var CurrencyWrapper
+     */
+    private $currencyWrapper;
+
+    /**
      * Construct method
      *
      * @param MachineManager $paymentMachineManager  Machine Manager for Payment
      * @param MachineManager $shippingMachineManager Machine Manager for Shipping
+     * @param CurrencyWrapper $currencyWrapper
      */
     public function __construct(
         MachineManager $paymentMachineManager,
-        MachineManager $shippingMachineManager
+        MachineManager $shippingMachineManager,
+        CurrencyWrapper $currencyWrapper
     ) {
         $this->paymentMachineManager = $paymentMachineManager;
         $this->shippingMachineManager = $shippingMachineManager;
+        $this->currencyWrapper = $currencyWrapper;;
     }
 
     /**
@@ -77,7 +87,15 @@ class OrderFactory extends AbstractFactory
             ->setHeight(0)
             ->setWidth(0)
             ->setWeight(0)
-            ->setCreatedAt($this->now());
+            ->setCreatedAt($this->now())
+            ->setCouponAmount(
+                Money::create(
+                    0,
+                    $this
+                        ->currencyWrapper
+                        ->loadCurrency()
+                )
+            );
 
         $paymentStateLineStack = $this
             ->paymentMachineManager


### PR DESCRIPTION
This PR is a fix of order factory when a new empty order is created. Error appears when load an order in admin and this order hasn't a coupon. 

Order entity has a field couponAmount, and method getCouponAmount returns a Money object. To create this object we need an amount and a currency, and currency must be a CurrencyInterface object. If database field of currency is null Currency can be initialized and Money object is wrong.

I saw this error when I did a paypal purchase. Coupon field of database is filled in an event that is dispatched when payment is done, but if admin want to view this order in administration and paypal payment is not finished an error is showed.

To fix this I create an empty coupon when an order is returned. Any other proposal is welcome :)

Thanks.