### PR TITLE
[WIP] Use master locale from settings

### DIFF
--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Language\Twig\LanguageExtension
         arguments:
             - @elcodi.manager.language
-            - @elcodi.locale
+            - @=elcodi_config('store.default_language')
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
@@ -7,6 +7,5 @@ services:
         class: Elcodi\Component\Language\Twig\LanguageExtension
         arguments:
             - @elcodi.manager.language
-            - @=elcodi_config('store.default_language')
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Component/Language/Twig/LanguageExtension.php
+++ b/src/Elcodi/Component/Language/Twig/LanguageExtension.php
@@ -20,7 +20,6 @@ namespace Elcodi\Component\Language\Twig;
 use Twig_Extension;
 
 use Elcodi\Component\Language\Entity\Interfaces\LanguageInterface;
-use Elcodi\Component\Language\Entity\Interfaces\LocaleInterface;
 use Elcodi\Component\Language\Services\LanguageManager;
 
 /**
@@ -36,24 +35,13 @@ class LanguageExtension extends Twig_Extension
     protected $languageManager;
 
     /**
-     * @var string
-     *
-     * Master locale ISO
-     */
-    protected $masterLocaleIso;
-
-    /**
      * Construct method
      *
      * @param LanguageManager $languageManager Language manager
-     * @param string          $masterLocaleIso Master locale ISO
      */
-    public function __construct(
-        LanguageManager $languageManager,
-        $masterLocaleIso
-    ) {
+    public function __construct(LanguageManager $languageManager)
+    {
         $this->languageManager = $languageManager;
-        $this->masterLocaleIso = $masterLocaleIso;
     }
 
     /**
@@ -71,16 +59,22 @@ class LanguageExtension extends Twig_Extension
     /**
      * Return all available languages
      *
+     * @param string $masterLanguage
+     *
      * @return array Available languages
      */
-    public function getLanguages()
+    public function getLanguages($masterLanguage = null)
     {
         $languages = $this
             ->languageManager
             ->getLanguages()
             ->toArray();
 
-        return $this->promoteMasterLanguage($languages);
+        if ($masterLanguage === null) {
+            return $languages;
+        }
+
+        return $this->promoteMasterLanguage($languages, $masterLanguage);
     }
 
     /**
@@ -97,16 +91,17 @@ class LanguageExtension extends Twig_Extension
      * Move master language to the first position
      *
      * @param LanguageInterface[] $languages
+     * @param string              $masterLocaleIso
      *
-     * @return LanguageInterface[]
+     * @return \Elcodi\Component\Language\Entity\Interfaces\LanguageInterface[]
      */
-    protected function promoteMasterLanguage(array $languages)
+    protected function promoteMasterLanguage(array $languages, $masterLocaleIso)
     {
-        $index = array_search($this->masterLocaleIso, $languages);
+        $index = array_search($masterLocaleIso, $languages);
 
         if (false !== $index) {
             unset($languages[$index]);
-            array_unshift($languages, $this->masterLocaleIso);
+            array_unshift($languages, $masterLocaleIso);
         }
 
         return $languages;

--- a/src/Elcodi/Component/Language/Twig/LanguageExtension.php
+++ b/src/Elcodi/Component/Language/Twig/LanguageExtension.php
@@ -36,24 +36,24 @@ class LanguageExtension extends Twig_Extension
     protected $languageManager;
 
     /**
-     * @var LocaleInterface
+     * @var string
      *
-     * Master locale
+     * Master locale ISO
      */
-    protected $masterLocale;
+    protected $masterLocaleIso;
 
     /**
      * Construct method
      *
      * @param LanguageManager $languageManager Language manager
-     * @param LocaleInterface $masterLocale    Master locale
+     * @param string          $masterLocaleIso Master locale ISO
      */
     public function __construct(
         LanguageManager $languageManager,
-        LocaleInterface $masterLocale
+        $masterLocaleIso
     ) {
         $this->languageManager = $languageManager;
-        $this->masterLocale = $masterLocale;
+        $this->masterLocaleIso = $masterLocaleIso;
     }
 
     /**
@@ -102,12 +102,11 @@ class LanguageExtension extends Twig_Extension
      */
     protected function promoteMasterLanguage(array $languages)
     {
-        $masterLocale = $this->masterLocale->getIso();
-        $index = array_search($masterLocale, $languages);
+        $index = array_search($this->masterLocaleIso, $languages);
 
         if (false !== $index) {
             unset($languages[$index]);
-            array_unshift($languages, $masterLocale);
+            array_unshift($languages, $this->masterLocaleIso);
         }
 
         return $languages;


### PR DESCRIPTION
When sorting active languages, it was promoting to master the wrong one (from `elcodi.locale`).
This uses the correct master-language from the configuration.

Possible improvements:
- Decouple from `elcodi/config`