### PR TITLE
Using self.version during Beta and RC

### DIFF
--- a/src/Elcodi/Bundle/AttributeBundle/composer.json
+++ b/src/Elcodi/Bundle/AttributeBundle/composer.json
@@ -39,12 +39,12 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/attribute": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/attribute": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/BannerBundle/composer.json
+++ b/src/Elcodi/Bundle/BannerBundle/composer.json
@@ -39,14 +39,14 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/language-bundle": "1.0.x-dev",
-        "elcodi/media-bundle": "1.0.x-dev",
-        "elcodi/banner": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/media-bundle": "self.version",
+        "elcodi/banner": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CartBundle/composer.json
+++ b/src/Elcodi/Bundle/CartBundle/composer.json
@@ -39,18 +39,18 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/user-bundle": "1.0.x-dev",
-        "elcodi/product-bundle": "1.0.x-dev",
-        "elcodi/currency-bundle": "1.0.x-dev",
-        "elcodi/state-transition-machine-bundle": "1.0.x-dev",
-        "elcodi/store-bundle": "1.0.x-dev",
-        "elcodi/shipping-bundle": "1.0.x-dev",
-        "elcodi/cart": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/user-bundle": "self.version",
+        "elcodi/product-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/state-transition-machine-bundle": "self.version",
+        "elcodi/store-bundle": "self.version",
+        "elcodi/shipping-bundle": "self.version",
+        "elcodi/cart": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CartCouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CartCouponBundle/composer.json
@@ -40,15 +40,15 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/cart-bundle": "1.0.x-dev",
-        "elcodi/coupon-bundle": "1.0.x-dev",
-        "elcodi/rule-bundle": "1.0.x-dev",
-        "elcodi/cart-coupon": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/cart-bundle": "self.version",
+        "elcodi/coupon-bundle": "self.version",
+        "elcodi/rule-bundle": "self.version",
+        "elcodi/cart-coupon": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CommentBundle/composer.json
+++ b/src/Elcodi/Bundle/CommentBundle/composer.json
@@ -40,12 +40,12 @@
         "mmoreram/simple-doctrine-mapping": "^1.0",
         "doctrine/doctrine-cache-bundle": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/comment": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/comment": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/ConfigurationBundle/composer.json
+++ b/src/Elcodi/Bundle/ConfigurationBundle/composer.json
@@ -40,13 +40,13 @@
         "mmoreram/simple-doctrine-mapping": "^1.0",
         "doctrine/doctrine-cache-bundle": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/configuration": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/configuration": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
         "symfony/expression-language": "^2.7",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CoreBundle/composer.json
+++ b/src/Elcodi/Bundle/CoreBundle/composer.json
@@ -45,11 +45,11 @@
         "mmoreram/simple-doctrine-mapping": "^1.0",
         "mmoreram/extractor": "^1.1.1",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CouponBundle/composer.json
@@ -39,14 +39,14 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/currency-bundle": "1.0.x-dev",
-        "elcodi/rule-bundle": "1.0.x-dev",
-        "elcodi/coupon": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/rule-bundle": "self.version",
+        "elcodi/coupon": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/CurrencyBundle/composer.json
+++ b/src/Elcodi/Bundle/CurrencyBundle/composer.json
@@ -46,13 +46,13 @@
         "ocramius/proxy-manager": "^1.0",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/language-bundle": "1.0.x-dev",
-        "elcodi/currency": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/currency": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
@@ -40,13 +40,13 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/entity-translator": "1.0.x-dev",
-        "elcodi/language-bundle": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/entity-translator": "self.version",
+        "elcodi/language-bundle": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/composer.json
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/composer.json
@@ -38,7 +38,7 @@
 
         "doctrine/doctrine-fixtures-bundle": "^2.2",
 
