### PR TITLE
Casting and missing types requirement

### DIFF
--- a/src/Elcodi/Component/Banner/Entity/Banner.php
+++ b/src/Elcodi/Component/Banner/Entity/Banner.php
@@ -88,7 +88,7 @@ class Banner implements BannerInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -112,7 +112,7 @@ class Banner implements BannerInterface
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }
@@ -136,7 +136,7 @@ class Banner implements BannerInterface
      */
     public function setUrl($url)
     {
-        $this->url = $url;
+        $this->url = (string) $url;
 
         return $this;
     }

--- a/src/Elcodi/Component/Banner/Entity/BannerZone.php
+++ b/src/Elcodi/Component/Banner/Entity/BannerZone.php
@@ -82,7 +82,7 @@ class BannerZone implements BannerZoneInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -106,7 +106,7 @@ class BannerZone implements BannerZoneInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }

--- a/src/Elcodi/Component/Banner/Repository/BannerRepository.php
+++ b/src/Elcodi/Component/Banner/Repository/BannerRepository.php
@@ -40,7 +40,7 @@ class BannerRepository extends EntityRepository
     public function getBannerByZone($bannerZoneCode, LanguageInterface $language = null)
     {
         $parameters = [
-            'code' => $bannerZoneCode,
+            'code' => (string) $bannerZoneCode,
         ];
 
         if (!is_null($language)) {

--- a/src/Elcodi/Component/Banner/Services/BannerManager.php
+++ b/src/Elcodi/Component/Banner/Services/BannerManager.php
@@ -57,7 +57,7 @@ class BannerManager
     {
         return $this
             ->bannerRepository
-            ->getBannerByZone($bannerZoneCode, $language);
+            ->getBannerByZone((string) $bannerZoneCode, $language);
     }
 
     /**

--- a/src/Elcodi/Component/Cart/Entity/Cart.php
+++ b/src/Elcodi/Component/Cart/Entity/Cart.php
@@ -164,7 +164,7 @@ class Cart implements CartInterface
      */
     public function setLoaded($loaded)
     {
-        $this->loaded = $loaded;
+        $this->loaded = (bool) $loaded;
 
         return $this;
     }
@@ -226,7 +226,7 @@ class Cart implements CartInterface
      */
     public function setOrdered($ordered)
     {
-        $this->ordered = $ordered;
+        $this->ordered = (bool) $ordered;
 
         return $this;
     }
@@ -304,7 +304,7 @@ class Cart implements CartInterface
      */
     public function setQuantity($quantity)
     {
-        $this->quantity = $quantity;
+        $this->quantity = (int) $quantity;
 
         return $this;
     }
@@ -563,7 +563,7 @@ class Cart implements CartInterface
      */
     public function setShippingMethod($shippingMethod)
     {
-        $this->shippingMethod = $shippingMethod;
+        $this->shippingMethod = (string) $shippingMethod;
 
         return $this;
     }
@@ -587,7 +587,7 @@ class Cart implements CartInterface
      */
     public function setCheapestShippingMethod($cheapestShippingMethod)
     {
-        $this->cheapestShippingMethod = $cheapestShippingMethod;
+        $this->cheapestShippingMethod = (string) $cheapestShippingMethod;
 
         return $this;
     }

--- a/src/Elcodi/Component/Cart/Entity/Order.php
+++ b/src/Elcodi/Component/Cart/Entity/Order.php
@@ -258,7 +258,7 @@ class Order implements OrderInterface
      */
     public function setQuantity($quantity)
     {
-        $this->quantity = $quantity;
+        $this->quantity = (int) $quantity;
 
         return $this;
     }

--- a/src/Elcodi/Component/Cart/Entity/Traits/PurchasableWrapperTrait.php
+++ b/src/Elcodi/Component/Cart/Entity/Traits/PurchasableWrapperTrait.php
@@ -141,7 +141,7 @@ trait PurchasableWrapperTrait
      */
     public function setQuantity($quantity)
     {
-        $this->quantity = $quantity;
+        $this->quantity = (int) $quantity;
 
         return $this;
     }

--- a/src/Elcodi/Component/Cart/EventListener/CartLoadEventListener.php
+++ b/src/Elcodi/Component/Cart/EventListener/CartLoadEventListener.php
@@ -112,7 +112,7 @@ class CartLoadEventListener
         $this->cartManager = $cartManager;
         $this->currencyWrapper = $currencyWrapper;
         $this->currencyConverter = $currencyConverter;
-        $this->useStock = $useStock;
+        $this->useStock = (bool) $useStock;
     }
 
     /**

--- a/src/Elcodi/Component/Cart/Services/CartManager.php
+++ b/src/Elcodi/Component/Cart/Services/CartManager.php
@@ -201,7 +201,7 @@ class CartManager
         }
 
         $cartLine->setPurchasable($purchasable);
-        $this->setCartLineQuantity($cartLine, $quantity);
+        $this->setCartLineQuantity($cartLine, (int) $quantity);
 
         return $this;
     }
@@ -451,7 +451,7 @@ class CartManager
             ->addPurchasable(
                 $cart,
                 $purchasable,
-                $quantity
+                (int) $quantity
             );
     }
 
@@ -484,7 +484,7 @@ class CartManager
             ->removePurchasable(
                 $cart,
                 $purchasable,
-                $quantity
+                (int) $quantity
             );
     }
 

--- a/src/Elcodi/Component/Cart/Services/CartSessionManager.php
+++ b/src/Elcodi/Component/Cart/Services/CartSessionManager.php
@@ -67,8 +67,8 @@ class CartSessionManager
         $saveInSession
     ) {
         $this->session = $session;
-        $this->sessionFieldName = $sessionFieldName;
-        $this->saveInSession = $saveInSession;
+        $this->sessionFieldName = (string) $sessionFieldName;
+        $this->saveInSession = (bool) $saveInSession;
     }
 
     /**

--- a/src/Elcodi/Component/CartCoupon/Entity/OrderCoupon.php
+++ b/src/Elcodi/Component/CartCoupon/Entity/OrderCoupon.php
@@ -131,7 +131,7 @@ class OrderCoupon implements OrderCouponInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }
@@ -155,7 +155,7 @@ class OrderCoupon implements OrderCouponInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }

--- a/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
+++ b/src/Elcodi/Component/CartCoupon/Services/CartCouponManager.php
@@ -165,7 +165,7 @@ class CartCouponManager
         $coupon = $this
             ->couponRepository
             ->findOneBy([
-                'code'    => $couponCode,
+                'code'    => (string) $couponCode,
                 'enabled' => true,
             ]);
 
@@ -211,7 +211,7 @@ class CartCouponManager
         $coupon = $this
             ->couponRepository
             ->findOneBy([
-                'code' => $couponCode,
+                'code' => (string) $couponCode,
             ]);
 
         if (!($coupon instanceof CouponInterface)) {

--- a/src/Elcodi/Component/Comment/Controller/CommentController.php
+++ b/src/Elcodi/Component/Comment/Controller/CommentController.php
@@ -81,7 +81,7 @@ class CommentController
     {
         $comments = $this
             ->commentCache
-            ->load($source, $context);
+            ->load((string) $source, (string) $context);
 
         return new Response(json_encode($comments));
     }
@@ -120,10 +120,10 @@ class CommentController
         $comment = $this
             ->commentManager
             ->addComment(
-                $source,
-                $context,
+                (string) $source,
+                (string) $context,
                 $content,
-                $authorToken,
+                (string) $authorToken,
                 $authorName,
                 $authorEmail,
                 $parent
@@ -158,8 +158,8 @@ class CommentController
         $requestBag = $request->request;
         $content = $requestBag->get('content');
         $comment = $this->findComment(
-            $commentId,
-            $authorToken
+            (int) $commentId,
+            (string) $authorToken
         );
 
         $this
@@ -185,8 +185,8 @@ class CommentController
     public function deleteCommentAction($commentId, $authorToken)
     {
         $comment = $this->findComment(
-            $commentId,
-            $authorToken
+            (int) $commentId,
+            (string) $authorToken
         );
 
         $this
@@ -213,8 +213,8 @@ class CommentController
         $comment = $this
             ->commentRepository
             ->findOneBy([
-                'id'          => $commentId,
-                'authorToken' => $authorToken,
+                'id'          => (string) $commentId,
+                'authorToken' => (string) $authorToken,
             ]);
 
         if (!($comment instanceof CommentInterface)) {

--- a/src/Elcodi/Component/Comment/Entity/Comment.php
+++ b/src/Elcodi/Component/Comment/Entity/Comment.php
@@ -96,7 +96,7 @@ class Comment implements CommentInterface
      */
     public function setContent($content)
     {
-        $this->content = $content;
+        $this->content = (string) $content;
 
         return $this;
     }
@@ -144,7 +144,7 @@ class Comment implements CommentInterface
      */
     public function setSource($source)
     {
-        $this->source = $source;
+        $this->source = (string) $source;
 
         return $this;
     }
@@ -202,7 +202,7 @@ class Comment implements CommentInterface
      */
     public function setContext($context)
     {
-        $this->context = $context;
+        $this->context = (string) $context;
 
         return $this;
     }
@@ -226,7 +226,7 @@ class Comment implements CommentInterface
      */
     public function setAuthorEmail($authorEmail)
     {
-        $this->authorEmail = $authorEmail;
+        $this->authorEmail = (string) $authorEmail;
 
         return $this;
     }
@@ -250,7 +250,7 @@ class Comment implements CommentInterface
      */
     public function setAuthorName($authorName)
     {
-        $this->authorName = $authorName;
+        $this->authorName = (string) $authorName;
 
         return $this;
     }
@@ -274,7 +274,7 @@ class Comment implements CommentInterface
      */
     public function setAuthorToken($authorToken)
     {
-        $this->authorToken = $authorToken;
+        $this->authorToken = (string) $authorToken;
 
         return $this;
     }

--- a/src/Elcodi/Component/Comment/Entity/Vote.php
+++ b/src/Elcodi/Component/Comment/Entity/Vote.php
@@ -107,7 +107,7 @@ class Vote implements VoteInterface
      */
     public function setType($type)
     {
-        $this->type = $type;
+        $this->type = (bool) $type;
 
         return $this;
     }
@@ -131,7 +131,7 @@ class Vote implements VoteInterface
      */
     public function setAuthorToken($authorToken)
     {
-        $this->authorToken = $authorToken;
+        $this->authorToken = (string) $authorToken;
 
         return $this;
     }

--- a/src/Elcodi/Component/Comment/Event/CommentOnVotedEvent.php
+++ b/src/Elcodi/Component/Comment/Event/CommentOnVotedEvent.php
@@ -55,7 +55,7 @@ class CommentOnVotedEvent extends AbstractCommentEvent
         parent::__construct($comment);
 
         $this->vote = $vote;
-        $this->edited = $edited;
+        $this->edited = (bool) $edited;
     }
 
     /**

--- a/src/Elcodi/Component/Comment/EventDispatcher/CommentEventDispatcher.php
+++ b/src/Elcodi/Component/Comment/EventDispatcher/CommentEventDispatcher.php
@@ -129,7 +129,7 @@ class CommentEventDispatcher extends AbstractEventDispatcher
         $event = new CommentOnVotedEvent(
             $comment,
             $vote,
-            $edited
+            (bool) $edited
         );
 
         $this

--- a/src/Elcodi/Component/Comment/Repository/CommentRepository.php
+++ b/src/Elcodi/Component/Comment/Repository/CommentRepository.php
@@ -48,8 +48,8 @@ class CommentRepository extends EntityRepository
             ->addOrderBy('c.parent', 'asc')
             ->addOrderBy('c.id', 'asc')
             ->setParameters([
-                'source'  => $source,
-                'context' => $context,
+                'source'  => (string) $source,
+                'context' => (string) $context,
                 'enabled' => true,
             ]);
 

--- a/src/Elcodi/Component/Comment/Services/CommentCache.php
+++ b/src/Elcodi/Component/Comment/Services/CommentCache.php
@@ -69,7 +69,7 @@ class CommentCache extends AbstractCacheWrapper
     ) {
         $this->commentRepository = $commentRepository;
         $this->voteManager = $voteManager;
-        $this->key = $key;
+        $this->key = (string) $key;
     }
 
     /**
@@ -83,8 +83,8 @@ class CommentCache extends AbstractCacheWrapper
     public function getCommentTree($source, $context)
     {
         $key = $this->getSpecificSourceCacheKey(
-            $source,
-            $context
+            (string) $source,
+            (string) $context
         );
 
         return isset($this->commentTree[$key])
@@ -105,6 +105,9 @@ class CommentCache extends AbstractCacheWrapper
      */
     public function load($source, $context)
     {
+        $source = (string) $source;
+        $context = (string) $context;
+
         $key = $this->getSpecificSourceCacheKey(
             $source,
             $context
@@ -141,6 +144,9 @@ class CommentCache extends AbstractCacheWrapper
      */
     public function invalidateCache($source, $context)
     {
+        $source = (string) $source;
+        $context = (string) $context;
+
         $key = $this->getSpecificSourceCacheKey(
             $source,
             $context
@@ -168,6 +174,9 @@ class CommentCache extends AbstractCacheWrapper
      */
     public function reload($source, $context)
     {
+        $source = (string) $source;
+        $context = (string) $context;
+
         $this->invalidateCache(
             $source,
             $context
@@ -231,8 +240,8 @@ class CommentCache extends AbstractCacheWrapper
                 $this
                     ->cache
                     ->fetch($this->getSpecificSourceCacheKey(
-                        $source,
-                        $context
+                        (string) $source,
+                        (string) $context
                     ))
             );
     }
@@ -247,6 +256,9 @@ class CommentCache extends AbstractCacheWrapper
      */
     private function buildCommentTreeAndSaveIntoCache($source, $context)
     {
+        $source = (string) $source;
+        $context = (string) $context;
+
         $commentTree = $this->buildCommentTree($source, $context);
         $this->saveCommentTreeIntoCache(
             $commentTree,
@@ -271,7 +283,7 @@ class CommentCache extends AbstractCacheWrapper
     {
         $comments = $this
             ->commentRepository
-            ->getAllCommentsSortedByParentAndIdAsc($source, $context);
+            ->getAllCommentsSortedByParentAndIdAsc((string) $source, (string) $context);
 
         $commentTree = [
             0          => null,
@@ -333,7 +345,7 @@ class CommentCache extends AbstractCacheWrapper
         $this
             ->cache
             ->save(
-                $this->getSpecificSourceCacheKey($source, $context),
+                $this->getSpecificSourceCacheKey((string) $source, (string) $context),
                 $this->encoder->encode($commentTree)
             );
 

--- a/src/Elcodi/Component/Comment/Services/CommentManager.php
+++ b/src/Elcodi/Component/Comment/Services/CommentManager.php
@@ -82,12 +82,12 @@ class CommentManager extends AbstractCacheWrapper
             ->create()
             ->setId(round(microtime(true) * 1000))
             ->setParent($parent)
-            ->setSource($source)
-            ->setAuthorToken($authorToken)
-            ->setAuthorName($authorName)
-            ->setAuthorEmail($authorEmail)
-            ->setContent($content)
-            ->setContext($context);
+            ->setSource((string) $source)
+            ->setAuthorToken((string) $authorToken)
+            ->setAuthorName((string) $authorName)
+            ->setAuthorEmail((string) $authorEmail)
+            ->setContent((string) $content)
+            ->setContext((string) $context);
 
         $this
             ->commentDirector
@@ -112,7 +112,7 @@ class CommentManager extends AbstractCacheWrapper
         CommentInterface $comment,
         $content
     ) {
-        $comment->setContent($content);
+        $comment->setContent((string) $content);
 
         $this
             ->commentDirector

--- a/src/Elcodi/Component/Comment/Services/VoteManager.php
+++ b/src/Elcodi/Component/Comment/Services/VoteManager.php
@@ -76,7 +76,7 @@ class VoteManager
         $vote = $this
             ->commentVoteObjectDirector
             ->findOneBy([
-                'authorToken' => $authorToken,
+                'authorToken' => (string) $authorToken,
                 'comment'     => $comment,
             ]);
 
@@ -86,13 +86,13 @@ class VoteManager
             $vote = $this
                 ->commentVoteObjectDirector
                 ->create()
-                ->setAuthorToken($authorToken)
+                ->setAuthorToken((string) $authorToken)
                 ->setComment($comment);
 
             $edited = false;
         }
 
-        $vote->setType($type);
+        $vote->setType((bool) $type);
 
         $this
             ->commentVoteObjectDirector
@@ -123,7 +123,7 @@ class VoteManager
         $vote = $this
             ->commentVoteObjectDirector
             ->findOneBy([
-                'authorToken' => $authorToken,
+                'authorToken' => (string) $authorToken,
                 'comment'     => $comment,
             ]);
 

--- a/src/Elcodi/Component/Configuration/Entity/Configuration.php
+++ b/src/Elcodi/Component/Configuration/Entity/Configuration.php
@@ -81,7 +81,7 @@ class Configuration implements ConfigurationInterface
      */
     public function setKey($key)
     {
-        $this->key = $key;
+        $this->key = (string) $key;
 
         return $this;
     }
@@ -105,7 +105,7 @@ class Configuration implements ConfigurationInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -129,7 +129,7 @@ class Configuration implements ConfigurationInterface
      */
     public function setNamespace($namespace)
     {
-        $this->namespace = $namespace;
+        $this->namespace = (string) $namespace;
 
         return $this;
     }
@@ -153,7 +153,7 @@ class Configuration implements ConfigurationInterface
      */
     public function setType($type)
     {
-        $this->type = $type;
+        $this->type = (string) $type;
 
         return $this;
     }

--- a/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
+++ b/src/Elcodi/Component/Configuration/Services/ConfigurationManager.php
@@ -105,6 +105,8 @@ class ConfigurationManager extends AbstractCacheWrapper
         $configurationIdentifier,
         $configurationValue
     ) {
+        $configurationIdentifier = (string) $configurationIdentifier;
+
         /**
          * Checks if the value is defined in the configuration elements
          */
@@ -170,6 +172,8 @@ class ConfigurationManager extends AbstractCacheWrapper
      */
     public function get($configurationIdentifier, $defaultValue = null)
     {
+        $configurationIdentifier = (string) $configurationIdentifier;
+
         /**
          * Checks if the value is defined in the configuration elements
          */
@@ -245,6 +249,8 @@ class ConfigurationManager extends AbstractCacheWrapper
      */
     public function delete($configurationIdentifier)
     {
+        $configurationIdentifier = (string) $configurationIdentifier;
+        
         /**
          * Checks if the value is defined in the configuration elements
          */
@@ -312,8 +318,8 @@ class ConfigurationManager extends AbstractCacheWrapper
         $configurationEntity = $this
             ->configurationRepository
             ->find([
-                'namespace' => $configurationNamespace,
-                'key'       => $configurationKey,
+                'namespace' => (string) $configurationNamespace,
+                'key'       => (string) $configurationKey,
             ]);
 
         return $configurationEntity;
@@ -377,6 +383,10 @@ class ConfigurationManager extends AbstractCacheWrapper
         $configurationKey,
         $configurationValue
     ) {
+        $configurationIdentifier = (string) $configurationIdentifier;
+        $configurationNamespace = (string) $configurationNamespace;
+        $configurationKey = (string) $configurationKey;
+        
         /**
          * Value is not found on database. We can just check if the value is
          * defined in the configuration elements, and we can generate new entry
@@ -426,7 +436,7 @@ class ConfigurationManager extends AbstractCacheWrapper
         $this
             ->cache
             ->save(
-                $configurationIdentifier,
+                (string) $configurationIdentifier,
                 $configurationValue
             );
 

--- a/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
+++ b/src/Elcodi/Component/Configuration/Twig/ConfigurationExtension.php
@@ -75,7 +75,7 @@ class ConfigurationExtension extends Twig_Extension
     ) {
         return $this
             ->configurationManager
-            ->get($parameterKey, $parameterNamespace);
+            ->get((string) $parameterKey, (string) $parameterNamespace);
     }
 
     /**

--- a/src/Elcodi/Component/Core/Command/Abstracts/AbstractElcodiCommand.php
+++ b/src/Elcodi/Component/Core/Command/Abstracts/AbstractElcodiCommand.php
@@ -99,7 +99,7 @@ class AbstractElcodiCommand extends Command
     {
         return $this
             ->stopwatch
-            ->start($eventName);
+            ->start((string) $eventName);
     }
 
     /**
@@ -188,7 +188,7 @@ class AbstractElcodiCommand extends Command
     {
         return $this
             ->stopwatch
-            ->stop($eventName);
+            ->stop((string) $eventName);
     }
 
     /**

--- a/src/Elcodi/Component/Core/Entity/Traits/EnabledTrait.php
+++ b/src/Elcodi/Component/Core/Entity/Traits/EnabledTrait.php
@@ -38,7 +38,7 @@ trait EnabledTrait
      */
     public function setEnabled($enabled)
     {
-        $this->enabled = $enabled;
+        $this->enabled = (bool) $enabled;
 
         return $this;
     }

--- a/src/Elcodi/Component/Core/Entity/Traits/IdentifiableTrait.php
+++ b/src/Elcodi/Component/Core/Entity/Traits/IdentifiableTrait.php
@@ -48,7 +48,7 @@ trait IdentifiableTrait
      */
     public function setId($id)
     {
-        $this->id = $id;
+        $this->id = (int) $id;
 
         return $this;
     }

--- a/src/Elcodi/Component/Core/Factory/Traits/EntityNamespaceTrait.php
+++ b/src/Elcodi/Component/Core/Factory/Traits/EntityNamespaceTrait.php
@@ -38,7 +38,7 @@ trait EntityNamespaceTrait
      */
     public function setEntityNamespace($entityNamespace)
     {
-        $this->entityNamespace = $entityNamespace;
+        $this->entityNamespace = (string) $entityNamespace;
 
         return $this;
     }

--- a/src/Elcodi/Component/Core/Generator/Sha1Generator.php
+++ b/src/Elcodi/Component/Core/Generator/Sha1Generator.php
@@ -56,7 +56,7 @@ class Sha1Generator implements GeneratorInterface
             "sha1",
             $this
                 ->generator
-                ->generate($length)
+                ->generate((int) $length)
         );
     }
 }

--- a/src/Elcodi/Component/Core/Mailer/Abstracts/AbstractMailer.php
+++ b/src/Elcodi/Component/Core/Mailer/Abstracts/AbstractMailer.php
@@ -79,9 +79,9 @@ abstract class AbstractMailer
     ) {
         $this->templatingEngine = $templatingEngine;
         $this->mailer = $mailer;
-        $this->layout = $layout;
-        $this->template = $template;
-        $this->fromEmail = $fromEmail;
+        $this->layout = (string) $layout;
+        $this->template = (string) $template;
+        $this->fromEmail = (string) $fromEmail;
     }
 
     /**
@@ -99,9 +99,9 @@ abstract class AbstractMailer
         array $context = []
     ) {
         $message = Swift_Message::newInstance()
-            ->setSubject($subject)
+            ->setSubject((string) $subject)
             ->setFrom($this->fromEmail)
-            ->setTo($receiverEmail)
+            ->setTo((string) $receiverEmail)
             ->setContentType('text/html')
             ->setBody(
                 $this->templatingEngine->render(

--- a/src/Elcodi/Component/Core/Services/ManagerProvider.php
+++ b/src/Elcodi/Component/Core/Services/ManagerProvider.php
@@ -65,7 +65,7 @@ class ManagerProvider
     {
         return $this
             ->manager
-            ->getManagerForClass($entityNamespace);
+            ->getManagerForClass((string) $entityNamespace);
     }
 
     /**
@@ -83,7 +83,7 @@ class ManagerProvider
     {
         $entityNamespace = $this
             ->parameterBag
-            ->get($entityParameter);
+            ->get((string) $entityParameter);
 
         return $this->getManagerByEntityNamespace($entityNamespace);
     }

--- a/src/Elcodi/Component/Core/Services/MappingProvider.php
+++ b/src/Elcodi/Component/Core/Services/MappingProvider.php
@@ -60,8 +60,8 @@ class MappingProvider
      */
     public function getInterface($implementation)
     {
-        return isset($this->interfaces[$implementation])
-            ? $this->interfaces[$implementation]
+        return isset($this->interfaces[(string) $implementation])
+            ? $this->interfaces[(string) $implementation]
             : false;
     }
 
@@ -74,8 +74,8 @@ class MappingProvider
      */
     public function getImplementation($interface)
     {
-        return isset($this->implementations[$interface])
-            ? $this->implementations[$interface]
+        return isset($this->implementations[(string) $interface])
+            ? $this->implementations[(string) $interface]
             : false;
     }
 }

--- a/src/Elcodi/Component/Core/Services/RepositoryProvider.php
+++ b/src/Elcodi/Component/Core/Services/RepositoryProvider.php
@@ -64,8 +64,8 @@ class RepositoryProvider
     {
         return $this
             ->managerProvider
-            ->getManagerByEntityNamespace($entityNamespace)
-            ->getRepository($entityNamespace);
+            ->getManagerByEntityNamespace((string) $entityNamespace)
+            ->getRepository((string) $entityNamespace);
     }
 
     /**
@@ -83,7 +83,7 @@ class RepositoryProvider
     {
         $entityNamespace = $this
             ->parameterBag
-            ->get($entityParameter);
+            ->get((string) $entityParameter);
 
         return $this->getRepositoryByEntityNamespace($entityNamespace);
     }

--- a/src/Elcodi/Component/Coupon/Entity/Coupon.php
+++ b/src/Elcodi/Component/Coupon/Entity/Coupon.php
@@ -158,7 +158,7 @@ class Coupon implements CouponInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }
@@ -182,7 +182,7 @@ class Coupon implements CouponInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -206,7 +206,7 @@ class Coupon implements CouponInterface
      */
     public function setType($type)
     {
-        $this->type = $type;
+        $this->type = (int) $type;
 
         return $this;
     }
@@ -230,7 +230,7 @@ class Coupon implements CouponInterface
      */
     public function setEnforcement($enforcement)
     {
-        $this->enforcement = $enforcement;
+        $this->enforcement = (int) $enforcement;
 
         return $this;
     }
@@ -282,7 +282,7 @@ class Coupon implements CouponInterface
      */
     public function setDiscount($discount)
     {
-        $this->discount = $discount;
+        $this->discount = (int) $discount;
 
         return $this;
     }
@@ -334,7 +334,7 @@ class Coupon implements CouponInterface
      */
     public function setCount($count)
     {
-        $this->count = $count;
+        $this->count = (int) $count;
 
         return $this;
     }
@@ -358,7 +358,7 @@ class Coupon implements CouponInterface
      */
     public function setUsed($used)
     {
-        $this->used = $used;
+        $this->used = (int) $used;
 
         return $this;
     }
@@ -382,7 +382,7 @@ class Coupon implements CouponInterface
      */
     public function setPriority($priority)
     {
-        $this->priority = $priority;
+        $this->priority = (int) $priority;
 
         return $this;
     }
@@ -468,7 +468,7 @@ class Coupon implements CouponInterface
      */
     public function setStackable($stackable)
     {
-        $this->stackable = $stackable;
+        $this->stackable = (int) $stackable;
 
         return $this;
     }

--- a/src/Elcodi/Component/Currency/Entity/Currency.php
+++ b/src/Elcodi/Component/Currency/Entity/Currency.php
@@ -59,7 +59,7 @@ class Currency implements CurrencyInterface
      */
     public function setIso($iso)
     {
-        $this->iso = $iso;
+        $this->iso = (string) $iso;
 
         return $this;
     }
@@ -83,7 +83,7 @@ class Currency implements CurrencyInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -107,7 +107,7 @@ class Currency implements CurrencyInterface
      */
     public function setSymbol($symbol)
     {
-        $this->symbol = $symbol;
+        $this->symbol = (string) $symbol;
 
         return $this;
     }

--- a/src/Elcodi/Component/Currency/Entity/CurrencyExchangeRate.php
+++ b/src/Elcodi/Component/Currency/Entity/CurrencyExchangeRate.php
@@ -106,7 +106,7 @@ class CurrencyExchangeRate implements CurrencyExchangeRateInterface
      */
     public function setExchangeRate($exchangeRate)
     {
-        $this->exchangeRate = $exchangeRate;
+        $this->exchangeRate = (float) $exchangeRate;
 
         return $this;
     }

--- a/src/Elcodi/Component/Currency/Entity/Money.php
+++ b/src/Elcodi/Component/Currency/Entity/Money.php
@@ -63,7 +63,7 @@ class Money implements MoneyInterface
      */
     protected function __construct($amount, CurrencyInterface $currency)
     {
-        $this->amount = intval($amount);
+        $this->amount = (int) $amount;
         $this->currency = $currency;
 
         $this->wrappedMoney = new WrappedMoney(
@@ -177,7 +177,7 @@ class Money implements MoneyInterface
     {
         $wrappedMoney = $this
             ->wrappedMoney
-            ->multiply($factor);
+            ->multiply((float) $factor);
 
         return Money::create(
             $wrappedMoney->getAmount(),
@@ -263,6 +263,6 @@ class Money implements MoneyInterface
         $amount,
         CurrencyInterface $currency
     ) {
-        return new self($amount, $currency);
+        return new self((int) $amount, $currency);
     }
 }

--- a/src/Elcodi/Component/Currency/Populator/CurrencyExchangeRatesPopulator.php
+++ b/src/Elcodi/Component/Currency/Populator/CurrencyExchangeRatesPopulator.php
@@ -73,7 +73,7 @@ class CurrencyExchangeRatesPopulator
         $this->currencyExchangeRatesAdapter = $currencyExchangeRatesAdapter;
         $this->currencyExchangeRateObjectDirector = $currencyExchangeRateObjectDirector;
         $this->currencyRepository = $currencyRepository;
-        $this->defaultCurrency = $defaultCurrency;
+        $this->defaultCurrency = (string) $defaultCurrency;
     }
 
     /**

--- a/src/Elcodi/Component/Currency/Services/CurrencyConverter.php
+++ b/src/Elcodi/Component/Currency/Services/CurrencyConverter.php
@@ -98,7 +98,7 @@ class CurrencyConverter
         $amount
     ) {
         if ($currencyFrom->getIso() == $currencyTo->getIso()) {
-            return Money::create($amount, $currencyFrom);
+            return Money::create((int) $amount, $currencyFrom);
         }
 
         $exchangeRate = $this
@@ -109,7 +109,7 @@ class CurrencyConverter
             );
 
         return Money::create(
-            $amount * $exchangeRate,
+            ((int) $amount) * $exchangeRate,
             $currencyTo
         );
     }

--- a/src/Elcodi/Component/Currency/Services/CurrencyManager.php
+++ b/src/Elcodi/Component/Currency/Services/CurrencyManager.php
@@ -68,7 +68,7 @@ class CurrencyManager
     ) {
         $this->currencyRepository = $currencyRepository;
         $this->currencyExchangeRateRepository = $currencyExchangeRateRepository;
-        $this->exchangeCurrencyIso = $exchangeCurrencyIso;
+        $this->exchangeCurrencyIso = (string) $exchangeCurrencyIso;
     }
 
     /**

--- a/src/Elcodi/Component/Currency/Services/CurrencySessionManager.php
+++ b/src/Elcodi/Component/Currency/Services/CurrencySessionManager.php
@@ -49,7 +49,7 @@ class CurrencySessionManager
     public function __construct(SessionInterface $session, $sessionFieldName)
     {
         $this->session = $session;
-        $this->sessionFieldName = $sessionFieldName;
+        $this->sessionFieldName = (string) $sessionFieldName;
     }
 
     /**

--- a/src/Elcodi/Component/Currency/Services/ExchangeRateCalculator.php
+++ b/src/Elcodi/Component/Currency/Services/ExchangeRateCalculator.php
@@ -50,7 +50,7 @@ class ExchangeRateCalculator
         $defaultExchangeCurrencyIso
     ) {
         $this->currencyManager = $currencyManager;
-        $this->defaultExchangeCurrencyIso = $defaultExchangeCurrencyIso;
+        $this->defaultExchangeCurrencyIso = (string) $defaultExchangeCurrencyIso;
     }
 
     /**
@@ -93,6 +93,9 @@ class ExchangeRateCalculator
         $currencyFromIso,
         $currencyToIso
     ) {
+        $currencyFromIso = (string) $currencyFromIso;
+        $currencyToIso = (string) $currencyToIso;
+        
         $currencyExchangeRates = $this->currencyManager->getExchangeRateList();
 
         /**

--- a/src/Elcodi/Component/Currency/Services/MoneyPrinter.php
+++ b/src/Elcodi/Component/Currency/Services/MoneyPrinter.php
@@ -169,7 +169,7 @@ class MoneyPrinter
             ->get();
 
         $money = Money::create(
-            $value,
+            (int) $value,
             $targetCurrency
         );
 

--- a/src/Elcodi/Component/Currency/Wrapper/DefaultCurrencyWrapper.php
+++ b/src/Elcodi/Component/Currency/Wrapper/DefaultCurrencyWrapper.php
@@ -52,7 +52,7 @@ class DefaultCurrencyWrapper implements WrapperInterface
         $defaultCurrencyIsoCode
     ) {
         $this->currencyRepository = $currencyRepository;
-        $this->defaultCurrencyIsoCode = $defaultCurrencyIsoCode;
+        $this->defaultCurrencyIsoCode = (string) $defaultCurrencyIsoCode;
     }
 
     /**

--- a/src/Elcodi/Component/EntityTranslator/Entity/EntityTranslation.php
+++ b/src/Elcodi/Component/EntityTranslator/Entity/EntityTranslation.php
@@ -78,7 +78,7 @@ class EntityTranslation implements EntityTranslationInterface
      */
     public function setEntityId($entityId)
     {
-        $this->entityId = $entityId;
+        $this->entityId = (string) $entityId;
 
         return $this;
     }
@@ -102,7 +102,7 @@ class EntityTranslation implements EntityTranslationInterface
      */
     public function setEntityType($entityType)
     {
-        $this->entityType = $entityType;
+        $this->entityType = (string) $entityType;
 
         return $this;
     }
@@ -126,7 +126,7 @@ class EntityTranslation implements EntityTranslationInterface
      */
     public function setLocale($locale)
     {
-        $this->locale = $locale;
+        $this->locale = (string) $locale;
 
         return $this;
     }
@@ -150,7 +150,7 @@ class EntityTranslation implements EntityTranslationInterface
      */
     public function setTranslation($translation)
     {
-        $this->translation = $translation;
+        $this->translation = (string) $translation;
 
         return $this;
     }
@@ -174,7 +174,7 @@ class EntityTranslation implements EntityTranslationInterface
      */
     public function setEntityField($entityField)
     {
-        $this->entityField = $entityField;
+        $this->entityField = (string) $entityField;
 
         return $this;
     }

--- a/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
+++ b/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
@@ -74,14 +74,14 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
      *
      * Submitted data in plain mode
      */
-    private $submittedDataPlain;
+    private $submittedDataPlain = [];
 
     /**
      * @var array
      *
      * Local and temporary backup of translations
      */
-    private $translationsBackup;
+    private $translationsBackup = [];
 
     /**
      * Construct method
@@ -102,10 +102,8 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
         $this->entityTranslationProvider = $entityTranslationProvider;
         $this->translationConfiguration = $translationConfiguration;
         $this->locales = $locales;
-        $this->masterLocale = $masterLocale;
-        $this->fallback = $fallback;
-        $this->submittedDataPlain = [];
-        $this->translationsBackup = [];
+        $this->masterLocale = (string) $masterLocale;
+        $this->fallback = (bool) $fallback;
     }
 
     /**
@@ -328,9 +326,9 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
      */
     private function getNamespacesFromClass($namespace)
     {
-        $classStack = [$namespace];
-        $classStack = array_merge($classStack, class_parents($namespace));
-        $classStack = array_merge($classStack, class_implements($namespace));
+        $classStack = [(string) $namespace];
+        $classStack = array_merge($classStack, class_parents((string) $namespace));
+        $classStack = array_merge($classStack, class_implements((string) $namespace));
 
         return $classStack;
     }

--- a/src/Elcodi/Component/EntityTranslator/Factory/EntityTranslatorFactory.php
+++ b/src/Elcodi/Component/EntityTranslator/Factory/EntityTranslatorFactory.php
@@ -44,7 +44,7 @@ class EntityTranslatorFactory
         return new $this->entityNamespace(
             $entityTranslationProvider,
             $configuration,
-            $fallback
+            (bool) $fallback
         );
     }
 }

--- a/src/Elcodi/Component/EntityTranslator/Form/Type/TranslatableFieldType.php
+++ b/src/Elcodi/Component/EntityTranslator/Form/Type/TranslatableFieldType.php
@@ -122,12 +122,12 @@ class TranslatableFieldType extends AbstractType
         $this->entityTranslationProvider = $entityTranslationProvider;
         $this->formConfig = $formConfig;
         $this->entity = $entity;
-        $this->fieldName = $fieldName;
+        $this->fieldName = (string) $fieldName;
         $this->entityConfiguration = $entityConfiguration;
         $this->fieldConfiguration = $fieldConfiguration;
         $this->locales = $locales;
-        $this->masterLocale = $masterLocale;
-        $this->fallback = $fallback;
+        $this->masterLocale = (string) $masterLocale;
+        $this->fallback = (bool) $fallback;
     }
 
     /**
@@ -190,7 +190,7 @@ class TranslatableFieldType extends AbstractType
      */
     public function evaluateRequired($required, $locale)
     {
-        return (boolean) $required
+        return (bool) $required
             ? !$this->fallback || ($this->masterLocale === $locale)
             : false;
     }

--- a/src/Elcodi/Component/EntityTranslator/Services/CachedEntityTranslationProvider.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/CachedEntityTranslationProvider.php
@@ -53,7 +53,7 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
      *
      * Translations to be flushed
      */
-    protected $translationsToBeFlushed;
+    protected $translationsToBeFlushed = [];
 
     /**
      * Construct method
@@ -69,8 +69,7 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
     ) {
         $this->entityTranslatorProvider = $entityTranslationProvider;
         $this->entityTranslationRepository = $entityTranslationRepository;
-        $this->cachePrefix = $cachePrefix;
-        $this->translationsToBeFlushed = [];
+        $this->cachePrefix = (string) $cachePrefix;
     }
 
     /**
@@ -90,10 +89,10 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
         $locale
     ) {
         $cacheKey = $this->buildKey(
-            $entityType,
-            $entityId,
-            $entityField,
-            $locale
+            (string) $entityType,
+            (string) $entityId,
+            (string) $entityField,
+            (string) $locale
         );
 
         $translation = $this
@@ -104,10 +103,10 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
             $translation = $this
                 ->entityTranslatorProvider
                 ->getTranslation(
-                    $entityType,
-                    $entityId,
-                    $entityField,
-                    $locale
+                    (string) $entityType,
+                    (string) $entityId,
+                    (string) $entityField,
+                    (string) $locale
                 );
 
             $this
@@ -140,9 +139,9 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
         $locale
     ) {
         $cacheKey = $this->buildKey(
-            $entityType,
-            $entityId,
-            $entityField,
+            (string) $entityType,
+            (string) $entityId,
+            (string) $entityField,
             $locale
         );
 
@@ -156,11 +155,11 @@ class CachedEntityTranslationProvider extends AbstractCacheWrapper implements En
         return $this
             ->entityTranslatorProvider
             ->setTranslation(
-                $entityType,
-                $entityId,
-                $entityField,
+                (string) $entityType,
+                (string) $entityId,
+                (string) $entityField,
                 $translationValue,
-                $locale
+                (string) $locale
             );
     }
 

--- a/src/Elcodi/Component/EntityTranslator/Services/EntityTranslationProvider.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/EntityTranslationProvider.php
@@ -94,10 +94,10 @@ class EntityTranslationProvider implements EntityTranslationProviderInterface
         $translation = $this
             ->entityTranslationRepository
             ->findOneBy([
-                'entityType'  => $entityType,
-                'entityId'    => $entityId,
-                'entityField' => $entityField,
-                'locale'      => $locale,
+                'entityType'  => (string) $entityType,
+                'entityId'    => (string) $entityId,
+                'entityField' => (string) $entityField,
+                'locale'      => (string) $locale,
             ]);
 
         return $translation instanceof EntityTranslationInterface
@@ -126,20 +126,20 @@ class EntityTranslationProvider implements EntityTranslationProviderInterface
         $translation = $this
             ->entityTranslationRepository
             ->findOneBy([
-                'entityType'  => $entityType,
-                'entityId'    => $entityId,
-                'entityField' => $entityField,
-                'locale'      => $locale,
+                'entityType'  => (string) $entityType,
+                'entityId'    => (string) $entityId,
+                'entityField' => (string) $entityField,
+                'locale'      => (string) $locale,
             ]);
 
         if (!($translation instanceof EntityTranslationInterface)) {
             $translation = $this
                 ->entityTranslationFactory
                 ->create()
-                ->setEntityType($entityType)
-                ->setEntityId($entityId)
-                ->setEntityField($entityField)
-                ->setLocale($locale);
+                ->setEntityType((string) $entityType)
+                ->setEntityId((string) $entityId)
+                ->setEntityField((string) $entityField)
+                ->setLocale((string) $locale);
 
             $this
                 ->entityTranslationObjectManager

--- a/src/Elcodi/Component/EntityTranslator/Services/EntityTranslator.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/EntityTranslator.php
@@ -64,7 +64,7 @@ class EntityTranslator implements EntityTranslatorInterface
     ) {
         $this->entityTranslationProvider = $entityTranslationProvider;
         $this->configuration = $configuration;
-        $this->fallback = $fallback;
+        $this->fallback = (bool) $fallback;
     }
 
     /**
@@ -96,7 +96,7 @@ class EntityTranslator implements EntityTranslatorInterface
                         $configuration['alias'],
                         $entityId,
                         $fieldName,
-                        $locale
+                        (string) $locale
                     );
 
                 if ($translation || !$this->fallback) {
@@ -173,9 +173,9 @@ class EntityTranslator implements EntityTranslatorInterface
      */
     protected function getNamespacesFromClass($namespace)
     {
-        $classStack = [$namespace];
-        $classStack = array_merge($classStack, class_parents($namespace));
-        $classStack = array_merge($classStack, class_implements($namespace));
+        $classStack = [(string) $namespace];
+        $classStack = array_merge($classStack, class_parents((string) $namespace));
+        $classStack = array_merge($classStack, class_implements((string) $namespace));
 
         return $classStack;
     }

--- a/src/Elcodi/Component/EntityTranslator/Services/EntityTranslatorBuilder.php
+++ b/src/Elcodi/Component/EntityTranslator/Services/EntityTranslatorBuilder.php
@@ -93,7 +93,7 @@ class EntityTranslatorBuilder
         $this->entityTranslationProvider = $entityTranslationProvider;
         $this->entityTranslatorFactory = $entityTranslatorFactory;
         $this->configuration = $configuration;
-        $this->fallback = $fallback;
+        $this->fallback = (bool) $fallback;
     }
 
     /**

--- a/src/Elcodi/Component/Geo/Adapter/LocationPopulator/GeonamesLocationPopulatorAdapter.php
+++ b/src/Elcodi/Component/Geo/Adapter/LocationPopulator/GeonamesLocationPopulatorAdapter.php
@@ -124,7 +124,7 @@ class GeonamesLocationPopulatorAdapter implements LocationPopulatorAdapterInterf
     {
         $extractedFiles = $this
             ->extractor
-            ->extractFromFile($tempname)
+            ->extractFromFile((string) $tempname)
             ->files()
             ->notName('readme.txt')
             ->getIterator();
@@ -149,7 +149,7 @@ class GeonamesLocationPopulatorAdapter implements LocationPopulatorAdapterInterf
         $countryCode,
         $pathname
     ) {
-        $countryInfo = $this->getCountryInfo($countryCode);
+        $countryInfo = $this->getCountryInfo((string) $countryCode);
         $country = $this
             ->locationBuilder
             ->addLocation(
@@ -224,7 +224,7 @@ class GeonamesLocationPopulatorAdapter implements LocationPopulatorAdapterInterf
         $config = new LexerConfig();
         $config->setDelimiter("\t");
         $lexer = new Lexer($config);
-        $lexer->parse($pathname, $interpreter);
+        $lexer->parse((string) $pathname, $interpreter);
 
         return $country;
     }
@@ -501,6 +501,6 @@ class GeonamesLocationPopulatorAdapter implements LocationPopulatorAdapterInterf
             "ZW" => ["ZW", "Zimbabwe"],
         ];
 
-        return $countryNames[$countryCode];
+        return $countryNames[(string) $countryCode];
     }
 }

--- a/src/Elcodi/Component/Geo/Adapter/LocationProvider/LocationApiProviderAdapter.php
+++ b/src/Elcodi/Component/Geo/Adapter/LocationProvider/LocationApiProviderAdapter.php
@@ -77,7 +77,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
         $this->locationDataFactory = $locationDataFactory;
         $this->urlGeneratorInterface = $urlGeneratorInterface;
         $this->apiUrls = $apiUrls;
-        $this->host = $host;
+        $this->host = (string) $host;
     }
 
     /**
@@ -109,7 +109,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
     {
         $url = $this->buildUrlByMethodName(
             'getGetChildrenUrl',
-            ['id' => $id]
+            ['id' => (string) $id]
         );
 
         return $this
@@ -129,7 +129,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
     {
         $url = $this->buildUrlByMethodName(
             'getGetParentsUrl',
-            ['id' => $id]
+            ['id' => (string) $id]
         );
 
         return $this
@@ -149,7 +149,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
     {
         $url = $this->buildUrlByMethodName(
             'getGetLocationUrl',
-            ['id' => $id]
+            ['id' => (string) $id]
         );
 
         return $this
@@ -170,7 +170,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
     {
         $url = $this->buildUrlByMethodName(
             'getGetHierarchyUrl',
-            ['id' => $id]
+            ['id' => (string) $id]
         );
 
         return $this
@@ -193,7 +193,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
         $url = $this->buildUrlByMethodName(
             'getInUrl',
             [
-                'id'  => $id,
+                'id'  => (string) $id,
                 'ids' => implode(',', $ids),
             ]
         );
@@ -246,7 +246,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
                 $this
                     ->urlGeneratorInterface
                     ->generate(
-                        $url,
+                        (string) $url,
                         $parameters,
                         UrlGeneratorInterface::ABSOLUTE_PATH
                     ), '/'
@@ -266,7 +266,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
         return $this
             ->urlGeneratorInterface
             ->generate(
-                $url,
+                (string) $url,
                 $parameters,
                 UrlGeneratorInterface::ABSOLUTE_URL
             );
@@ -289,7 +289,7 @@ class LocationApiProviderAdapter implements LocationProviderAdapterInterface
                 'timeout' => 5,
             ],
         ]);
-        $response = $client->get($url);
+        $response = $client->get((string) $url);
         $responseStatusCode = $response->getStatusCode();
 
         if (404 == $responseStatusCode) {

--- a/src/Elcodi/Component/Geo/Adapter/LocationProvider/LocationServiceProviderAdapter.php
+++ b/src/Elcodi/Component/Geo/Adapter/LocationProvider/LocationServiceProviderAdapter.php
@@ -87,7 +87,7 @@ class LocationServiceProviderAdapter implements LocationProviderAdapterInterface
         $location = $this
             ->locationRepository
             ->findOneBy([
-                'id' => $id,
+                'id' => (string) $id,
             ]);
 
         if (empty($location)) {
@@ -113,7 +113,7 @@ class LocationServiceProviderAdapter implements LocationProviderAdapterInterface
         $location = $this
             ->locationRepository
             ->findOneBy([
-                'id' => $id,
+                'id' => (string) $id,
             ]);
 
         if (empty($location)) {
@@ -142,7 +142,7 @@ class LocationServiceProviderAdapter implements LocationProviderAdapterInterface
         $location = $this
             ->locationRepository
             ->findOneBy([
-                'id' => $id,
+                'id' => (string) $id,
             ]);
 
         if (!($location instanceof LocationInterface)) {
@@ -167,7 +167,7 @@ class LocationServiceProviderAdapter implements LocationProviderAdapterInterface
         $location = $this
             ->locationRepository
             ->findOneBy([
-                'id' => $id,
+                'id' => (string) $id,
             ]);
 
         if (empty($location)) {
@@ -196,7 +196,7 @@ class LocationServiceProviderAdapter implements LocationProviderAdapterInterface
      */
     public function in($id, array $ids)
     {
-        $allParents = $this->getHierarchy($id);
+        $allParents = $this->getHierarchy((string) $id);
 
         /**
          * To increase the efficiency, we can index the results of the parent

--- a/src/Elcodi/Component/Geo/Command/Abstracts/AbstractLocationCommand.php
+++ b/src/Elcodi/Component/Geo/Command/Abstracts/AbstractLocationCommand.php
@@ -88,7 +88,7 @@ class AbstractLocationCommand extends AbstractElcodiCommand
         $country = $this
             ->locationDirector
             ->findOneBy([
-                'code' => $countryCode,
+                'code' => (string) $countryCode,
             ]);
 
         if ($country instanceof LocationInterface) {
@@ -97,7 +97,7 @@ class AbstractLocationCommand extends AbstractElcodiCommand
                 !$this->confirmRemoval(
                     $input,
                     $output,
-                    $countryCode,
+                    (string) $countryCode,
                     $output
                 )
             ) {

--- a/src/Elcodi/Component/Geo/Entity/Address.php
+++ b/src/Elcodi/Component/Geo/Entity/Address.php
@@ -108,7 +108,7 @@ class Address implements AddressInterface
      */
     public function setAddress($address)
     {
-        $this->address = $address;
+        $this->address = (string) $address;
 
         return $this;
     }
@@ -132,7 +132,7 @@ class Address implements AddressInterface
      */
     public function setAddressMore($addressMore)
     {
-        $this->addressMore = $addressMore;
+        $this->addressMore = (string) $addressMore;
 
         return $this;
     }
@@ -156,7 +156,7 @@ class Address implements AddressInterface
      */
     public function setComments($comments)
     {
-        $this->comments = $comments;
+        $this->comments = (string) $comments;
 
         return $this;
     }
@@ -180,7 +180,7 @@ class Address implements AddressInterface
      */
     public function setMobile($mobile)
     {
-        $this->mobile = $mobile;
+        $this->mobile = (string) $mobile;
 
         return $this;
     }
@@ -204,7 +204,7 @@ class Address implements AddressInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -228,7 +228,7 @@ class Address implements AddressInterface
      */
     public function setPhone($phone)
     {
-        $this->phone = $phone;
+        $this->phone = (string) $phone;
 
         return $this;
     }
@@ -252,7 +252,7 @@ class Address implements AddressInterface
      */
     public function setRecipientName($recipientName)
     {
-        $this->recipientName = $recipientName;
+        $this->recipientName = (string) $recipientName;
 
         return $this;
     }
@@ -276,7 +276,7 @@ class Address implements AddressInterface
      */
     public function setRecipientSurname($recipientSurname)
     {
-        $this->recipientSurname = $recipientSurname;
+        $this->recipientSurname = (string) $recipientSurname;
 
         return $this;
     }
@@ -300,7 +300,7 @@ class Address implements AddressInterface
      */
     public function setCity($city)
     {
-        $this->city = $city;
+        $this->city = (string) $city;
 
         return $this;
     }
@@ -324,7 +324,7 @@ class Address implements AddressInterface
      */
     public function setPostalcode($postalCode)
     {
-        $this->postalCode = $postalCode;
+        $this->postalCode = (string) $postalCode;
 
         return $this;
     }

--- a/src/Elcodi/Component/Geo/Entity/Location.php
+++ b/src/Elcodi/Component/Geo/Entity/Location.php
@@ -83,7 +83,7 @@ class Location implements LocationInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -107,7 +107,7 @@ class Location implements LocationInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }
@@ -131,7 +131,7 @@ class Location implements LocationInterface
      */
     public function setType($type)
     {
-        $this->type = $type;
+        $this->type = (string) $type;
 
         return $this;
     }

--- a/src/Elcodi/Component/Geo/Factory/LocationDataFactory.php
+++ b/src/Elcodi/Component/Geo/Factory/LocationDataFactory.php
@@ -41,10 +41,10 @@ class LocationDataFactory
         $locationType
     ) {
         return new LocationData(
-            $locationId,
-            $locationName,
-            $locationCode,
-            $locationType
+            (string) $locationId,
+            (string) $locationName,
+            (string) $locationCode,
+            (string) $locationType
         );
     }
 }

