### PR TITLE
added productCurrency to OrderLine ORM

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/Resources/config/doctrine/OrderLine.orm.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/doctrine/OrderLine.orm.yml
@@ -49,6 +49,13 @@ Elcodi\Component\Cart\Entity\OrderLine:
                 name: order_id
                 referencedColumnName: id
                 nullable: false
+        productCurrency:
+            targetEntity: Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface
+            fetch: EAGER
+            joinColumn:
+                 name: product_currency_iso
+                 referencedColumnName: iso
+                 nullable: false
         currency:
             targetEntity: Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface
             joinColumn:


### PR DESCRIPTION
This field exists in CartLine but is missing in OrderLine

The thing is that when you try to do a doctrine schema update, there is an error ...
````
[Doctrine\DBAL\Driver\PDOException]
  SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`deliberry`.`#sql-4c8_59`, CONSTRAINT `FK_9CE58EE1
  3E76C531` FOREIGN KEY (`product_currency_iso`) REFERENCES `currency` (`iso`))
````
... because this field is required. I can put a default value in my project, but what is the best approach for existing data for other elcodi projects?