### PR TITLE
Can disable entities

### DIFF
--- a/src/Elcodi/Bundle/CoreBundle/DependencyInjection/Abstracts/AbstractConfiguration.php
+++ b/src/Elcodi/Bundle/CoreBundle/DependencyInjection/Abstracts/AbstractConfiguration.php
@@ -86,6 +86,9 @@ abstract class AbstractConfiguration implements ConfigurationInterface
         $node = $builder->root($nodeName);
 
         $node
+            ->treatFalseLike([
+                'enabled' => false,
+            ])
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('class')
@@ -102,7 +105,6 @@ abstract class AbstractConfiguration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('enabled')
                     ->defaultValue($entityEnabled)
-                    ->cannotBeEmpty()
                 ->end()
             ->end()
         ->end();


### PR DESCRIPTION
Elcodi entities can't be disabled, because `cannotBeEmpty` don't let you to set `enabled` to `false`.
Removing the call fixes this bug.

Also, adding `treatFalseLike` in the root node, you can disable an entity easier.
Before:
```yml
elcodi_banner:
    mapping:
        banner:
            enabled: false
        banner_zone:
            enabled: false
```

After:
```yml
elcodi_banner:
    mapping:
        banner: false
        banner_zone: false
```