### PR TITLE
added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/AttributeBundle/.gitattributes
+++ b/src/Elcodi/Bundle/AttributeBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/BannerBundle/.gitattributes
+++ b/src/Elcodi/Bundle/BannerBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/CartBundle/.gitattributes
+++ b/src/Elcodi/Bundle/CartBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/CartCouponBundle/.gitattributes
+++ b/src/Elcodi/Bundle/CartCouponBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/CommentBundle/.gitattributes
+++ b/src/Elcodi/Bundle/CommentBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/ConfigurationBundle/.gitattributes
+++ b/src/Elcodi/Bundle/ConfigurationBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/CoreBundle/.gitattributes
+++ b/src/Elcodi/Bundle/CoreBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/CouponBundle/.gitattributes
+++ b/src/Elcodi/Bundle/CouponBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/CurrencyBundle/.gitattributes
+++ b/src/Elcodi/Bundle/CurrencyBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/.gitattributes
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/.gitattributes
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/GeoBundle/.gitattributes
+++ b/src/Elcodi/Bundle/GeoBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/LanguageBundle/.gitattributes
+++ b/src/Elcodi/Bundle/LanguageBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/MediaBundle/.gitattributes
+++ b/src/Elcodi/Bundle/MediaBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/MenuBundle/.gitattributes
+++ b/src/Elcodi/Bundle/MenuBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/MetricBundle/.gitattributes
+++ b/src/Elcodi/Bundle/MetricBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/NewsletterBundle/.gitattributes
+++ b/src/Elcodi/Bundle/NewsletterBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/PageBundle/.gitattributes
+++ b/src/Elcodi/Bundle/PageBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/PaymentBundle/.gitattributes
+++ b/src/Elcodi/Bundle/PaymentBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/PluginBundle/.gitattributes
+++ b/src/Elcodi/Bundle/PluginBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/ProductBundle/.gitattributes
+++ b/src/Elcodi/Bundle/ProductBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/RuleBundle/.gitattributes
+++ b/src/Elcodi/Bundle/RuleBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/ShippingBundle/.gitattributes
+++ b/src/Elcodi/Bundle/ShippingBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/SitemapBundle/.gitattributes
+++ b/src/Elcodi/Bundle/SitemapBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/.gitattributes
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/StoreBundle/.gitattributes
+++ b/src/Elcodi/Bundle/StoreBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/TaxBundle/.gitattributes
+++ b/src/Elcodi/Bundle/TaxBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/UserBundle/.gitattributes
+++ b/src/Elcodi/Bundle/UserBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Bundle/ZoneBundle/.gitattributes
+++ b/src/Elcodi/Bundle/ZoneBundle/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Attribute/.gitattributes
+++ b/src/Elcodi/Component/Attribute/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Banner/.gitattributes
+++ b/src/Elcodi/Component/Banner/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Cart/.gitattributes
+++ b/src/Elcodi/Component/Cart/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/CartCoupon/.gitattributes
+++ b/src/Elcodi/Component/CartCoupon/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Comment/.gitattributes
+++ b/src/Elcodi/Component/Comment/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Configuration/.gitattributes
+++ b/src/Elcodi/Component/Configuration/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Core/.gitattributes
+++ b/src/Elcodi/Component/Core/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Coupon/.gitattributes
+++ b/src/Elcodi/Component/Coupon/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Currency/.gitattributes
+++ b/src/Elcodi/Component/Currency/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/EntityTranslator/.gitattributes
+++ b/src/Elcodi/Component/EntityTranslator/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Geo/.gitattributes
+++ b/src/Elcodi/Component/Geo/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Language/.gitattributes
+++ b/src/Elcodi/Component/Language/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Media/.gitattributes
+++ b/src/Elcodi/Component/Media/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Menu/.gitattributes
+++ b/src/Elcodi/Component/Menu/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/MetaData/.gitattributes
+++ b/src/Elcodi/Component/MetaData/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Metric/.gitattributes
+++ b/src/Elcodi/Component/Metric/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Newsletter/.gitattributes
+++ b/src/Elcodi/Component/Newsletter/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Page/.gitattributes
+++ b/src/Elcodi/Component/Page/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Payment/.gitattributes
+++ b/src/Elcodi/Component/Payment/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Plugin/.gitattributes
+++ b/src/Elcodi/Component/Plugin/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Product/.gitattributes
+++ b/src/Elcodi/Component/Product/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Rule/.gitattributes
+++ b/src/Elcodi/Component/Rule/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Shipping/.gitattributes
+++ b/src/Elcodi/Component/Shipping/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Sitemap/.gitattributes
+++ b/src/Elcodi/Component/Sitemap/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/StateTransitionMachine/.gitattributes
+++ b/src/Elcodi/Component/StateTransitionMachine/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Store/.gitattributes
+++ b/src/Elcodi/Component/Store/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Tax/.gitattributes
+++ b/src/Elcodi/Component/Tax/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/User/.gitattributes
+++ b/src/Elcodi/Component/User/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore

--- a/src/Elcodi/Component/Zone/.gitattributes
+++ b/src/Elcodi/Component/Zone/.gitattributes
@@ -1,0 +1,16 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+.editorconfig       export-ignore
+.formatter.yml      export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.gitsplit.yml       export-ignore
+.gush.yml           export-ignore
+.php_cs             export-ignore
+.travis.yml         export-ignore
+composer.lock       export-ignore
+DataFixtures        export-ignore
+phpunit.xml.dist    export-ignore
+Tests               export-ignore


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Fixed Tickets|   |
                   

Considering CI systems, I think some files (including the *Tests* directory) should be removed when developers download dependencies using `--prefer-dist`.

thephpleague is doing this: https://github.com/thephpleague/skeleton/blob/master/.gitattributes