--- a/src/Elcodi/Component/Geo/Services/LocationBuilder.php
+++ b/src/Elcodi/Component/Geo/Services/LocationBuilder.php
@@ -69,15 +69,17 @@ class LocationBuilder
         $type,
         LocationInterface $parent = null
     ) {
+        $id = (string) $id;
+        
         $location = isset($this->locations[$id])
             ? $this->locations[$id]
             : $this
                 ->locationFactory
                 ->create()
                 ->setId($id)
-                ->setName($name)
-                ->setCode($code)
-                ->setType($type);
+                ->setName((string) $name)
+                ->setCode((string) $code)
+                ->setType((string) $type);
 
         if ($parent instanceof LocationInterface) {
             $location->addParent($parent);

--- a/src/Elcodi/Component/Geo/Services/LocationLoader.php
+++ b/src/Elcodi/Component/Geo/Services/LocationLoader.php
@@ -65,7 +65,7 @@ class LocationLoader
     {
         $content = $this
             ->locationLoaderAdapter
-            ->getSqlForCountry($countryIso);
+            ->getSqlForCountry((string) $countryIso);
 
         $statement = $this
             ->locationEntityManager

--- a/src/Elcodi/Component/Geo/Services/LocationPopulator.php
+++ b/src/Elcodi/Component/Geo/Services/LocationPopulator.php
@@ -65,7 +65,7 @@ class LocationPopulator
     {
         $rootLocation = $this
             ->locationPopulatorAdapter
-            ->populate($countryCode);
+            ->populate((string) $countryCode);
 
         $this
             ->locationObjectManager

--- a/src/Elcodi/Component/Geo/ValueObject/ApiUrls.php
+++ b/src/Elcodi/Component/Geo/ValueObject/ApiUrls.php
@@ -82,12 +82,12 @@ class ApiUrls
         $getHierarchyUrl,
         $inUrl
     ) {
-        $this->getRootLocationsUrl = $getRootLocationsUrl;
-        $this->getChildrenUrl = $getChildrenUrl;
-        $this->getParentsUrl = $getParentsUrl;
-        $this->getLocationUrl = $getLocationUrl;
-        $this->getHierarchyUrl = $getHierarchyUrl;
-        $this->inUrl = $inUrl;
+        $this->getRootLocationsUrl = (string) $getRootLocationsUrl;
+        $this->getChildrenUrl = (string) $getChildrenUrl;
+        $this->getParentsUrl = (string) $getParentsUrl;
+        $this->getLocationUrl = (string) $getLocationUrl;
+        $this->getHierarchyUrl = (string) $getHierarchyUrl;
+        $this->inUrl = (string) $inUrl;
     }
 
     /**

--- a/src/Elcodi/Component/Geo/ValueObject/LocationData.php
+++ b/src/Elcodi/Component/Geo/ValueObject/LocationData.php
@@ -66,10 +66,10 @@ class LocationData
         $code,
         $type
     ) {
-        $this->id   = $id;
-        $this->name = $name;
-        $this->code = $code;
-        $this->type = $type;
+        $this->id   = (string) $id;
+        $this->name = (string) $name;
+        $this->code = (string) $code;
+        $this->type = (string) $type;
     }
 
     /**

--- a/src/Elcodi/Component/Language/Entity/Language.php
+++ b/src/Elcodi/Component/Language/Entity/Language.php
@@ -52,7 +52,7 @@ class Language implements LanguageInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -76,7 +76,7 @@ class Language implements LanguageInterface
      */
     public function setIso($iso)
     {
-        $this->iso = $iso;
+        $this->iso = (string) $iso;
 
         return $this;
     }

--- a/src/Elcodi/Component/Language/Services/LocaleManager.php
+++ b/src/Elcodi/Component/Language/Services/LocaleManager.php
@@ -77,7 +77,7 @@ class LocaleManager
         $localeTranslationAssociations = []
     ) {
         $this->locale = $locale;
-        $this->encoding = $encoding;
+        $this->encoding = (string) $encoding;
         $this->localeCountryAssociations = $localeCountryAssociations;
         $this->localeTranslationAssociations = $localeTranslationAssociations;
     }
@@ -151,7 +151,7 @@ class LocaleManager
      */
     public function setEncoding($encoding)
     {
-        $this->encoding = $encoding;
+        $this->encoding = (string) $encoding;
         $this->initialize();
 
         return $this;

--- a/src/Elcodi/Component/Language/Services/LocaleProvider.php
+++ b/src/Elcodi/Component/Language/Services/LocaleProvider.php
@@ -52,7 +52,7 @@ class LocaleProvider
         $defaultLocale
     ) {
         $this->requestStack = $requestStack;
-        $this->defaultLocale = $defaultLocale;
+        $this->defaultLocale = (string) $defaultLocale;
     }
 
     /**

--- a/src/Elcodi/Component/Media/Adapter/Resizer/ImageMagickResizeAdapter.php
+++ b/src/Elcodi/Component/Media/Adapter/Resizer/ImageMagickResizeAdapter.php
@@ -50,8 +50,8 @@ class ImageMagickResizeAdapter implements ResizeAdapterInterface
      */
     public function __construct($imageConverterBin, $profile)
     {
-        $this->imageConverterBin = $imageConverterBin;
-        $this->profile = $profile;
+        $this->imageConverterBin = (string) $imageConverterBin;
+        $this->profile = (string) $profile;
     }
 
     /**
@@ -73,13 +73,13 @@ class ImageMagickResizeAdapter implements ResizeAdapterInterface
         $type = ElcodiMediaImageResizeTypes::FORCE_MEASURES
     ) {
         if (ElcodiMediaImageResizeTypes::NO_RESIZE === $type) {
-            return $imageData;
+            return (string) $imageData;
         }
 
         $originalFile = new File(tempnam(sys_get_temp_dir(), '_original'));
         $resizedFile = new File(tempnam(sys_get_temp_dir(), '_resize'));
 
-        file_put_contents($originalFile, $imageData);
+        file_put_contents($originalFile, (string) $imageData);
 
         //ImageMagick params
         $pb = new ProcessBuilder();

--- a/src/Elcodi/Component/Media/Adapter/Resizer/Model/Dimensions.php
+++ b/src/Elcodi/Component/Media/Adapter/Resizer/Model/Dimensions.php
@@ -131,14 +131,14 @@ class Dimensions
         $newHeight,
         $type
     ) {
-        $this->originalWidth = $originalWidth;
-        $this->originalHeight = $originalHeight;
+        $this->originalWidth = (float) $originalWidth;
+        $this->originalHeight = (float) $originalHeight;
         $this->originalAspectRatio = $originalWidth / $originalHeight;
 
         $this->resolveDimensions(
-            $newWidth,
-            $newHeight,
-            $type
+            (float) $newWidth,
+            (float) $newHeight,
+            (int) $type
         );
     }
 
@@ -156,6 +156,10 @@ class Dimensions
         $newHeight,
         $type
     ) {
+        $newWidth = (float) $newWidth;
+        $newHeight = (float) $newHeight;
+        $type = (int) $type;
+
         $this->dstX = 0;
         $this->dstY = 0;
         $this->dstWidth = $newWidth;
@@ -379,11 +383,11 @@ class Dimensions
         $type
     ) {
         return new self(
-            $originalWidth,
-            $originalHeight,
-            $newWidth,
-            $newHeight,
-            $type
+            (float) $originalWidth,
+            (float) $originalHeight,
+            (float) $newWidth,
+            (float) $newHeight,
+            (int) $type
         );
     }
 }

--- a/src/Elcodi/Component/Media/Controller/ImageResizeController.php
+++ b/src/Elcodi/Component/Media/Controller/ImageResizeController.php
@@ -97,8 +97,8 @@ class ImageResizeController
         $this->imageRepository = $imageRepository;
         $this->imageManager = $imageManager;
         $this->imageEtagTransformer = $imageEtagTransformer;
-        $this->maxAge = $maxAge;
-        $this->sharedMaxAge = $sharedMaxAge;
+        $this->maxAge = (int) $maxAge;
+        $this->sharedMaxAge = (int) $sharedMaxAge;
     }
 
     /**

--- a/src/Elcodi/Component/Media/Controller/ImageUploadController.php
+++ b/src/Elcodi/Component/Media/Controller/ImageUploadController.php
@@ -93,9 +93,9 @@ class ImageUploadController
         $this->requestStack = $requestStack;
         $this->imageUploader = $imageUploader;
         $this->router = $router;
-        $this->uploadFieldName = $uploadFieldName;
-        $this->viewImageRouteName = $viewImageRouteName;
-        $this->resizeImageRouteName = $resizeImageRouteName;
+        $this->uploadFieldName = (string) $uploadFieldName;
+        $this->viewImageRouteName = (string) $viewImageRouteName;
+        $this->resizeImageRouteName = (string) $resizeImageRouteName;
     }
 
     /**

--- a/src/Elcodi/Component/Media/Entity/Abstracts/Media.php
+++ b/src/Elcodi/Component/Media/Entity/Abstracts/Media.php
@@ -59,7 +59,7 @@ abstract class Media implements MediaInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }

--- a/src/Elcodi/Component/Media/Entity/File.php
+++ b/src/Elcodi/Component/Media/Entity/File.php
@@ -69,7 +69,7 @@ class File extends Media implements FileInterface
      */
     public function setPath($path)
     {
-        $this->path = $path;
+        $this->path = (string) $path;
 
         return $this;
     }
@@ -93,7 +93,7 @@ class File extends Media implements FileInterface
      */
     public function setContentType($contentType)
     {
-        $this->contentType = $contentType;
+        $this->contentType = (string) $contentType;
 
         return $this;
     }
@@ -117,7 +117,7 @@ class File extends Media implements FileInterface
      */
     public function setExtension($extension)
     {
-        $this->extension = $extension;
+        $this->extension = (string) $extension;
 
         return $this;
     }
@@ -141,7 +141,7 @@ class File extends Media implements FileInterface
      */
     public function setSize($size)
     {
-        $this->size = $size;
+        $this->size = (int) $size;
 
         return $this;
     }
@@ -165,7 +165,7 @@ class File extends Media implements FileInterface
      */
     public function setContent($content)
     {
-        $this->content = $content;
+        $this->content = (string) $content;
 
         return $this;
     }

--- a/src/Elcodi/Component/Media/Entity/Image.php
+++ b/src/Elcodi/Component/Media/Entity/Image.php
@@ -47,7 +47,7 @@ class Image extends File implements ImageInterface
      */
     public function setWidth($width)
     {
-        $this->width = $width;
+        $this->width = (int) $width;
 
         return $this;
     }
@@ -71,7 +71,7 @@ class Image extends File implements ImageInterface
      */
     public function setHeight($height)
     {
-        $this->height = $height;
+        $this->height = (int) $height;
 
         return $this;
     }

--- a/src/Elcodi/Component/Media/Services/ImageManager.php
+++ b/src/Elcodi/Component/Media/Services/ImageManager.php
@@ -156,7 +156,7 @@ class ImageManager
 
         $resizedImageData = $this
             ->resizeAdapter
-            ->resize($imageData, $height, $width, $type);
+            ->resize($imageData, (int) $height, (int) $width, (int) $type);
 
         /**
          * We need to physically store the new resized

--- a/src/Elcodi/Component/Media/Twig/ImageExtension.php
+++ b/src/Elcodi/Component/Media/Twig/ImageExtension.php
@@ -91,9 +91,9 @@ class ImageExtension extends Twig_Extension
 
     ) {
         $this->router = $router;
-        $this->imageResizeControllerRouteName = $imageResizeControllerRouteName;
-        $this->imageViewControllerRouteName = $imageViewControllerRouteName;
-        $this->generatedRouteHost = $generatedRouteHost;
+        $this->imageResizeControllerRouteName = (string) $imageResizeControllerRouteName;
+        $this->imageViewControllerRouteName = (string) $imageViewControllerRouteName;
+        $this->generatedRouteHost = (string) $generatedRouteHost;
 
         /**
          * Routing context will change when a hostname is
@@ -163,7 +163,7 @@ class ImageExtension extends Twig_Extension
     {
         $this->prepareRouterContext();
 
-        $routeReferenceType = $this->getReferenceType($absoluteUrl);
+        $routeReferenceType = $this->getReferenceType((bool) $absoluteUrl);
 
         $generatedRoute = $this
             ->router
@@ -236,7 +236,7 @@ class ImageExtension extends Twig_Extension
      */
     private function getReferenceType($absoluteUrlOption = false)
     {
-        return ($this->generatedRouteHost || $absoluteUrlOption)
+        return ($this->generatedRouteHost || ((bool) $absoluteUrlOption))
             ? UrlGeneratorInterface::ABSOLUTE_URL
             : UrlGeneratorInterface::ABSOLUTE_PATH;
     }

--- a/src/Elcodi/Component/Menu/Entity/Menu/Menu.php
+++ b/src/Elcodi/Component/Menu/Entity/Menu/Menu.php
@@ -54,7 +54,7 @@ class Menu implements MenuInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }
@@ -78,7 +78,7 @@ class Menu implements MenuInterface
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }

