### PR TITLE
moved setup and teardown before and after class

### DIFF
--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Services/BannerManagerTest.php
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/Services/BannerManagerTest.php
@@ -29,7 +29,7 @@ class BannerManagerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiLanguageBundle',

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartLineTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartLineTest.php
@@ -29,7 +29,7 @@ class CartLineTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCartBundle',

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Entity/CartTest.php
@@ -29,7 +29,7 @@ class CartTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCartBundle',

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/EventListener/OrderLineCreationEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/EventListener/OrderLineCreationEventListenerTest.php
@@ -42,7 +42,7 @@ class OrderLineCreationEventListenerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCartBundle',

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerProductTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerProductTest.php
@@ -43,7 +43,7 @@ class CartManagerProductTest extends AbstractCartManagerTest
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCurrencyBundle',

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
@@ -44,7 +44,7 @@ class CartManagerVariantTest extends AbstractCartManagerTest
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCurrencyBundle',

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Transformer/CartLineOrderLineTransformerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Transformer/CartLineOrderLineTransformerTest.php
@@ -44,7 +44,7 @@ class CartLineOrderLineTransformerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCartBundle',

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Transformer/CartOrderTransformerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Transformer/CartOrderTransformerTest.php
@@ -56,7 +56,7 @@ class CartOrderTransformerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCartBundle',

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponRulesEventListenerTest.php
@@ -47,7 +47,7 @@ class CartCouponRulesEventListenerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCartBundle',
@@ -65,6 +65,9 @@ class CartCouponRulesEventListenerTest extends WebTestCase
      */
     public function testOnCartCouponApplyValidate(array $expressions, $couponsNumber)
     {
+        static::setUpBeforeClass();
+        $this->setUp();
+
         /**
          * @var CartInterface $cart
          * @var CouponInterface $coupon

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponStackableEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartCouponStackableEventListenerTest.php
@@ -50,7 +50,7 @@ class CartCouponStackableEventListenerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCartBundle',

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/CartEventListenerTest.php
@@ -46,7 +46,7 @@ class CartEventListenerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiUserBundle',
@@ -90,6 +90,9 @@ class CartEventListenerTest extends WebTestCase
      */
     public function testOnCartPreLoadCouponsRemove()
     {
+        static::setUpBeforeClass();
+        $this->setUp();
+
         $ruleId = $this->loadDefaultTestConfigurationAndReturnRuleId();
 
         $cartCouponManager = $this

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/EventListener/OrderEventListenerTest.php
@@ -46,7 +46,7 @@ class OrderEventListenerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiUserBundle',

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/Services/ConfigurationManagerTest.php
@@ -47,7 +47,7 @@ class ConfigurationManagerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiConfigurationBundle',
@@ -240,6 +240,9 @@ class ConfigurationManagerTest extends WebTestCase
      */
     public function testDeleteParameter()
     {
+        static::setUpBeforeClass();
+        $this->setUp();
+
         /*
          * Deletion of a non-persisted parameter should return false
          */

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/Factory/CouponFactoryTest.php
@@ -40,7 +40,7 @@ class CouponFactoryTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCurrencyBundle',

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/Services/TranslatorTest.php
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/Services/TranslatorTest.php
@@ -72,6 +72,9 @@ class TranslatorTest extends WebTestCase
      */
     public function testSave()
     {
+        static::setUpBeforeClass();
+        $this->setUp();
+
         $translation = $this
             ->getFactory('entity_translation')
             ->create()

--- a/src/Elcodi/Bundle/GeoBundle/Tests/Functional/Adapter/LocationProvider/LocationServiceProviderAdapterTest.php
+++ b/src/Elcodi/Bundle/GeoBundle/Tests/Functional/Adapter/LocationProvider/LocationServiceProviderAdapterTest.php
@@ -48,7 +48,7 @@ class LocationServiceProviderAdapterTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiGeoBundle',

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Twig/LanguageExtensionTest.php
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/Twig/LanguageExtensionTest.php
@@ -41,7 +41,7 @@ class LanguageExtensionTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiLanguageBundle',

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuBuilderTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuBuilderTest.php
@@ -41,7 +41,7 @@ class MenuBuilderTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiMenuBundle',

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuFiltererTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuFiltererTest.php
@@ -41,7 +41,7 @@ class MenuFiltererTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiMenuBundle',

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuManagerTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuManagerTest.php
@@ -42,7 +42,7 @@ class MenuManagerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiMenuBundle',

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuModifierTest.php
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/Services/MenuModifierTest.php
@@ -41,7 +41,7 @@ class MenuModifierTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiMenuBundle',

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Service/NewsletterManagerTest.php
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/Service/NewsletterManagerTest.php
@@ -57,7 +57,7 @@ class NewsletterManagerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiLanguageBundle',
@@ -128,6 +128,9 @@ class NewsletterManagerTest extends WebTestCase
      */
     public function testSubscribeNoLanguage()
     {
+        static::setUpBeforeClass();
+        $this->setUp();
+
         $this->assertCount(2, $this
                 ->newsletterSubscriptionRepository
                 ->findBy([
@@ -152,6 +155,9 @@ class NewsletterManagerTest extends WebTestCase
      */
     public function testUnsubscribeExisting()
     {
+        static::setUpBeforeClass();
+        $this->setUp();
+
         $this->assertCount(2, $this
                 ->newsletterSubscriptionRepository
                 ->findBy([

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Adapter/SimilarPurchasablesProvider/SameCategoryRelatedPurchasablesProviderTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Adapter/SimilarPurchasablesProvider/SameCategoryRelatedPurchasablesProviderTest.php
@@ -30,7 +30,7 @@ class SameCategoryRelatedPurchasablesProviderTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiProductBundle',

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/EventListener/ProductCategoryIntegrityEventListenerTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/EventListener/ProductCategoryIntegrityEventListenerTest.php
@@ -57,7 +57,7 @@ class ProductCategoryIntegrityEventListenerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiProductBundle',

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/EventListener/RootCategoryEventListenerTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/EventListener/RootCategoryEventListenerTest.php
@@ -48,7 +48,7 @@ class RootCategoryEventListenerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiProductBundle',

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ProductFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/ProductFactoryTest.php
@@ -29,7 +29,7 @@ class ProductFactoryTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCurrencyBundle',

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/VariantFactoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Factory/VariantFactoryTest.php
@@ -29,7 +29,7 @@ class VariantFactoryTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiCurrencyBundle',

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Repository/CategoryRepositoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Repository/CategoryRepositoryTest.php
@@ -48,7 +48,7 @@ class CategoryRepositoryTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiProductBundle',

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Repository/ProductRepositoryTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Repository/ProductRepositoryTest.php
@@ -57,7 +57,7 @@ class ProductRepositoryTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiProductBundle',

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Services/ProductCollectionProviderTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Services/ProductCollectionProviderTest.php
@@ -37,7 +37,7 @@ class ProductCollectionProviderTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiProductBundle',

--- a/src/Elcodi/Bundle/RuleBundle/Tests/Functional/Services/RuleManagerTest.php
+++ b/src/Elcodi/Bundle/RuleBundle/Tests/Functional/Services/RuleManagerTest.php
@@ -48,7 +48,7 @@ class RuleManagerTest extends WebTestCase
      *
      * @return array Bundles name where fixtures should be found
      */
-    protected function loadFixturesBundles()
+    protected static function loadFixturesBundles()
     {
         return [
             'ElcodiRuleBundle',

--- a/src/Elcodi/Component/Product/Adapter/SimilarPurchasablesProvider/SameCategoryRelatedPurchasableProvider.php
+++ b/src/Elcodi/Component/Product/Adapter/SimilarPurchasablesProvider/SameCategoryRelatedPurchasableProvider.php
@@ -17,8 +17,6 @@
 
 namespace Elcodi\Component\Product\Adapter\SimilarPurchasablesProvider;
 
-use Doctrine\Common\Collections\Collection;
-
 use Elcodi\Component\Product\Adapter\SimilarPurchasablesProvider\Interfaces\RelatedPurchasablesProviderInterface;
 use Elcodi\Component\Product\Entity\Interfaces\CategoryInterface;
 use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;


### PR DESCRIPTION
Split of #958

Database schema generation and fixtures were executed for every test, this slows down the execution a lot, so I moved database related stuffs (setup and teardown) before and after class so some of them could be prevented.

For tests requiring explicitly everything new I've included:

static::setUpBeforeClass();
$this->setUp();