### PR TITLE
Make plugin services lazy by default

### DIFF
--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
@@ -44,6 +44,7 @@ services:
 
     elcodi.abstract_plugin:
         abstract: true
+        lazy: true
         class: Elcodi\Component\Plugin\Entity\Plugin
         factory:
             - @elcodi.repository.plugin


### PR DESCRIPTION
To avoid extra db queries, plugin services must be defined lazy by default.