### PR TITLE
Replace elcodi:~0.5.0 to elcodi:self.version

### DIFF
--- a/src/Elcodi/Bundle/AttributeBundle/composer.json
+++ b/src/Elcodi/Bundle/AttributeBundle/composer.json
@@ -40,12 +40,12 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/attribute": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/attribute": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/BannerBundle/composer.json
+++ b/src/Elcodi/Bundle/BannerBundle/composer.json
@@ -40,14 +40,14 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/language-bundle": "~0.5.0",
-        "elcodi/media-bundle": "~0.5.0",
-        "elcodi/banner": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/media-bundle": "self.version",
+        "elcodi/banner": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CartBundle/composer.json
+++ b/src/Elcodi/Bundle/CartBundle/composer.json
@@ -40,17 +40,17 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/user-bundle": "~0.5.0",
-        "elcodi/product-bundle": "~0.5.0",
-        "elcodi/currency-bundle": "~0.5.0",
-        "elcodi/state-transition-machine-bundle": "~0.5.0",
-        "elcodi/shipping-bundle": "~0.5.0",
-        "elcodi/cart": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/user-bundle": "self.version",
+        "elcodi/product-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/state-transition-machine-bundle": "self.version",
+        "elcodi/shipping-bundle": "self.version",
+        "elcodi/cart": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CartCouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CartCouponBundle/composer.json
@@ -41,15 +41,15 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/cart-bundle": "~0.5.0",
-        "elcodi/coupon-bundle": "~0.5.0",
-        "elcodi/rule-bundle": "~0.5.0",
-        "elcodi/cart-coupon": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/cart-bundle": "self.version",
+        "elcodi/coupon-bundle": "self.version",
+        "elcodi/rule-bundle": "self.version",
+        "elcodi/cart-coupon": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CommentBundle/composer.json
+++ b/src/Elcodi/Bundle/CommentBundle/composer.json
@@ -41,12 +41,12 @@
         "mmoreram/simple-doctrine-mapping": "~1.0",
         "doctrine/doctrine-cache-bundle": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/comment": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/comment": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/ConfigurationBundle/composer.json
+++ b/src/Elcodi/Bundle/ConfigurationBundle/composer.json
@@ -41,13 +41,13 @@
         "mmoreram/simple-doctrine-mapping": "~1.0",
         "doctrine/doctrine-cache-bundle": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/configuration": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/configuration": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
         "symfony/expression-language": "~2.6",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CoreBundle/composer.json
+++ b/src/Elcodi/Bundle/CoreBundle/composer.json
@@ -43,11 +43,11 @@
         "symfony/yaml": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core": "~0.5.0"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CouponBundle/composer.json
@@ -40,14 +40,14 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/currency-bundle": "~0.5.0",
-        "elcodi/rule-bundle": "~0.5.0",
-        "elcodi/coupon": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/rule-bundle": "self.version",
+        "elcodi/coupon": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CurrencyBundle/composer.json
+++ b/src/Elcodi/Bundle/CurrencyBundle/composer.json
@@ -47,13 +47,13 @@
         "ocramius/proxy-manager": "~1.0",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/language-bundle": "~0.5.0",
-        "elcodi/currency": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/currency": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
@@ -41,13 +41,13 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/entity-translator": "~0.5.0",
-        "elcodi/language-bundle": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/entity-translator": "self.version",
+        "elcodi/language-bundle": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/composer.json
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/composer.json
@@ -38,7 +38,7 @@
 
         "doctrine/doctrine-fixtures-bundle": "~2.2",
 