--- a/src/Elcodi/Component/Menu/Entity/Menu/Node.php
+++ b/src/Elcodi/Component/Menu/Entity/Menu/Node.php
@@ -99,7 +99,7 @@ class Node implements NodeInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }
@@ -113,7 +113,7 @@ class Node implements NodeInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -139,7 +139,7 @@ class Node implements NodeInterface
      */
     public function setUrl($url)
     {
-        $this->url = $url;
+        $this->url = (string) $url;
 
         return $this;
     }
@@ -188,7 +188,7 @@ class Node implements NodeInterface
     public function addActiveUrl($activeUrl)
     {
         $activeUrls = json_decode($this->activeUrls, true);
-        $activeUrls[] = $activeUrl;
+        $activeUrls[] = (string) $activeUrl;
         $this->activeUrls = json_encode($activeUrls);
 
         return $this;
@@ -204,7 +204,7 @@ class Node implements NodeInterface
     public function removeActiveUrl($activeUrl)
     {
         $activeUrls = json_decode($this->activeUrls, true);
-        $positionFound = array_search($activeUrl, $activeUrls);
+        $positionFound = array_search((string) $activeUrl, $activeUrls);
         if ($positionFound) {
             unset($activeUrls[$positionFound]);
             $this->activeUrls = json_encode($activeUrls);
@@ -232,7 +232,7 @@ class Node implements NodeInterface
      */
     public function setTag($tag)
     {
-        $this->tag = $tag;
+        $this->tag = (string) $tag;
 
         return $this;
     }
@@ -256,7 +256,7 @@ class Node implements NodeInterface
      */
     public function setPriority($priority)
     {
-        $this->priority = $priority;
+        $this->priority = (int) $priority;
 
         return $this;
     }
@@ -274,8 +274,8 @@ class Node implements NodeInterface
     public function isActive($currentUrl)
     {
         return
-            $currentUrl == $this->url ||
-            in_array($currentUrl, $this->getActiveUrls());
+            ((string) $currentUrl) == $this->url ||
+            in_array((string) $currentUrl, $this->getActiveUrls());
     }
 
     /**
@@ -290,6 +290,8 @@ class Node implements NodeInterface
      */
     public function isExpanded($currentUrl)
     {
+        $currentUrl = (string) $currentUrl;
+
         return $this
             ->subnodes
             ->exists(function ($_, NodeInterface $node) use ($currentUrl) {
@@ -309,7 +311,7 @@ class Node implements NodeInterface
      */
     public function setWarnings($warnings)
     {
-        $this->warnings = $warnings;
+        $this->warnings = (int) $warnings;
 
         return $this;
     }

--- a/src/Elcodi/Component/Menu/Entity/Menu/Traits/SubnodesTrait.php
+++ b/src/Elcodi/Component/Menu/Entity/Menu/Traits/SubnodesTrait.php
@@ -129,7 +129,7 @@ trait SubnodesTrait
             }
 
             if ($inDepth) {
-                $subnode = $subnode->findSubnodeByName($subnodeName, $inDepth);
+                $subnode = $subnode->findSubnodeByName($subnodeName, (bool) $inDepth);
 
                 if ($subnode instanceof \Elcodi\Component\Menu\Entity\Menu\Interfaces\NodeInterface) {
                     return $subnode;

--- a/src/Elcodi/Component/Menu/Services/Abstracts/AbstractMenuModifier.php
+++ b/src/Elcodi/Component/Menu/Services/Abstracts/AbstractMenuModifier.php
@@ -96,7 +96,7 @@ abstract class AbstractMenuModifier
 
         $this->addElementByStage(
             $element,
-            $stage
+            (string) $stage
         );
 
         $this->priorities[$elementId] = $priority;
@@ -116,12 +116,12 @@ abstract class AbstractMenuModifier
         $menuCode,
         $stage
     ) {
-        $elementsByMenuCode = isset($this->elementsStoredByMenuCode[$menuCode])
-            ? $this->elementsStoredByMenuCode[$menuCode]
+        $elementsByMenuCode = isset($this->elementsStoredByMenuCode[(string) $menuCode])
+            ? $this->elementsStoredByMenuCode[(string) $menuCode]
             : [];
 
-        $elementsByStage = isset($this->elementsStoredByStage[$stage])
-            ? $this->elementsStoredByStage[$stage]
+        $elementsByStage = isset($this->elementsStoredByStage[(string) $stage])
+            ? $this->elementsStoredByStage[(string) $stage]
             : [];
 
         $elements = array_values(
@@ -156,12 +156,12 @@ abstract class AbstractMenuModifier
         $element,
         $menuCode
     ) {
-        if (!isset($this->elementsStoredByMenuCode[$menuCode])) {
-            $this->elementsStoredByMenuCode[$menuCode] = [];
+        if (!isset($this->elementsStoredByMenuCode[(string) $menuCode])) {
+            $this->elementsStoredByMenuCode[(string) $menuCode] = [];
         }
 
         $elementId = spl_object_hash($element);
-        $this->elementsStoredByMenuCode[$menuCode][$elementId] = $element;
+        $this->elementsStoredByMenuCode[(string) $menuCode][$elementId] = $element;
 
         return $this;
     }
@@ -178,12 +178,12 @@ abstract class AbstractMenuModifier
         $element,
         $stage
     ) {
-        if (!isset($this->elementsStoredByStage[$stage])) {
-            $this->elementsStoredByStage[$stage] = [];
+        if (!isset($this->elementsStoredByStage[(string) $stage])) {
+            $this->elementsStoredByStage[(string) $stage] = [];
         }
 
         $elementId = spl_object_hash($element);
-        $this->elementsStoredByStage[$stage][$elementId] = $element;
+        $this->elementsStoredByStage[(string) $stage][$elementId] = $element;
 
         return $this;
     }

--- a/src/Elcodi/Component/Menu/Services/MenuBuilder.php
+++ b/src/Elcodi/Component/Menu/Services/MenuBuilder.php
@@ -46,8 +46,8 @@ class MenuBuilder extends AbstractMenuModifier implements MenuChangerInterface
         $this->addElement(
             $menuBuilder,
             $menus,
-            $stage,
-            $priority
+            (string) $stage,
+            (int) $priority
         );
 
         return $this;
@@ -67,7 +67,7 @@ class MenuBuilder extends AbstractMenuModifier implements MenuChangerInterface
     ) {
         $menuBuilders = $this->getElementsByMenuCodeAndStage(
             $menu->getCode(),
-            $stage
+            (string) $stage
         );
 
         /**

--- a/src/Elcodi/Component/Menu/Services/MenuFilterer.php
+++ b/src/Elcodi/Component/Menu/Services/MenuFilterer.php
@@ -49,8 +49,8 @@ class MenuFilterer extends AbstractMenuModifier implements MenuChangerInterface
         $this->addElement(
             $menuFilter,
             $menus,
-            $stage,
-            $priority
+            (string) $stage,
+            (int) $priority
         );
 
         return $this;
@@ -72,7 +72,7 @@ class MenuFilterer extends AbstractMenuModifier implements MenuChangerInterface
             $this->applyFiltersToMenuNodes(
                 $menu->getSubnodes(),
                 $menu->getCode(),
-                $stage
+                (string) $stage
             )
         );
 
@@ -97,15 +97,15 @@ class MenuFilterer extends AbstractMenuModifier implements MenuChangerInterface
 
             if ($this->applyFiltersToMenuNode(
                 $menuNode,
-                $menuCode,
-                $stage
+                (string) $menuCode,
+                (string) $stage
             )
             ) {
                 $menuNode->setSubnodes(
                     $this->applyFiltersToMenuNodes(
                         $menuNode->getSubnodes(),
-                        $menuCode,
-                        $stage
+                        (string) $menuCode,
+                        (string) $stage
                     )
                 );
 
@@ -131,8 +131,8 @@ class MenuFilterer extends AbstractMenuModifier implements MenuChangerInterface
         $stage
     ) {
         $menuFilters = $this->getElementsByMenuCodeAndStage(
-            $menuCode,
-            $stage
+            (string) $menuCode,
+            (string) $stage
         );
 
         return array_reduce(

--- a/src/Elcodi/Component/Menu/Services/MenuManager.php
+++ b/src/Elcodi/Component/Menu/Services/MenuManager.php
@@ -50,7 +50,7 @@ class MenuManager extends AbstractCacheWrapper
      *
      * Menu changers
      */
-    private $menuChangers;
+    private $menuChangers = [];
 
     /**
      * @var string
@@ -64,7 +64,7 @@ class MenuManager extends AbstractCacheWrapper
      *
      * menus
      */
-    private $menus;
+    private $menus = [];
 
     /**
      * Construct method
@@ -80,9 +80,7 @@ class MenuManager extends AbstractCacheWrapper
     ) {
         $this->menuRepository = $menuRepository;
         $this->menuObjectManager = $menuObjectManager;
-        $this->key = $key;
-        $this->menuChangers = [];
-        $this->menus = [];
+        $this->key = (string) $key;
     }
 
     /**
@@ -114,6 +112,8 @@ class MenuManager extends AbstractCacheWrapper
      */
     public function loadMenuByCode($menuCode)
     {
+        $menuCode = (string) $menuCode;
+
         $menu = $this->loadFromMemory($menuCode);
         if (!($menu instanceof MenuInterface)) {
 
@@ -156,7 +156,7 @@ class MenuManager extends AbstractCacheWrapper
      */
     public function removeFromCache($menuCode)
     {
-        $key = $this->getCacheKey($menuCode);
+        $key = $this->getCacheKey((string) $menuCode);
         $this
             ->cache
             ->delete($key);
@@ -173,8 +173,8 @@ class MenuManager extends AbstractCacheWrapper
      */
     private function loadFromMemory($menuCode)
     {
-        return isset($this->menus[$menuCode])
-            ? $this->menus[$menuCode]
+        return isset($this->menus[(string) $menuCode])
+            ? $this->menus[(string) $menuCode]
             : null;
     }
 
@@ -203,7 +203,7 @@ class MenuManager extends AbstractCacheWrapper
     {
         $encoded = (string) $this
             ->cache
-            ->fetch($key);
+            ->fetch((string) $key);
 
         try {
             return is_string($encoded)
@@ -234,7 +234,7 @@ class MenuManager extends AbstractCacheWrapper
 
         $this
             ->cache
-            ->save($key, $encodedMenu);
+            ->save((string) $key, $encodedMenu);
 
         return $this;
     }
@@ -253,7 +253,7 @@ class MenuManager extends AbstractCacheWrapper
         $menu = $this
             ->menuRepository
             ->findOneBy([
-                'code'    => $menuCode,
+                'code'    => (string) $menuCode,
                 'enabled' => true,
             ]);
 
@@ -287,7 +287,7 @@ class MenuManager extends AbstractCacheWrapper
             $menuChanger
                 ->applyChange(
                     $menu,
-                    $stage
+                    (string) $stage
                 );
         }
 

--- a/src/Elcodi/Component/Menu/Services/MenuModifier.php
+++ b/src/Elcodi/Component/Menu/Services/MenuModifier.php
@@ -49,8 +49,8 @@ class MenuModifier extends AbstractMenuModifier implements MenuChangerInterface
         $this->addElement(
             $menuModifier,
             $menus,
-            $stage,
-            $priority
+            (string) $stage,
+            (int) $priority
         );
 
         return $this;
@@ -71,7 +71,7 @@ class MenuModifier extends AbstractMenuModifier implements MenuChangerInterface
         $this->applyModifiersToMenuNodes(
             $menu->getSubnodes(),
             $menu->getCode(),
-            $stage
+            (string) $stage
         );
 
         return $this;
@@ -95,13 +95,13 @@ class MenuModifier extends AbstractMenuModifier implements MenuChangerInterface
 
             $this->applyModifiersToMenuNodes(
                 $menuNode->getSubnodes(),
-                $menuCode,
-                $stage
+                (string) $menuCode,
+                (string) $stage
             );
 
             $menuModifiers = $this->getElementsByMenuCodeAndStage(
-                $menuCode,
-                $stage
+                (string) $menuCode,
+                (string) $stage
             );
 
             /**

--- a/src/Elcodi/Component/Menu/Twig/PrintRouteExtension.php
+++ b/src/Elcodi/Component/Menu/Twig/PrintRouteExtension.php
@@ -82,10 +82,10 @@ class PrintRouteExtension extends Twig_Extension
                 ->urlGenerator
                 ->generate($route);
         } catch (ExceptionInterface $e) {
-            $url = (string) $route;
+            $url = $route;
         }
 
-        return $url;
+        return (string) $url;
     }
 
     /**

--- a/src/Elcodi/Component/MetaData/Entity/Traits/MetaDataTrait.php
+++ b/src/Elcodi/Component/MetaData/Entity/Traits/MetaDataTrait.php
@@ -52,7 +52,7 @@ trait MetaDataTrait
      */
     public function setMetaDescription($metaDescription)
     {
-        $this->metaDescription = $metaDescription;
+        $this->metaDescription = (string) $metaDescription;
 
         return $this;
     }
@@ -76,7 +76,7 @@ trait MetaDataTrait
      */
     public function setMetaKeywords($metaKeywords)
     {
-        $this->metaKeywords = $metaKeywords;
+        $this->metaKeywords = (string) $metaKeywords;
 
         return $this;
     }
@@ -100,7 +100,7 @@ trait MetaDataTrait
      */
     public function setMetaTitle($metaTitle)
     {
-        $this->metaTitle = $metaTitle;
+        $this->metaTitle = (string) $metaTitle;
 
         return $this;
     }

--- a/src/Elcodi/Component/Metric/API/Twig/APIMetricExtension.php
+++ b/src/Elcodi/Component/Metric/API/Twig/APIMetricExtension.php
@@ -75,7 +75,7 @@ class APIMetricExtension extends Twig_Extension
     ) {
         return (int) $this
             ->metricBucket
-            ->getBeaconsUnique($token, $event, $dates);
+            ->getBeaconsUnique((string) $token, (string) $event, $dates);
     }
 
     /**
@@ -94,7 +94,7 @@ class APIMetricExtension extends Twig_Extension
     ) {
         return (int) $this
             ->metricBucket
-            ->getBeaconsTotal($token, $event, $dates);
+            ->getBeaconsTotal((string) $token, (string) $event, $dates);
     }
 
     /**
@@ -113,7 +113,7 @@ class APIMetricExtension extends Twig_Extension
     ) {
         return $this
             ->metricBucket
-            ->getAccumulation($token, $event, $dates);
+            ->getAccumulation((string) $token, (string) $event, $dates);
     }
 
     /**
@@ -132,7 +132,7 @@ class APIMetricExtension extends Twig_Extension
     ) {
         return (int) $this
             ->metricBucket
-            ->getDistributions($token, $event, $dates);
+            ->getDistributions((string) $token, (string) $event, $dates);
     }
 
     /**

--- a/src/Elcodi/Component/Metric/Core/Bucket/Abstracts/AbstractMetricsBucket.php
+++ b/src/Elcodi/Component/Metric/Core/Bucket/Abstracts/AbstractMetricsBucket.php
@@ -36,11 +36,11 @@ abstract class AbstractMetricsBucket
     protected function generateEntryKey($token, $event, $date)
     {
         return
-            $this->normalizeForKey($token) .
+            $this->normalizeForKey((string) $token) .
             '.' .
-            $this->normalizeForKey($event) .
+            $this->normalizeForKey((string) $event) .
             '.' .
-            $this->normalizeForKey($date);
+            $this->normalizeForKey((string) $date);
     }
 
     /**

--- a/src/Elcodi/Component/Metric/Core/Bucket/RedisMetricsBucket.php
+++ b/src/Elcodi/Component/Metric/Core/Bucket/RedisMetricsBucket.php
@@ -77,8 +77,8 @@ class RedisMetricsBucket extends AbstractMetricsBucket
 
         foreach ($dates as $date) {
             $keys[] = $this->generateEntryKey(
-                    $token,
-                    $event,
+                    (string) $token,
+                    (string) $event,
                     $date
                 ) . '_unique';
         }
@@ -106,8 +106,8 @@ class RedisMetricsBucket extends AbstractMetricsBucket
 
         foreach ($dates as $date) {
             $key = $this->generateEntryKey(
-                $token,
-                $event,
+                (string) $token,
+                (string) $event,
                 $date
             );
 
@@ -136,8 +136,8 @@ class RedisMetricsBucket extends AbstractMetricsBucket
 
         foreach ($dates as $date) {
             $key = $this->generateEntryKey(
-                $token,
-                $event,
+                (string) $token,
+                (string) $event,
                 $date
             );
 
@@ -172,8 +172,8 @@ class RedisMetricsBucket extends AbstractMetricsBucket
 
         foreach ($dates as $date) {
             $key = $this->generateEntryKey(
-                $token,
-                $event,
+                (string) $token,
+                (string) $event,
                 $date
             );
 
@@ -210,7 +210,7 @@ class RedisMetricsBucket extends AbstractMetricsBucket
         $entryKey = $this->generateEntryKey(
             $entry->getToken(),
             $entry->getEvent(),
-            $entry->getCreatedAt()->format($dateTimeFormat)
+            $entry->getCreatedAt()->format((string) $dateTimeFormat)
         );
 
         $entryType = $entry->getType();

--- a/src/Elcodi/Component/Metric/Core/Entity/Entry.php
+++ b/src/Elcodi/Component/Metric/Core/Entity/Entry.php
@@ -84,10 +84,10 @@ class Entry implements EntryInterface
         $type,
         $createdAt
     ) {
-        $this->token = $token;
-        $this->event = $event;
-        $this->value = $value;
-        $this->type = $type;
+        $this->token = (string) $token;
+        $this->event = (string) $event;
+        $this->value = (string) $value;
+        $this->type = (int) $type;
         $this->createdAt = $createdAt;
     }
 

--- a/src/Elcodi/Component/Metric/Core/Factory/EntryFactory.php
+++ b/src/Elcodi/Component/Metric/Core/Factory/EntryFactory.php
@@ -45,10 +45,10 @@ class EntryFactory
         $createdAt
     ) {
         return new Entry(
-            $token,
-            $event,
-            $uniqueId,
-            $type,
+            (string) $token,
+            (string) $event,
+            (string) $uniqueId,
+            (int) $type,
             $createdAt
         );
     }

--- a/src/Elcodi/Component/Metric/Core/Services/MetricLoader.php
+++ b/src/Elcodi/Component/Metric/Core/Services/MetricLoader.php
@@ -65,7 +65,7 @@ class MetricLoader
     {
         $entries = $this
             ->entryRepository
-            ->getEntriesFromLastDays($days);
+            ->getEntriesFromLastDays((int) $days);
 
         foreach ($entries as $entry) {
             $this

--- a/src/Elcodi/Component/Metric/Core/Services/MetricManager.php
+++ b/src/Elcodi/Component/Metric/Core/Services/MetricManager.php
@@ -87,10 +87,10 @@ class MetricManager
         $entry = $this
             ->entryFactory
             ->create(
-                $token,
-                $event,
-                $uniqueId,
-                $type,
+                (string) $token,
+                (string) $event,
+                (string) $uniqueId,
+                (int) $type,
                 $dateTime
             );
 

--- a/src/Elcodi/Component/Metric/Input/Controller/InputController.php
+++ b/src/Elcodi/Component/Metric/Input/Controller/InputController.php
@@ -96,8 +96,8 @@ class InputController
         $this
             ->metricManager
             ->addEntry(
-                $token,
-                $event,
+                (string) $token,
+                (string) $event,
                 $value,
                 $type,
                 $this

--- a/src/Elcodi/Component/Metric/Input/Router/MetricInputLoader.php
+++ b/src/Elcodi/Component/Metric/Input/Router/MetricInputLoader.php
@@ -59,8 +59,8 @@ class MetricInputLoader implements LoaderInterface
         $inputControllerRouteName,
         $inputResizeControllerRoute
     ) {
-        $this->inputControllerRouteName = $inputControllerRouteName;
-        $this->inputResizeControllerRoute = $inputResizeControllerRoute;
+        $this->inputControllerRouteName = (string) $inputControllerRouteName;
+        $this->inputResizeControllerRoute = (string) $inputResizeControllerRoute;
     }
 
     /**

--- a/src/Elcodi/Component/Newsletter/Entity/NewsletterSubscription.php
+++ b/src/Elcodi/Component/Newsletter/Entity/NewsletterSubscription.php
@@ -77,7 +77,7 @@ class NewsletterSubscription implements NewsletterSubscriptionInterface
      */
     public function setEmail($email)
     {
-        $this->email = $email;
+        $this->email = (string) $email;
 
         return $this;
     }
@@ -125,7 +125,7 @@ class NewsletterSubscription implements NewsletterSubscriptionInterface
      */
     public function setHash($hash)
     {
-        $this->hash = $hash;
+        $this->hash = (string) $hash;
 
         return $this;
     }
@@ -149,7 +149,7 @@ class NewsletterSubscription implements NewsletterSubscriptionInterface
      */
     public function setReason($reason)
     {
-        $this->reason = $reason;
+        $this->reason = (string) $reason;
 
         return $this;
     }

--- a/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
+++ b/src/Elcodi/Component/Newsletter/Services/NewsletterManager.php
@@ -104,6 +104,8 @@ class NewsletterManager
      */
     public function subscribe($email, LanguageInterface $language = null)
     {
+        $email = (string) $email;
+
         if (!$this->validateEmail($email)) {
             throw new NewsletterCannotBeAddedException();
         }
@@ -141,6 +143,8 @@ class NewsletterManager
      */
     public function unSubscribe($email, $hash, LanguageInterface $language = null, $reason = null)
     {
+        $email = (string) $email;
+        
         if (!$this->validateEmail($email)) {
             throw new NewsletterCannotBeRemovedException();
         }
@@ -182,7 +186,7 @@ class NewsletterManager
      */
     public function isSubscribed($email)
     {
-        $newsletterSubscription = $this->getSubscription($email);
+        $newsletterSubscription = $this->getSubscription((string) $email);
 
         return ($newsletterSubscription instanceof NewsletterSubscriptionInterface);
     }
@@ -199,7 +203,7 @@ class NewsletterManager
         return $this
             ->newsletterSubscriptionRepository
             ->findOneBy([
-                'email' => $email,
+                'email' => (string) $email,
             ]);
     }
 
@@ -218,7 +222,7 @@ class NewsletterManager
 
         $validationViolationList = $this
             ->validator
-            ->validate($email, new Email());
+            ->validate((string) $email, new Email());
 
         return ($validationViolationList->count() === 0);
     }

--- a/src/Elcodi/Component/Page/Controller/PageController.php
+++ b/src/Elcodi/Component/Page/Controller/PageController.php
@@ -76,13 +76,13 @@ class PageController
          */
         $page = $this
             ->pageRepository
-            ->findOneById($id);
+            ->findOneById((string) $id);
 
         return $this
             ->pageResponseTransformer
             ->createResponseFromPage(
                 $page,
-                $path
+                (string) $path
             );
     }
 
@@ -102,13 +102,13 @@ class PageController
          */
         $page = $this
             ->pageRepository
-            ->findOneByPath($path);
+            ->findOneByPath((string) $path);
 
         return $this
             ->pageResponseTransformer
             ->createResponseFromPage(
                 $page,
-                $path
+                (string) $path
             );
     }
 }

--- a/src/Elcodi/Component/Page/Entity/Page.php
+++ b/src/Elcodi/Component/Page/Entity/Page.php
@@ -108,7 +108,7 @@ class Page implements PageInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -132,7 +132,7 @@ class Page implements PageInterface
      */
     public function setPath($path)
     {
-        $this->path = $path;
+        $this->path = (string) $path;
 
         return $this;
     }
@@ -156,7 +156,7 @@ class Page implements PageInterface
      */
     public function setTitle($title)
     {
-        $this->title = $title;
+        $this->title = (string) $title;
 
         return $this;
     }
@@ -180,7 +180,7 @@ class Page implements PageInterface
      */
     public function setContent($content)
     {
-        $this->content = $content;
+        $this->content = (string) $content;
 
         return $this;
     }
@@ -204,7 +204,7 @@ class Page implements PageInterface
      */
     public function setType($type)
     {
-        $this->type = $type;
+        $this->type = (int) $type;
 
         return $this;
     }
@@ -242,7 +242,7 @@ class Page implements PageInterface
      */
     public function setPersistent($persistent)
     {
-        $this->persistent = $persistent;
+        $this->persistent = (bool) $persistent;
 
         return $this;
     }

--- a/src/Elcodi/Component/Page/Renderer/TemplatedPageRenderer.php
+++ b/src/Elcodi/Component/Page/Renderer/TemplatedPageRenderer.php
@@ -66,7 +66,7 @@ class TemplatedPageRenderer implements PageRendererInterface
         array $bundles
     ) {
         $this->engine = $engine;
-        $this->templatePath = $path;
+        $this->templatePath = (string) $path;
         $this->bundles = $bundles;
     }
 

--- a/src/Elcodi/Component/Page/Repository/PageRepository.php
+++ b/src/Elcodi/Component/Page/Repository/PageRepository.php
@@ -40,7 +40,7 @@ class PageRepository extends EntityRepository
     public function findOneByPath($path)
     {
         return $this->findOneBy([
-            'path'    => $path,
+            'path'    => (string) $path,
             'enabled' => true,
         ]);
     }
@@ -55,7 +55,7 @@ class PageRepository extends EntityRepository
     public function findOneById($id)
     {
         return $this->findOneBy([
-            'id'    => $id,
+            'id'      => (string) $id,
             'enabled' => true,
         ]);
     }
@@ -80,10 +80,10 @@ class PageRepository extends EntityRepository
             ->orderBy('p.publicationDate', 'DESC')
             ->setParameters([
                 'enabled' => true,
-                'type'    => $type,
+                'type'    => (string) $type,
             ])
             ->setFirstResult($offset)
-            ->setMaxResults($numberPerPage)
+            ->setMaxResults((int) $numberPerPage)
             ->getQuery()
             ->getArrayResult();
     }
@@ -104,7 +104,7 @@ class PageRepository extends EntityRepository
             ->andWhere('p.type = :type')
             ->setParameters([
                 'enabled' => true,
-                'type'    => $type,
+                'type'    => (string) $type,
             ])
             ->getQuery()
             ->getSingleScalarResult();

--- a/src/Elcodi/Component/Page/Transformer/PageResponseTransformer.php
+++ b/src/Elcodi/Component/Page/Transformer/PageResponseTransformer.php
@@ -79,7 +79,7 @@ class PageResponseTransformer
         $this->requestStack = $requestStack;
         $this->urlGenerator = $urlGenerator;
         $this->pageRenderer = $pageRenderer;
-        $this->pageRenderRoute = $pageRenderRoute;
+        $this->pageRenderRoute = (string) $pageRenderRoute;
     }
 
     /**

--- a/src/Elcodi/Component/Payment/Entity/PaymentMethod.php
+++ b/src/Elcodi/Component/Payment/Entity/PaymentMethod.php
@@ -82,12 +82,12 @@ class PaymentMethod
         $imageUrl = '',
         $script = ''
     ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->description = $description;
-        $this->url = $url;
-        $this->imageUrl = $imageUrl;
-        $this->script = $script;
+        $this->id = (string) $id;
+        $this->name = (string) $name;
+        $this->description = (string) $description;
+        $this->url = (string) $url;
+        $this->imageUrl = (string) $imageUrl;
+        $this->script = (string) $script;
     }
 
     /**

--- a/src/Elcodi/Component/Plugin/Entity/Plugin.php
+++ b/src/Elcodi/Component/Plugin/Entity/Plugin.php
@@ -79,12 +79,12 @@ class Plugin
         PluginConfiguration $configuration,
         $enabled
     ) {
-        $this->namespace = $namespace;
+        $this->namespace = (string) $namespace;
         $this->hash = sha1($namespace);
-        $this->type = $type;
-        $this->category = $category;
+        $this->type = (string) $type;
+        $this->category = (string) $category;
         $this->configuration = $configuration;
-        $this->enabled = $enabled;
+        $this->enabled = (bool) $enabled;
     }
 
     /**
@@ -174,7 +174,7 @@ class Plugin
     {
         return $this
             ->getConfiguration()
-            ->get($configurationName);
+            ->get((string) $configurationName);
     }
 
     /**
@@ -212,7 +212,7 @@ class Plugin
     {
         return $this
             ->getConfiguration()
-            ->getField($fieldName);
+            ->getField((string) $fieldName);
     }
 
     /**
@@ -226,7 +226,7 @@ class Plugin
     {
         return $this
             ->getConfiguration()
-            ->hasField($fieldName);
+            ->hasField((string) $fieldName);
     }
 
     /**
@@ -257,7 +257,7 @@ class Plugin
     {
         return $this
             ->configuration
-            ->getFieldValue($fieldName);
+            ->getFieldValue((string) $fieldName);
     }
 
     /**

--- a/src/Elcodi/Component/Plugin/Entity/PluginConfiguration.php
+++ b/src/Elcodi/Component/Plugin/Entity/PluginConfiguration.php
@@ -74,8 +74,8 @@ class PluginConfiguration
      */
     public function get($name)
     {
-        return isset($this->configuration[$name])
-            ? $this->configuration[$name]
+        return isset($this->configuration[(string) $name])
+            ? $this->configuration[(string) $name]
             : [];
     }
 
@@ -98,8 +98,8 @@ class PluginConfiguration
      */
     public function getField($fieldName)
     {
-        return $this->hasField($fieldName)
-            ? $this->configuration['fields'][$fieldName]
+        return $this->hasField((string) $fieldName)
+            ? $this->configuration['fields'][(string) $fieldName]
             : null;
     }
 
@@ -112,7 +112,7 @@ class PluginConfiguration
      */
     public function hasField($fieldName)
     {
-        return isset($this->configuration['fields'][$fieldName]);
+        return isset($this->configuration['fields'][(string) $fieldName]);
     }
 
     /**
@@ -125,11 +125,11 @@ class PluginConfiguration
      */
     public function setFieldValue($fieldName, $fieldValue)
     {
-        if (!$this->hasField($fieldName)) {
+        if (!$this->hasField((string) $fieldName)) {
             throw new RuntimeException('Field "' . $fieldName . '" not found in Plugin Configuration');
         }
 
-        $this->configuration['fields'][$fieldName]['data'] = $fieldValue;
+        $this->configuration['fields'][(string) $fieldName]['data'] = $fieldValue;
 
         return $this;
     }
@@ -143,11 +143,11 @@ class PluginConfiguration
      */
     public function getFieldValue($fieldName)
     {
-        if (!$this->hasField($fieldName)) {
+        if (!$this->hasField((string) $fieldName)) {
             throw new RuntimeException('Field "' . $fieldName . '" not found in Plugin Configuration');
         }
 
-        return $this->configuration['fields'][$fieldName]['data'];
+        return $this->configuration['fields'][(string) $fieldName]['data'];
     }
 
     /**

--- a/src/Elcodi/Component/Plugin/EventDispatcher/EventAdapter.php
+++ b/src/Elcodi/Component/Plugin/EventDispatcher/EventAdapter.php
@@ -50,7 +50,7 @@ class EventAdapter extends Event implements EventInterface
      */
     public function __construct(array $context = [], $content = '')
     {
-        $this->content = $content;
+        $this->content = (string) $content;
         $this->context = $context;
     }
 
@@ -64,8 +64,8 @@ class EventAdapter extends Event implements EventInterface
      */
     public function get($key, $default = null)
     {
-        if (array_key_exists($key, $this->context)) {
-            return $this->context[$key];
+        if (array_key_exists((string) $key, $this->context)) {
+            return $this->context[(string) $key];
         }
 
         return $default;
@@ -88,7 +88,7 @@ class EventAdapter extends Event implements EventInterface
      */
     public function getContent()
     {
-        return (string) $this->content;
+        return $this->content;
     }
 
     /**
@@ -100,7 +100,7 @@ class EventAdapter extends Event implements EventInterface
      */
     public function setContent($content)
     {
-        $this->content = $content;
+        $this->content = (string) $content;
 
         return $this;
     }

--- a/src/Elcodi/Component/Plugin/EventDispatcher/HookSystemEventDispatcher.php
+++ b/src/Elcodi/Component/Plugin/EventDispatcher/HookSystemEventDispatcher.php
@@ -39,7 +39,7 @@ class HookSystemEventDispatcher extends AbstractEventDispatcher implements HookS
      */
     public function listen($hookName, $callable)
     {
-        $this->eventDispatcher->addListener($hookName, $callable);
+        $this->eventDispatcher->addListener((string) $hookName, $callable);
 
         return $this;
     }
@@ -55,8 +55,8 @@ class HookSystemEventDispatcher extends AbstractEventDispatcher implements HookS
      */
     public function execute($hookName, $context = [], $content = '')
     {
-        $event = new EventAdapter($context, $content);
-        $this->eventDispatcher->dispatch($hookName, $event);
+        $event = new EventAdapter($context, (string) $content);
+        $this->eventDispatcher->dispatch((string) $hookName, $event);
 
         return $event->getContent();
     }

--- a/src/Elcodi/Component/Plugin/Repository/PluginRepository.php
+++ b/src/Elcodi/Component/Plugin/Repository/PluginRepository.php
@@ -38,7 +38,7 @@ class PluginRepository extends EntityRepository
     {
         return $this->findBy([
             'type' => PluginTypes::TYPE_PLUGIN,
-            'category' => $category,
+            'category' => (string) $category,
             'enabled'  => true,
         ]);
     }
@@ -54,7 +54,7 @@ class PluginRepository extends EntityRepository
     {
         return $this->findBy([
             'type' => PluginTypes::TYPE_TEMPLATE,
-            'category' => $category,
+            'category' => (string) $category,
             'enabled'  => true,
         ]);
     }

--- a/src/Elcodi/Component/Plugin/Services/PluginManager.php
+++ b/src/Elcodi/Component/Plugin/Services/PluginManager.php
@@ -174,7 +174,7 @@ class PluginManager
         unset($pluginConfiguration['type']);
 
         $pluginInstance = Plugin::create(
-            $pluginNamespace,
+            (string) $pluginNamespace,
             $pluginType,
             $pluginCategory,
             PluginConfiguration::create($pluginConfiguration),

--- a/src/Elcodi/Component/Plugin/Templating/Traits/TemplatingTrait.php
+++ b/src/Elcodi/Component/Plugin/Templating/Traits/TemplatingTrait.php
@@ -61,7 +61,7 @@ trait TemplatingTrait
             $this
                 ->twig
                 ->render(
-                    $template,
+                    (string) $template,
                     array_merge(
                         $event->getContext(),
                         ['plugin' => $plugin],

--- a/src/Elcodi/Component/Product/Entity/Category.php
+++ b/src/Elcodi/Component/Product/Entity/Category.php
@@ -94,7 +94,7 @@ class Category implements CategoryInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -118,7 +118,7 @@ class Category implements CategoryInterface
      */
     public function setSlug($slug)
     {
-        $this->slug = $slug;
+        $this->slug = (string) $slug;
 
         return $this;
     }
@@ -240,7 +240,7 @@ class Category implements CategoryInterface
      */
     public function setRoot($root)
     {
-        $this->root = $root;
+        $this->root = (bool) $root;
 
         return $this;
     }
@@ -264,7 +264,7 @@ class Category implements CategoryInterface
      */
     public function setPosition($position)
     {
-        $this->position = $position;
+        $this->position = (int) $position;
 
         return $this;
     }

--- a/src/Elcodi/Component/Product/Entity/Manufacturer.php
+++ b/src/Elcodi/Component/Product/Entity/Manufacturer.php
@@ -77,7 +77,7 @@ class Manufacturer implements ManufacturerInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -101,7 +101,7 @@ class Manufacturer implements ManufacturerInterface
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }
@@ -123,7 +123,7 @@ class Manufacturer implements ManufacturerInterface
      */
     public function setSlug($slug)
     {
-        $this->slug = $slug;
+        $this->slug = (string) $slug;
 
         return $this;
     }

--- a/src/Elcodi/Component/Product/Entity/Product.php
+++ b/src/Elcodi/Component/Product/Entity/Product.php
@@ -163,7 +163,7 @@ class Product implements ProductInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -187,7 +187,7 @@ class Product implements ProductInterface
      */
     public function setSlug($slug)
     {
-        $this->slug = $slug;
+        $this->slug = (string) $slug;
 
         return $this;
     }
@@ -211,7 +211,7 @@ class Product implements ProductInterface
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }
@@ -235,7 +235,7 @@ class Product implements ProductInterface
      */
     public function setShortDescription($shortDescription)
     {
-        $this->shortDescription = $shortDescription;
+        $this->shortDescription = (string) $shortDescription;
 
         return $this;
     }
@@ -335,7 +335,7 @@ class Product implements ProductInterface
      */
     public function setStock($stock)
     {
-        $this->stock = $stock;
+        $this->stock = (int) $stock;
 
         return $this;
     }
@@ -359,7 +359,7 @@ class Product implements ProductInterface
      */
     public function setShowInHome($showInHome)
     {
-        $this->showInHome = $showInHome;
+        $this->showInHome = (bool) $showInHome;
 
         return $this;
     }
@@ -407,7 +407,7 @@ class Product implements ProductInterface
      */
     public function setDimensions($dimensions)
     {
-        $this->dimensions = $dimensions;
+        $this->dimensions = (string) $dimensions;
 
         return $this;
     }
@@ -441,7 +441,7 @@ class Product implements ProductInterface
      */
     public function setSku($sku)
     {
-        $this->sku = $sku;
+        $this->sku = (string) $sku;
 
         return $this;
     }
@@ -455,7 +455,7 @@ class Product implements ProductInterface
      */
     public function setType($type)
     {
-        $this->type = $type;
+        $this->type = (int) $type;
 
         return $this;
     }

--- a/src/Elcodi/Component/Product/Entity/Traits/DimensionsTrait.php
+++ b/src/Elcodi/Component/Product/Entity/Traits/DimensionsTrait.php
@@ -69,7 +69,7 @@ trait DimensionsTrait
      */
     public function setDepth($depth)
     {
-        $this->depth = $depth;
+        $this->depth = (int) $depth;
 
         return $this;
     }
@@ -93,7 +93,7 @@ trait DimensionsTrait
      */
     public function setHeight($height)
     {
-        $this->height = $height;
+        $this->height = (int) $height;
 
         return $this;
     }
@@ -117,7 +117,7 @@ trait DimensionsTrait
      */
     public function setWeight($weight)
     {
-        $this->weight = $weight;
+        $this->weight = (int) $weight;
 
         return $this;
     }
@@ -141,7 +141,7 @@ trait DimensionsTrait
      */
     public function setWidth($width)
     {
-        $this->width = $width;
+        $this->width = (int) $width;
 
         return $this;
     }

--- a/src/Elcodi/Component/Product/Entity/Variant.php
+++ b/src/Elcodi/Component/Product/Entity/Variant.php
@@ -98,7 +98,7 @@ class Variant implements VariantInterface
      */
     public function setSku($sku)
     {
-        $this->sku = $sku;
+        $this->sku = (string) $sku;
 
         return $this;
     }
@@ -122,7 +122,7 @@ class Variant implements VariantInterface
      */
     public function setStock($stock)
     {
-        $this->stock = $stock;
+        $this->stock = (int) $stock;
 
         return $this;
     }

--- a/src/Elcodi/Component/Product/Factory/ProductFactory.php
+++ b/src/Elcodi/Component/Product/Factory/ProductFactory.php
@@ -45,7 +45,7 @@ class ProductFactory extends AbstractPurchasableFactory
      */
     public function setUseStock($useStock = false)
     {
-        $this->useStock = $useStock;
+        $this->useStock = (bool) $useStock;
 
         return $this;
     }

--- a/src/Elcodi/Component/Product/Services/ProductCollectionProvider.php
+++ b/src/Elcodi/Component/Product/Services/ProductCollectionProvider.php
@@ -55,7 +55,7 @@ class ProductCollectionProvider
         $useStock = false
     ) {
         $this->productRepository = $productRepository;
-        $this->useStock = $useStock;
+        $this->useStock = (bool) $useStock;
     }
 
     /**

--- a/src/Elcodi/Component/Rule/Entity/Rule.php
+++ b/src/Elcodi/Component/Rule/Entity/Rule.php
@@ -50,7 +50,7 @@ class Rule implements RuleInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -74,7 +74,7 @@ class Rule implements RuleInterface
      */
     public function setExpression($expression)
     {
-        $this->expression = $expression;
+        $this->expression = (string) $expression;
 
         return $this;
     }

--- a/src/Elcodi/Component/Shipping/Entity/ShippingMethod.php
+++ b/src/Elcodi/Component/Shipping/Entity/ShippingMethod.php
@@ -73,10 +73,10 @@ class ShippingMethod
         $description,
         MoneyInterface $price
     ) {
-        $this->id = $id;
-        $this->carrierName = $carrierName;
-        $this->name = $name;
-        $this->description = $description;
+        $this->id = (string) $id;
+        $this->carrierName = (string) $carrierName;
+        $this->name = (string) $name;
+        $this->description = (string) $description;
         $this->price = $price;
     }
 

--- a/src/Elcodi/Component/Shipping/Wrapper/ShippingWrapper.php
+++ b/src/Elcodi/Component/Shipping/Wrapper/ShippingWrapper.php
@@ -76,7 +76,7 @@ class ShippingWrapper
                 ShippingMethod $shippingMethod
             ) use ($shippingMethodId) {
 
-                return ($shippingMethodId === $shippingMethod->getId())
+                return ((string) $shippingMethodId === $shippingMethod->getId())
                     ? $shippingMethod
                     : $foundShippingMethod;
             },

--- a/src/Elcodi/Component/Sitemap/Builder/SitemapBuilder.php
+++ b/src/Elcodi/Component/Sitemap/Builder/SitemapBuilder.php
@@ -85,7 +85,7 @@ class SitemapBuilder
 
         $data = $this
             ->sitemapRenderer
-            ->render($sitemapElements, $basepath);
+            ->render($sitemapElements, (string) $basepath);
 
         return $data;
     }

--- a/src/Elcodi/Component/Sitemap/Dumper/FilesystemDumper.php
+++ b/src/Elcodi/Component/Sitemap/Dumper/FilesystemDumper.php
@@ -35,8 +35,8 @@ class FilesystemDumper implements SitemapDumperInterface
     public function dump($path, $sitemap)
     {
         file_put_contents(
-            $path,
-            $sitemap
+            (string) $path,
+            (string) $sitemap
         );
 
         return $this;

--- a/src/Elcodi/Component/Sitemap/Dumper/SitemapDumper.php
+++ b/src/Elcodi/Component/Sitemap/Dumper/SitemapDumper.php
@@ -58,7 +58,7 @@ class SitemapDumper
     ) {
         $this->sitemapBuilder = $sitemapBuilder;
         $this->sitemapDumper = $sitemapDumper;
-        $this->path = $path;
+        $this->path = (string) $path;
     }
 
     /**
@@ -71,7 +71,7 @@ class SitemapDumper
     {
         $sitemapData = $this
             ->sitemapBuilder
-            ->build($basepath, $language);
+            ->build((string) $basepath, $language);
 
         $path = $this->resolvePathWithLanguage(
             $this->path,
@@ -93,6 +93,6 @@ class SitemapDumper
      */
     private function resolvePathWithLanguage($path, $language)
     {
-        return str_replace('{_locale}', $language, $path);
+        return str_replace('{_locale}', (string) $language, (string) $path);
     }
 }

--- a/src/Elcodi/Component/Sitemap/Element/EntitySitemapElementProvider.php
+++ b/src/Elcodi/Component/Sitemap/Element/EntitySitemapElementProvider.php
@@ -58,7 +58,7 @@ class EntitySitemapElementProvider
         array $arguments
     ) {
         $this->repository = $repository;
-        $this->method = $method;
+        $this->method = (string) $method;
         $this->arguments = $arguments;
     }
 

--- a/src/Elcodi/Component/Sitemap/Element/SitemapElement.php
+++ b/src/Elcodi/Component/Sitemap/Element/SitemapElement.php
@@ -64,7 +64,7 @@ class SitemapElement
         $changeFrequency = null,
         $priority = null
     ) {
-        $this->location = $location;
+        $this->location = (string) $location;
         $this->lastModification = $lastModification;
         $this->changeFrequency = $changeFrequency;
         $this->priority = $priority;

--- a/src/Elcodi/Component/Sitemap/Element/StaticSitemapElementGenerator.php
+++ b/src/Elcodi/Component/Sitemap/Element/StaticSitemapElementGenerator.php
@@ -79,7 +79,7 @@ class StaticSitemapElementGenerator implements SitemapElementGeneratorInterface
     ) {
         $this->sitemapElementFactory = $sitemapElementFactory;
         $this->transformer = $transformer;
-        $this->route = $route;
+        $this->route = (string) $route;
         $this->changeFrequency = $changeFrequency;
         $this->priority = $priority;
     }

--- a/src/Elcodi/Component/Sitemap/Factory/SitemapElementFactory.php
+++ b/src/Elcodi/Component/Sitemap/Factory/SitemapElementFactory.php
@@ -41,7 +41,7 @@ class SitemapElementFactory
         $priority = null
     ) {
         return new SitemapElement(
-            $location,
+            (string) $location,
             $lastModification,
             $changeFrequency,
             $priority

--- a/src/Elcodi/Component/StateTransitionMachine/Definition/State.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Definition/State.php
@@ -36,7 +36,7 @@ class State
      */
     public function __construct($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
     }
 
     /**

--- a/src/Elcodi/Component/StateTransitionMachine/Definition/Transition.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Definition/Transition.php
@@ -61,7 +61,7 @@ class Transition
      */
     public function __construct($name, State $start, State $final)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
         $this->start = $start;
         $this->final = $final;
         $this->createdAt = new DateTime();

--- a/src/Elcodi/Component/StateTransitionMachine/Definition/TransitionChain.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Definition/TransitionChain.php
@@ -70,7 +70,7 @@ class TransitionChain
      */
     public function hasTransition($transitionName)
     {
-        return !is_null($this->getTransitionsByName($transitionName));
+        return !is_null($this->getTransitionsByName((string) $transitionName));
     }
 
     /**
@@ -85,7 +85,7 @@ class TransitionChain
         return array_filter(
             $this->transitions,
             function (Transition $transition) use ($transitionName) {
-                return $transition->getName() === $transitionName;
+                return $transition->getName() === (string) $transitionName;
             }
         );
     }
@@ -104,7 +104,7 @@ class TransitionChain
             function (Transition $transition) use ($stateName) {
                 return $transition
                     ->getStart()
-                    ->getName() === $stateName;
+                    ->getName() === (string) $stateName;
             }
         );
     }
@@ -123,7 +123,7 @@ class TransitionChain
             function (Transition $transition) use ($stateName) {
                 return $transition
                     ->getFinal()
-                    ->getName() === $stateName;
+                    ->getName() === (string) $stateName;
             }
         );
     }
@@ -144,8 +144,8 @@ class TransitionChain
             $this->transitions,
             function (Transition $transition) use ($stateName, $transitionName) {
                 return
-                    $transition->getName() === $transitionName &&
-                    $transition->getStart()->getName() === $stateName;
+                    $transition->getName() === (string) $transitionName &&
+                    $transition->getStart()->getName() === (string) $stateName;
             }
         );
 
@@ -170,8 +170,8 @@ class TransitionChain
             $this->transitions,
             function (Transition $transition) use ($startStateName, $finalStateName) {
                 return
-                    $transition->getStart()->getName() === $startStateName &&
-                    $transition->getFinal()->getName() === $finalStateName;
+                    $transition->getStart()->getName() === (string) $startStateName &&
+                    $transition->getFinal()->getName() === (string) $finalStateName;
             }
         );
 

--- a/src/Elcodi/Component/StateTransitionMachine/Entity/StateLine.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Entity/StateLine.php
@@ -58,7 +58,7 @@ class StateLine implements StateLineInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -82,7 +82,7 @@ class StateLine implements StateLineInterface
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/InconsistentTransitionConfigurationException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/InconsistentTransitionConfigurationException.php
@@ -36,6 +36,6 @@ class InconsistentTransitionConfigurationException extends Exception
     {
         $message = 'Given state "' . $state . '" only one transition with name "' . $transition . '" can be defined.';
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, (int) $code, $previous);
     }
 }

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/InvalidPointOfEntryException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/InvalidPointOfEntryException.php
@@ -35,6 +35,6 @@ class InvalidPointOfEntryException extends Exception
     {
         $message = 'Invalid point of entry "' . $state . '"';
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, (int) $code, $previous);
     }
 }

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/ObjectNotInitializedException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/ObjectNotInitializedException.php
@@ -38,6 +38,6 @@ class ObjectNotInitializedException extends Exception
     {
         $message = 'Given object needs to be initialized into this machine before applying any state transition';
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, (int) $code, $previous);
     }
 }

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/StateNotValidException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/StateNotValidException.php
@@ -35,6 +35,6 @@ class StateNotValidException extends Exception
     {
         $message = 'State "' . $state . '" is not valid or is unreachable';
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, (int) $code, $previous);
     }
 }

--- a/src/Elcodi/Component/StateTransitionMachine/Exception/TransitionNotValidException.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Exception/TransitionNotValidException.php
@@ -37,6 +37,6 @@ class TransitionNotValidException extends AbstractTransitionException
     {
         $message = 'Invalid transition definition';
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct((string) $message, (int) $code, $previous);
     }
 }

--- a/src/Elcodi/Component/StateTransitionMachine/Factory/MachineFactory.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Factory/MachineFactory.php
@@ -41,9 +41,9 @@ class MachineFactory
         $pointOfEntry
     ) {
         $machine = new Machine(
-            $machineId,
+            (int) $machineId,
             $transitionChain,
-            $pointOfEntry
+            (string) $pointOfEntry
         );
 
         return $machine;

--- a/src/Elcodi/Component/StateTransitionMachine/Machine/LoggableMachine.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Machine/LoggableMachine.php
@@ -100,8 +100,8 @@ class LoggableMachine implements MachineInterface
         $transition = $this
             ->machine
             ->transition(
-                $startStateName,
-                $transitionName
+                (string) $startStateName,
+                (string) $transitionName
             );
 
         $this->logTransition($transition);
@@ -126,8 +126,8 @@ class LoggableMachine implements MachineInterface
         $transition = $this
             ->machine
             ->reachState(
-                $startStateName,
-                $finalStateName
+                (string) $startStateName,
+                (string) $finalStateName
             );
 
         $this->logTransition($transition);

--- a/src/Elcodi/Component/StateTransitionMachine/Machine/Machine.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Machine/Machine.php
@@ -30,7 +30,7 @@ use Elcodi\Component\StateTransitionMachine\Machine\Interfaces\MachineInterface;
 class Machine implements MachineInterface
 {
     /**
-     * @var integer
+     * @var integer|string
      *
      * Machine id
      */
@@ -51,7 +51,7 @@ class Machine implements MachineInterface
     private $pointOfEntry;
 
     /**
-     * @param integer         $machineId       Machine id
+     * @param integer|string  $machineId       Machine id
      * @param TransitionChain $transitionChain Transition Chain
      * @param string          $pointOfEntry    Point of entry
      */
@@ -62,13 +62,13 @@ class Machine implements MachineInterface
     ) {
         $this->machineId = $machineId;
         $this->transitionChain = $transitionChain;
-        $this->pointOfEntry = $pointOfEntry;
+        $this->pointOfEntry = (string) $pointOfEntry;
     }
 
     /**
      * Get machine id
      *
-     * @return string Machine identifier
+     * @return integer|string Machine identifier
      */
     public function getId()
     {
@@ -100,15 +100,15 @@ class Machine implements MachineInterface
         $startStateName,
         $transitionName
     ) {
-        if (!$this->transitionChain->hasTransition($transitionName)) {
-            throw new TransitionNotValidException($transitionName);
+        if (!$this->transitionChain->hasTransition((string) $transitionName)) {
+            throw new TransitionNotValidException((string) $transitionName);
         }
 
         $transition = $this
             ->transitionChain
             ->getTransitionByStartingStateAndTransitionName(
-                $startStateName,
-                $transitionName
+                (string) $startStateName,
+                (string) $transitionName
             );
 
         if (!($transition instanceof Transition)) {
@@ -135,8 +135,8 @@ class Machine implements MachineInterface
         $transition = $this
             ->transitionChain
             ->getTransitionByStartingStateAndFinalState(
-                $startStateName,
-                $finalStateName
+                (string) $startStateName,
+                (string) $finalStateName
             );
 
         if (!($transition instanceof Transition)) {
@@ -159,7 +159,7 @@ class Machine implements MachineInterface
             $this->transitionChain->getTransitions(),
             function (Transition $transition) use ($startStateName) {
                 return
-                    $transition->getStart()->getName() === $startStateName;
+                    $transition->getStart()->getName() === (string) $startStateName;
             }
         );
     }

--- a/src/Elcodi/Component/StateTransitionMachine/Machine/MachineBuilder.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Machine/MachineBuilder.php
@@ -72,7 +72,7 @@ class MachineBuilder
      *
      * Can be cyclic
      */
-    private $canBeCyclic;
+    private $canBeCyclic = true;
 
     /**
      * construct method
@@ -89,11 +89,10 @@ class MachineBuilder
         $pointOfEntry
     ) {
         $this->machineFactory = $machineFactory;
-        $this->machineId = $machineId;
+        $this->machineId = (string) $machineId;
         $this->configuration = $configuration;
         $this->transitionChain = TransitionChain::create();
-        $this->pointOfEntry = $pointOfEntry;
-        $this->canBeCyclic = true;
+        $this->pointOfEntry = (string) $pointOfEntry;
     }
 
     /**
@@ -105,7 +104,7 @@ class MachineBuilder
      */
     public function allowCycles($canBeCyclic)
     {
-        $this->canBeCyclic = $canBeCyclic;
+        $this->canBeCyclic = (bool) $canBeCyclic;
 
         return $this;
     }
@@ -208,12 +207,12 @@ class MachineBuilder
     private function checkPointOfEntry(array $configuration, $pointOfEntry)
     {
         foreach ($configuration as $transitionConfiguration) {
-            if ($transitionConfiguration[0] === $pointOfEntry) {
+            if ($transitionConfiguration[0] === (string) $pointOfEntry) {
                 return $this;
             }
         }
 
-        throw new InvalidPointOfEntryException($pointOfEntry);
+        throw new InvalidPointOfEntryException((string) $pointOfEntry);
     }
 
     /**
@@ -232,7 +231,7 @@ class MachineBuilder
         $node,
         array &$nodesVisited
     ) {
-        if (in_array($node, $nodesVisited)) {
+        if (in_array((string) $node, $nodesVisited)) {
             if (!$this->canBeCyclic) {
                 throw new CyclesNotAllowedException();
             }
@@ -240,10 +239,10 @@ class MachineBuilder
             return $this;
         }
 
-        $nodesVisited[] = $node;
+        $nodesVisited[] = (string) $node;
 
         foreach ($configuration as $transitionConfiguration) {
-            if ($transitionConfiguration[0] === $node) {
+            if ($transitionConfiguration[0] === (string) $node) {
                 $this->checkCycles(
                     $configuration,
                     $transitionConfiguration[2],

--- a/src/Elcodi/Component/StateTransitionMachine/Machine/MachineManager.php
+++ b/src/Elcodi/Component/StateTransitionMachine/Machine/MachineManager.php
@@ -100,7 +100,7 @@ class MachineManager
 
         $stateLine = $this->createStateLine(
             $pointOfEntry,
-            $description
+            (string) $description
         );
 
         $stateLineStack->addStateLine($stateLine);
@@ -140,8 +140,8 @@ class MachineManager
             ->applyTransitionAction(
                 $object,
                 $stateLineStack,
-                $transitionName,
-                $description,
+                (string) $transitionName,
+                (string) $description,
                 'transition'
             );
     }
@@ -169,8 +169,8 @@ class MachineManager
             ->applyTransitionAction(
                 $object,
                 $stateLineStack,
-                $transitionName,
-                $description,
+                (string) $transitionName,
+                (string) $description,
                 'reachState'
             );
     }
@@ -188,8 +188,8 @@ class MachineManager
         $stateLine = $this
             ->stateLineFactory
             ->create()
-            ->setName($name)
-            ->setDescription($description);
+            ->setName((string) $name)
+            ->setDescription((string) $description);
 
         return $stateLine;
     }
@@ -229,12 +229,12 @@ class MachineManager
             ->machine
             ->$transitionAction(
                 $startState->getName(),
-                $transitionName
+                (string) $transitionName
             );
 
         $stateLine = $this->createStateLine(
             $transition->getFinal()->getName(),
-            $description
+            (string) $description
         );
 
         $stateLineStack->addStateLine($stateLine);

--- a/src/Elcodi/Component/Store/Entity/Store.php
+++ b/src/Elcodi/Component/Store/Entity/Store.php
@@ -173,7 +173,7 @@ class Store implements StoreInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -197,7 +197,7 @@ class Store implements StoreInterface
      */
     public function setLeitmotiv($leitmotiv)
     {
-        $this->leitmotiv = $leitmotiv;
+        $this->leitmotiv = (string) $leitmotiv;
 
         return $this;
     }
@@ -221,7 +221,7 @@ class Store implements StoreInterface
      */
     public function setEmail($email)
     {
-        $this->email = $email;
+        $this->email = (string) $email;
 
         return $this;
     }
@@ -245,7 +245,7 @@ class Store implements StoreInterface
      */
     public function setIsCompany($isCompany)
     {
-        $this->isCompany = $isCompany;
+        $this->isCompany = (bool) $isCompany;
 
         return $this;
     }
@@ -269,7 +269,7 @@ class Store implements StoreInterface
      */
     public function setCif($cif)
     {
-        $this->cif = $cif;
+        $this->cif = (string) $cif;
 
         return $this;
     }
@@ -293,7 +293,7 @@ class Store implements StoreInterface
      */
     public function setTracker($tracker)
     {
-        $this->tracker = $tracker;
+        $this->tracker = (string) $tracker;
 
         return $this;
     }
@@ -317,7 +317,7 @@ class Store implements StoreInterface
      */
     public function setTemplate($template)
     {
-        $this->template = $template;
+        $this->template = (string) $template;
 
         return $this;
     }
@@ -341,7 +341,7 @@ class Store implements StoreInterface
      */
     public function setUseStock($useStock)
     {
-        $this->useStock = $useStock;
+        $this->useStock = (bool) $useStock;
 
         return $this;
     }
@@ -437,7 +437,7 @@ class Store implements StoreInterface
      */
     public function setRoutingStrategy($routingStrategy)
     {
-        $this->routingStrategy = $routingStrategy;
+        $this->routingStrategy = (string) $routingStrategy;
 
         return $this;
     }

--- a/src/Elcodi/Component/Store/Exception/StoreNotFoundException.php
+++ b/src/Elcodi/Component/Store/Exception/StoreNotFoundException.php
@@ -36,6 +36,6 @@ class StoreNotFoundException extends Exception
     {
         $message = 'Store not found.';
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct((string) $message, (int) $code, $previous);
     }
 }

--- a/src/Elcodi/Component/Tax/Entity/Tax.php
+++ b/src/Elcodi/Component/Tax/Entity/Tax.php
@@ -68,7 +68,7 @@ class Tax implements TaxInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -92,7 +92,7 @@ class Tax implements TaxInterface
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = (string) $description;
 
         return $this;
     }
@@ -116,7 +116,7 @@ class Tax implements TaxInterface
      */
     public function setValue($value)
     {
-        $this->value = $value;
+        $this->value = (float) $value;
 
         return $this;
     }

--- a/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
+++ b/src/Elcodi/Component/User/Entity/Abstracts/AbstractUser.php
@@ -121,7 +121,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function setFirstname($firstname)
     {
-        $this->firstname = $firstname;
+        $this->firstname = (string) $firstname;
 
         return $this;
     }
@@ -145,7 +145,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function setLastname($lastname)
     {
-        $this->lastname = $lastname;
+        $this->lastname = (string) $lastname;
 
         return $this;
     }
@@ -193,7 +193,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function setEmail($email)
     {
-        $this->email = $email;
+        $this->email = (string) $email;
 
         return $this;
     }
@@ -227,7 +227,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function setToken($token)
     {
-        $this->token = $token;
+        $this->token = (string) $token;
 
         return $this;
     }
@@ -277,7 +277,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function setRecoveryHash($recoveryHash)
     {
-        $this->recoveryHash = $recoveryHash;
+        $this->recoveryHash = (string) $recoveryHash;
 
         return $this;
     }
@@ -311,8 +311,8 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function setPassword($password)
     {
-        if (null !== $password) {
-            $this->password = $password;
+        if (trim($password)) {
+            $this->password = trim($password);
         }
 
         return $this;
@@ -347,7 +347,7 @@ abstract class AbstractUser implements AbstractUserInterface
      */
     public function setOneTimeLoginHash($oneTimeLoginHash)
     {
-        $this->oneTimeLoginHash = $oneTimeLoginHash;
+        $this->oneTimeLoginHash = (string) $oneTimeLoginHash;
 
         return $this;
     }

--- a/src/Elcodi/Component/User/Entity/Customer.php
+++ b/src/Elcodi/Component/User/Entity/Customer.php
@@ -122,7 +122,7 @@ class Customer extends AbstractUser implements CustomerInterface
      */
     public function setPhone($phone)
     {
-        $this->phone = $phone;
+        $this->phone = (string) $phone;
 
         return $this;
     }
@@ -146,7 +146,7 @@ class Customer extends AbstractUser implements CustomerInterface
      */
     public function setIdentityDocument($identityDocument)
     {
-        $this->identityDocument = $identityDocument;
+        $this->identityDocument = (string) $identityDocument;
 
         return $this;
     }
@@ -170,7 +170,7 @@ class Customer extends AbstractUser implements CustomerInterface
      */
     public function setGuest($guest)
     {
-        $this->guest = $guest;
+        $this->guest = (bool) $guest;
 
         return $this;
     }
@@ -194,7 +194,7 @@ class Customer extends AbstractUser implements CustomerInterface
      */
     public function setNewsletter($newsletter)
     {
-        $this->newsletter = $newsletter;
+        $this->newsletter = (bool) $newsletter;
 
         return $this;
     }

--- a/src/Elcodi/Component/User/Event/PasswordRememberEvent.php
+++ b/src/Elcodi/Component/User/Event/PasswordRememberEvent.php
@@ -51,7 +51,7 @@ class PasswordRememberEvent extends Event
     public function __construct(AbstractUserInterface $user, $rememberUrl)
     {
         $this->user = $user;
-        $this->rememberUrl = $rememberUrl;
+        $this->rememberUrl = (string) $rememberUrl;
     }
 
     /**

--- a/src/Elcodi/Component/User/EventDispatcher/PasswordEventDispatcher.php
+++ b/src/Elcodi/Component/User/EventDispatcher/PasswordEventDispatcher.php
@@ -39,7 +39,7 @@ class PasswordEventDispatcher extends AbstractEventDispatcher implements Passwor
      */
     public function dispatchOnPasswordRememberEvent(AbstractUserInterface $user, $recoverUrl)
     {
-        $event = new PasswordRememberEvent($user, $recoverUrl);
+        $event = new PasswordRememberEvent($user, (string) $recoverUrl);
         $this
             ->eventDispatcher
             ->dispatch(

--- a/src/Elcodi/Component/User/EventListener/Abstracts/AbstractPasswordEventListener.php
+++ b/src/Elcodi/Component/User/EventListener/Abstracts/AbstractPasswordEventListener.php
@@ -94,7 +94,7 @@ abstract class AbstractPasswordEventListener
      */
     public function encryptPassword($password, $salt = null)
     {
-        return $this->passwordEncoder->encodePassword($password, $salt);
+        return $this->passwordEncoder->encodePassword((string) $password, $salt);
     }
 
     /**

--- a/src/Elcodi/Component/User/EventListener/AutologinOnRegisterEventListener.php
+++ b/src/Elcodi/Component/User/EventListener/AutologinOnRegisterEventListener.php
@@ -77,8 +77,8 @@ class AutologinOnRegisterEventListener
     ) {
         $this->requestStack = $requestStack;
         $this->tokenStorage = $tokenStorage;
-        $this->providerKey = $providerKey;
         $this->dispatcher = $dispatcher;
+        $this->providerKey = (string) $providerKey;
     }
 
     /**

--- a/src/Elcodi/Component/User/Repository/AdminUserRepository.php
+++ b/src/Elcodi/Component/User/Repository/AdminUserRepository.php
@@ -38,7 +38,7 @@ class AdminUserRepository extends EntityRepository implements UserEmaileableInte
     {
         $user = $this
             ->findOneBy([
-                'email' => $email,
+                'email' => (string) $email,
             ]);
 
         return ($user instanceof AbstractUserInterface)

--- a/src/Elcodi/Component/User/Repository/CustomerRepository.php
+++ b/src/Elcodi/Component/User/Repository/CustomerRepository.php
@@ -39,7 +39,7 @@ class CustomerRepository extends EntityRepository implements UserEmaileableInter
     {
         $user = $this
             ->findOneBy([
-                'email' => $email,
+                'email' => (string) $email,
             ]);
 
         return ($user instanceof AbstractUserInterface)
@@ -65,8 +65,8 @@ class CustomerRepository extends EntityRepository implements UserEmaileableInter
             ->innerJoin('c.addresses', 'a')
             ->where('c.id = :customerId')
             ->andWhere('a.id = :addressId')
-            ->setParameter('customerId', $customerId)
-            ->setParameter('addressId', $addressId)
+            ->setParameter('customerId', (int) $customerId)
+            ->setParameter('addressId', (int) $addressId)
             ->setMaxResults(1)
             ->getQuery()
             ->getResult();

--- a/src/Elcodi/Component/User/Services/PasswordManager.php
+++ b/src/Elcodi/Component/User/Services/PasswordManager.php
@@ -92,13 +92,13 @@ class PasswordManager
         $recoverPasswordUrlName,
         $hashField = 'hash'
     ) {
-        $user = $userRepository->findOneByEmail($email);
+        $user = $userRepository->findOneByEmail((string) $email);
 
         if (!($user instanceof AbstractUser)) {
             return false;
         }
 
-        $this->rememberPassword($user, $recoverPasswordUrlName, $hashField);
+        $this->rememberPassword($user, (string) $recoverPasswordUrlName, (string) $hashField);
 
         return true;
     }
@@ -126,7 +126,7 @@ class PasswordManager
 
         $recoverUrl = $this
             ->router
-            ->generate($recoverPasswordUrlName, [
+            ->generate((string) $recoverPasswordUrlName, [
                 $hashField => $recoveryHash,
             ], true);
 
@@ -153,7 +153,7 @@ class PasswordManager
     {
         if ($hash == $user->getRecoveryHash()) {
             $user
-                ->setPassword($newPassword)
+                ->setPassword((string) $newPassword)
                 ->setRecoveryHash(null);
             $this->manager->flush($user);
 

--- a/src/Elcodi/Component/Zone/Entity/Zone.php
+++ b/src/Elcodi/Component/Zone/Entity/Zone.php
@@ -69,7 +69,7 @@ class Zone implements ZoneInterface
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = (string) $name;
 
         return $this;
     }
@@ -93,7 +93,7 @@ class Zone implements ZoneInterface
      */
     public function setCode($code)
     {
-        $this->code = $code;
+        $this->code = (string) $code;
 
         return $this;
     }
@@ -135,7 +135,7 @@ class Zone implements ZoneInterface
             array_unique(
                 array_merge(
                     $this->getLocations(),
-                    [$location]
+                    [(string) $location]
                 )
             )
         );
@@ -153,10 +153,10 @@ class Zone implements ZoneInterface
     public function removeLocation($location)
     {
         $locations = $this->getLocations();
-        $key = array_search($location, $locations);
+        $key = array_search((string) $location, $locations);
 
         if ($key !== false) {
-            unset($locations[$location]);
+            unset($locations[(string) $location]);
         }
 
         $this->setLocations($locations);


### PR DESCRIPTION
Things I'm doing in this PR:

* adding missed parameter types (ex: `AddressInterface` into src/Elcodi/Component/Cart/Entity/Cart.php)
* `use` statements for repeated FQCN
* parameters casting

Why parameters casting? Imo could be useful for different reasons:

1. if the parameter implements the `__toString` method, than it can be used without breaking internal code
2. a basic validation system ([in just one opcode](https://3v4l.org/UIWWv/vld#tabs), maximum 3 for assignments)