### PR TITLE
Fixed order factory when empty coupon

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/factories.yml
@@ -21,6 +21,7 @@ services:
         arguments:
             - @elcodi.order_payment_states_machine_manager
             - @elcodi.order_shipping_states_machine_manager
+            - @elcodi.wrapper.default_currency
         calls:
             - [setEntityNamespace, ["%elcodi.entity.order.class%"]]
             - [setDateTimeFactory, ["@elcodi.factory.datetime"]]

--- a/src/Elcodi/Component/Cart/Factory/OrderFactory.php
+++ b/src/Elcodi/Component/Cart/Factory/OrderFactory.php
@@ -20,7 +20,10 @@ namespace Elcodi\Component\Cart\Factory;
 use Doctrine\Common\Collections\ArrayCollection;
 
 use Elcodi\Component\Cart\Entity\Order;
+use Elcodi\Component\Currency\Entity\Money;
+use Elcodi\Component\Currency\Wrapper\CurrencyWrapper;
 use Elcodi\Component\Core\Factory\Abstracts\AbstractFactory;
+use Elcodi\Component\Currency\Wrapper\DefaultCurrencyWrapper;
 use Elcodi\Component\StateTransitionMachine\Entity\StateLineStack;
 use Elcodi\Component\StateTransitionMachine\Machine\MachineManager;
 
@@ -44,17 +47,25 @@ class OrderFactory extends AbstractFactory
     protected $shippingMachineManager;
 
     /**
+     * @var DefaultCurrencyWrapper
+     */
+    private $defaultCurrencyWrapper;
+
+    /**
      * Construct method
      *
-     * @param MachineManager $paymentMachineManager  Machine Manager for Payment
+     * @param MachineManager $paymentMachineManager Machine Manager for Payment
      * @param MachineManager $shippingMachineManager Machine Manager for Shipping
+     * @param DefaultCurrencyWrapper $defaultCurrencyWrapper
      */
     public function __construct(
         MachineManager $paymentMachineManager,
-        MachineManager $shippingMachineManager
+        MachineManager $shippingMachineManager,
+        DefaultCurrencyWrapper $defaultCurrencyWrapper
     ) {
         $this->paymentMachineManager = $paymentMachineManager;
         $this->shippingMachineManager = $shippingMachineManager;
+        $this->defaultCurrencyWrapper = $defaultCurrencyWrapper;
     }
 
     /**
@@ -77,7 +88,15 @@ class OrderFactory extends AbstractFactory
             ->setHeight(0)
             ->setWidth(0)
             ->setWeight(0)
-            ->setCreatedAt($this->now());
+            ->setCreatedAt($this->now())
+            ->setCouponAmount(
+                Money::create(
+                    0,
+                    $this
+                        ->defaultCurrencyWrapper
+                        ->get()
+                )
+            );
 
         $paymentStateLineStack = $this
             ->paymentMachineManager


### PR DESCRIPTION
This PR is a fix of order factory when a new empty order is created. Error appears when load an order in admin and this order hasn't a coupon.

Order entity has a field couponAmount, and method getCouponAmount returns a Money object. To create this object we need an amount and a currency, and currency must be a CurrencyInterface object. If database field of currency is null Currency can be initialized and Money object is wrong.

I saw this error when I did a paypal purchase. Coupon field of database is filled in an event that is dispatched when payment is done, but if admin want to view this order in administration and paypal payment is not finished an error is showed.

To fix it I have created an empty coupon when an empty order is created. Another proposal is welcome :)

Thanks.