-        "elcodi/core-bundle": "~0.5.0"
+        "elcodi/core-bundle": "self.version"
     },
     "autoload": {
         "psr-4": {

--- a/src/Elcodi/Bundle/GeoBundle/composer.json
+++ b/src/Elcodi/Bundle/GeoBundle/composer.json
@@ -43,12 +43,12 @@
 
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/geo": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/geo": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/LanguageBundle/composer.json
+++ b/src/Elcodi/Bundle/LanguageBundle/composer.json
@@ -40,12 +40,12 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/language": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/MediaBundle/composer.json
+++ b/src/Elcodi/Bundle/MediaBundle/composer.json
@@ -43,12 +43,12 @@
         "knplabs/knp-gaufrette-bundle": "~0.1",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/media": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/media": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/MenuBundle/composer.json
+++ b/src/Elcodi/Bundle/MenuBundle/composer.json
@@ -42,12 +42,12 @@
         "symfony/twig-bundle": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/menu": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/menu": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/MetricBundle/composer.json
+++ b/src/Elcodi/Bundle/MetricBundle/composer.json
@@ -41,12 +41,12 @@
         "mmoreram/simple-doctrine-mapping": "~1.0",
         "snc/redis-bundle": "~1.1, >=1.1.8",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/metric": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/metric": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/NewsletterBundle/composer.json
+++ b/src/Elcodi/Bundle/NewsletterBundle/composer.json
@@ -40,13 +40,13 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/language-bundle": "~0.5.0",
-        "elcodi/newsletter": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/newsletter": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/PageBundle/composer.json
+++ b/src/Elcodi/Bundle/PageBundle/composer.json
@@ -40,12 +40,12 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/page": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/page": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/PluginBundle/composer.json
+++ b/src/Elcodi/Bundle/PluginBundle/composer.json
@@ -27,8 +27,8 @@
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/plugin": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/plugin": "self.version"
     },
     "autoload": {
         "psr-4": {

--- a/src/Elcodi/Bundle/ProductBundle/composer.json
+++ b/src/Elcodi/Bundle/ProductBundle/composer.json
@@ -43,17 +43,17 @@
         "mmoreram/simple-doctrine-mapping": "~1.0",
         "doctrine/doctrine-cache-bundle": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/language-bundle": "~0.5.0",
-        "elcodi/media-bundle": "~0.5.0",
-        "elcodi/currency-bundle": "~0.5.0",
-        "elcodi/attribute-bundle": "~0.5.0",
-        "elcodi/configuration-bundle": "~0.5.0",
-        "elcodi/product": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/media-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/attribute-bundle": "self.version",
+        "elcodi/configuration-bundle": "self.version",
+        "elcodi/product": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/RuleBundle/composer.json
+++ b/src/Elcodi/Bundle/RuleBundle/composer.json
@@ -41,12 +41,12 @@
         "symfony/expression-language": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/rule": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/rule": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/ShippingBundle/composer.json
+++ b/src/Elcodi/Bundle/ShippingBundle/composer.json
@@ -40,17 +40,17 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/tax-bundle": "~0.5.0",
-        "elcodi/currency-bundle": "~0.5.0",
-        "elcodi/cart-bundle": "~0.5.0",
-        "elcodi/geo-bundle": "~0.5.0",
-        "elcodi/zone-bundle": "~0.5.0",
-        "elcodi/shipping": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/tax-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/cart-bundle": "self.version",
+        "elcodi/geo-bundle": "self.version",
+        "elcodi/zone-bundle": "self.version",
+        "elcodi/shipping": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/SitemapBundle/composer.json
+++ b/src/Elcodi/Bundle/SitemapBundle/composer.json
@@ -39,12 +39,12 @@
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/sitemap": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/sitemap": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
@@ -36,12 +36,12 @@
         "symfony/console": "~2.6",
         "symfony/config": "~2.6",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/state-transition-machine": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/state-transition-machine": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/TaxBundle/composer.json
+++ b/src/Elcodi/Bundle/TaxBundle/composer.json
@@ -40,12 +40,12 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/tax": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/tax": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/UserBundle/composer.json
+++ b/src/Elcodi/Bundle/UserBundle/composer.json
@@ -42,15 +42,15 @@
         "mmoreram/simple-doctrine-mapping": "~1.0",
         "ircmaxell/password-compat": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/geo-bundle": "~0.5.0",
-        "elcodi/language-bundle": "~0.5.0",
-        "elcodi/cart-bundle": "~0.5.0",
-        "elcodi/user": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/geo-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/cart-bundle": "self.version",
+        "elcodi/user": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/ZoneBundle/composer.json
+++ b/src/Elcodi/Bundle/ZoneBundle/composer.json
@@ -40,13 +40,13 @@
         "symfony/dependency-injection": "~2.6",
         "mmoreram/simple-doctrine-mapping": "~1.0",
 
-        "elcodi/core-bundle": "~0.5.0",
-        "elcodi/geo-bundle": "~0.5.0",
-        "elcodi/zone": "~0.5.0"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/geo-bundle": "self.version",
+        "elcodi/zone": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "~0.5.0",
-        "elcodi/fixtures-booster-bundle": "~0.5.0",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },


### PR DESCRIPTION
Could something like this make sense? /ping @mmoreram 

This fixes a bug with `--prefer-lowest` when requiring a bundle `0.5.18` installs the component `0.5.0`.