-        "elcodi/core-bundle": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version"
     },
     "autoload": {
         "psr-4": {

--- a/src/Elcodi/Bundle/GeoBundle/composer.json
+++ b/src/Elcodi/Bundle/GeoBundle/composer.json
@@ -42,12 +42,12 @@
 
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/geo": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/geo": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/LanguageBundle/composer.json
+++ b/src/Elcodi/Bundle/LanguageBundle/composer.json
@@ -39,12 +39,12 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/language": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/MediaBundle/composer.json
+++ b/src/Elcodi/Bundle/MediaBundle/composer.json
@@ -42,12 +42,12 @@
         "knplabs/knp-gaufrette-bundle": "^0.1.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/media": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/media": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/MenuBundle/composer.json
+++ b/src/Elcodi/Bundle/MenuBundle/composer.json
@@ -41,12 +41,12 @@
         "symfony/twig-bundle": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/menu": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/menu": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/MetricBundle/composer.json
+++ b/src/Elcodi/Bundle/MetricBundle/composer.json
@@ -40,12 +40,12 @@
         "mmoreram/simple-doctrine-mapping": "^1.0",
         "snc/redis-bundle": "^1.1.8",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/metric": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/metric": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/NewsletterBundle/composer.json
+++ b/src/Elcodi/Bundle/NewsletterBundle/composer.json
@@ -39,13 +39,13 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/language-bundle": "1.0.x-dev",
-        "elcodi/newsletter": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/newsletter": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/PageBundle/composer.json
+++ b/src/Elcodi/Bundle/PageBundle/composer.json
@@ -39,12 +39,12 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/page": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/page": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/PaymentBundle/composer.json
+++ b/src/Elcodi/Bundle/PaymentBundle/composer.json
@@ -35,12 +35,12 @@
         "symfony/http-kernel": "^2.7",
         "symfony/dependency-injection": "^2.7",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/payment": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/payment": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/PluginBundle/composer.json
+++ b/src/Elcodi/Bundle/PluginBundle/composer.json
@@ -26,8 +26,8 @@
         "symfony/config": "^2.7",
         "symfony/dependency-injection": "^2.7",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/plugin": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/plugin": "self.version"
     },
     "autoload": {
         "psr-4": {

--- a/src/Elcodi/Bundle/ProductBundle/composer.json
+++ b/src/Elcodi/Bundle/ProductBundle/composer.json
@@ -42,18 +42,18 @@
         "mmoreram/simple-doctrine-mapping": "^1.0",
         "doctrine/doctrine-cache-bundle": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/language-bundle": "1.0.x-dev",
-        "elcodi/media-bundle": "1.0.x-dev",
-        "elcodi/currency-bundle": "1.0.x-dev",
-        "elcodi/attribute-bundle": "1.0.x-dev",
-        "elcodi/configuration-bundle": "1.0.x-dev",
-        "elcodi/store-bundle": "1.0.x-dev",
-        "elcodi/product": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/media-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/attribute-bundle": "self.version",
+        "elcodi/configuration-bundle": "self.version",
+        "elcodi/store-bundle": "self.version",
+        "elcodi/product": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/RuleBundle/composer.json
+++ b/src/Elcodi/Bundle/RuleBundle/composer.json
@@ -40,12 +40,12 @@
         "symfony/expression-language": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/rule": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/rule": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/ShippingBundle/composer.json
+++ b/src/Elcodi/Bundle/ShippingBundle/composer.json
@@ -35,12 +35,12 @@
         "symfony/http-kernel": "^2.7",
         "symfony/dependency-injection": "^2.7",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/shipping": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/shipping": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/SitemapBundle/composer.json
+++ b/src/Elcodi/Bundle/SitemapBundle/composer.json
@@ -38,12 +38,12 @@
         "symfony/config": "^2.7",
         "symfony/dependency-injection": "^2.7",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/sitemap": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/sitemap": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
@@ -36,12 +36,12 @@
         "symfony/http-kernel": "^2.7",
         "symfony/config": "^2.7",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/state-transition-machine": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/state-transition-machine": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/StoreBundle/composer.json
+++ b/src/Elcodi/Bundle/StoreBundle/composer.json
@@ -38,15 +38,15 @@
         "symfony/http-kernel": "^2.7",
         "symfony/config": "^2.7",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/geo-bundle": "1.0.x-dev",
-        "elcodi/language-bundle": "1.0.x-dev",
-        "elcodi/currency-bundle": "1.0.x-dev",
-        "elcodi/store": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/geo-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/currency-bundle": "self.version",
+        "elcodi/store": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/TaxBundle/composer.json
+++ b/src/Elcodi/Bundle/TaxBundle/composer.json
@@ -39,12 +39,12 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/tax": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/tax": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/UserBundle/composer.json
+++ b/src/Elcodi/Bundle/UserBundle/composer.json
@@ -41,15 +41,15 @@
         "mmoreram/simple-doctrine-mapping": "^1.0",
         "ircmaxell/password-compat": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/geo-bundle": "1.0.x-dev",
-        "elcodi/language-bundle": "1.0.x-dev",
-        "elcodi/cart-bundle": "1.0.x-dev",
-        "elcodi/user": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/geo-bundle": "self.version",
+        "elcodi/language-bundle": "self.version",
+        "elcodi/cart-bundle": "self.version",
+        "elcodi/user": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Bundle/ZoneBundle/composer.json
+++ b/src/Elcodi/Bundle/ZoneBundle/composer.json
@@ -39,13 +39,13 @@
         "symfony/dependency-injection": "^2.7",
         "mmoreram/simple-doctrine-mapping": "^1.0",
 
-        "elcodi/core-bundle": "1.0.x-dev",
-        "elcodi/geo-bundle": "1.0.x-dev",
-        "elcodi/zone": "1.0.x-dev"
+        "elcodi/core-bundle": "self.version",
+        "elcodi/geo-bundle": "self.version",
+        "elcodi/zone": "self.version"
     },
     "require-dev": {
-        "elcodi/test-common-bundle": "1.0.x-dev",
-        "elcodi/fixtures-booster-bundle": "1.0.x-dev",
+        "elcodi/test-common-bundle": "self.version",
+        "elcodi/fixtures-booster-bundle": "self.version",
         "doctrine/data-fixtures": "^1.1",
         "phpunit/phpunit": "4.5.0"
     },

--- a/src/Elcodi/Component/Attribute/composer.json
+++ b/src/Elcodi/Component/Attribute/composer.json
@@ -35,7 +35,7 @@
         "doctrine/common": "^2.5",
         "doctrine/orm": "^2.5",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Banner/composer.json
+++ b/src/Elcodi/Component/Banner/composer.json
@@ -35,9 +35,9 @@
         "doctrine/common": "^2.5",
         "doctrine/orm": "^2.5",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/language": "1.0.x-dev",
-        "elcodi/media": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/language": "self.version",
+        "elcodi/media": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Cart/composer.json
+++ b/src/Elcodi/Component/Cart/composer.json
@@ -37,11 +37,11 @@
         "symfony/event-dispatcher": "^2.7",
         "symfony/http-foundation": "^2.7",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/user": "1.0.x-dev",
-        "elcodi/product": "1.0.x-dev",
-        "elcodi/state-transition-machine": "1.0.x-dev",
-        "elcodi/currency": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/user": "self.version",
+        "elcodi/product": "self.version",
+        "elcodi/state-transition-machine": "self.version",
+        "elcodi/currency": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/CartCoupon/composer.json
+++ b/src/Elcodi/Component/CartCoupon/composer.json
@@ -37,10 +37,10 @@
         "doctrine/orm": "^2.5",
         "symfony/event-dispatcher": "^2.7",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/cart": "1.0.x-dev",
-        "elcodi/coupon": "1.0.x-dev",
-        "elcodi/rule": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/cart": "self.version",
+        "elcodi/coupon": "self.version",
+        "elcodi/rule": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Comment/composer.json
+++ b/src/Elcodi/Component/Comment/composer.json
@@ -36,7 +36,7 @@
         "doctrine/orm": "^2.5",
         "doctrine/cache": "^1.0",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Configuration/composer.json
+++ b/src/Elcodi/Component/Configuration/composer.json
@@ -36,7 +36,7 @@
         "doctrine/common": "^2.5",
         "doctrine/orm": "^2.5",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Coupon/composer.json
+++ b/src/Elcodi/Component/Coupon/composer.json
@@ -36,9 +36,9 @@
         "doctrine/orm": "^2.5",
         "symfony/event-dispatcher": "^2.7",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/currency": "1.0.x-dev",
-        "elcodi/rule": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/currency": "self.version",
+        "elcodi/rule": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Currency/composer.json
+++ b/src/Elcodi/Component/Currency/composer.json
@@ -38,8 +38,8 @@
         "sebastian/money": "^1.5",
         "twig/twig": "^1.18",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/language": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/language": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/EntityTranslator/composer.json
+++ b/src/Elcodi/Component/EntityTranslator/composer.json
@@ -39,7 +39,7 @@
         "symfony/dependency-injection": "^2.7",
         "symfony/form": "^2.7",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Geo/composer.json
+++ b/src/Elcodi/Component/Geo/composer.json
@@ -37,7 +37,7 @@
         "mmoreram/extractor": "^1.0",
         "goodby/csv": "^1.0",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Language/composer.json
+++ b/src/Elcodi/Component/Language/composer.json
@@ -36,7 +36,7 @@
         "doctrine/orm": "^2.5",
         "twig/twig": "^1.18",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Media/composer.json
+++ b/src/Elcodi/Component/Media/composer.json
@@ -40,7 +40,7 @@
         "symfony/routing": "^2.7",
         "knplabs/gaufrette": "^0.1.7",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Menu/composer.json
+++ b/src/Elcodi/Component/Menu/composer.json
@@ -36,7 +36,7 @@
         "doctrine/orm": "^2.5",
         "symfony/routing": "^2.7",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Metric/composer.json
+++ b/src/Elcodi/Component/Metric/composer.json
@@ -37,7 +37,7 @@
         "twig/twig": "^1.18",
         "predis/predis": "^0.8.7",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Newsletter/composer.json
+++ b/src/Elcodi/Component/Newsletter/composer.json
@@ -37,8 +37,8 @@
         "symfony/event-dispatcher": "^2.7",
         "symfony/validator": "^2.7",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/language": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/language": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Page/composer.json
+++ b/src/Elcodi/Component/Page/composer.json
@@ -36,8 +36,8 @@
         "symfony/http-foundation": "^2.7",
         "symfony/http-kernel": "^2.7",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/metadata": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/metadata": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Payment/composer.json
+++ b/src/Elcodi/Component/Payment/composer.json
@@ -35,7 +35,7 @@
         "symfony/event-dispatcher": "^2.7",
         "twig/twig": "^1.18",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Plugin/composer.json
+++ b/src/Elcodi/Component/Plugin/composer.json
@@ -35,8 +35,8 @@
         "symfony/yaml": "^2.7",
         "twig/twig": "^1.18",
 
-        "elcodi/configuration": "1.0.x-dev",
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/configuration": "self.version",
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Product/composer.json
+++ b/src/Elcodi/Component/Product/composer.json
@@ -36,12 +36,12 @@
         "doctrine/orm": "^2.5",
         "twig/twig": "^1.18",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/language": "1.0.x-dev",
-        "elcodi/media": "1.0.x-dev",
-        "elcodi/currency": "1.0.x-dev",
-        "elcodi/attribute": "1.0.x-dev",
-        "elcodi/metadata": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/language": "self.version",
+        "elcodi/media": "self.version",
+        "elcodi/currency": "self.version",
+        "elcodi/attribute": "self.version",
+        "elcodi/metadata": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Rule/composer.json
+++ b/src/Elcodi/Component/Rule/composer.json
@@ -36,7 +36,7 @@
         "doctrine/orm": "^2.5",
         "symfony/expression-language": "^2.7",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Shipping/composer.json
+++ b/src/Elcodi/Component/Shipping/composer.json
@@ -35,9 +35,9 @@
         "symfony/event-dispatcher": "^2.7",
         "twig/twig": "^1.18",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/cart": "1.0.x-dev",
-        "elcodi/currency": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/cart": "self.version",
+        "elcodi/currency": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Sitemap/composer.json
+++ b/src/Elcodi/Component/Sitemap/composer.json
@@ -34,7 +34,7 @@
         "php": ">=5.4",
         "doctrine/common": "^2.5",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/StateTransitionMachine/composer.json
+++ b/src/Elcodi/Component/StateTransitionMachine/composer.json
@@ -36,7 +36,7 @@
         "psr/log": "^1.0",
         "symfony/event-dispatcher": "^2.7",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Store/composer.json
+++ b/src/Elcodi/Component/Store/composer.json
@@ -35,11 +35,11 @@
         "doctrine/common": "^2.5",
         "doctrine/orm": "^2.5",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/geo": "1.0.x-dev",
-        "elcodi/currency": "1.0.x-dev",
-        "elcodi/language": "1.0.x-dev",
-        "elcodi/media": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/geo": "self.version",
+        "elcodi/currency": "self.version",
+        "elcodi/language": "self.version",
+        "elcodi/media": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Tax/composer.json
+++ b/src/Elcodi/Component/Tax/composer.json
@@ -35,7 +35,7 @@
         "doctrine/common": "^2.5",
         "doctrine/orm": "^2.5",
 
-        "elcodi/core": "1.0.x-dev"
+        "elcodi/core": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/User/composer.json
+++ b/src/Elcodi/Component/User/composer.json
@@ -39,10 +39,10 @@
         "symfony/event-dispatcher": "^2.7",
         "symfony/dependency-injection": "^2.7",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/geo": "1.0.x-dev",
-        "elcodi/language": "1.0.x-dev",
-        "elcodi/cart": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/geo": "self.version",
+        "elcodi/language": "self.version",
+        "elcodi/cart": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"

--- a/src/Elcodi/Component/Zone/composer.json
+++ b/src/Elcodi/Component/Zone/composer.json
@@ -35,8 +35,8 @@
         "doctrine/common": "^2.5",
         "doctrine/orm": "^2.5",
 
-        "elcodi/core": "1.0.x-dev",
-        "elcodi/geo": "1.0.x-dev"
+        "elcodi/core": "self.version",
+        "elcodi/geo": "self.version"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.0"


### PR DESCRIPTION
* Unless there is no strict BC promise (stable), we need to work with self.version dependencies
    * When attached to specific beta version (v1.0.0-beta3), then all dependencies are resolved with same version
    * Otherwise, dev-master is used (by definition)