### PR TITLE
Appveyor tests improvement

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,6 @@
 build: false
 platform: x86
 clone_folder: c:\projects\elcodi
-version: '{build}-$(PHP_VERSION)'
-os: Windows Server 2012
-
-environment:
-  matrix:
-  - PHP_VERSION: 5.6.15
-    PHP_DEP_VER: 5.6
-  - PHP_VERSION: 5.5.30
-    PHP_DEP_VER: 5.5
-  - PHP_VERSION: 5.4.45
-    PHP_DEP_VER: 5.4
-    PHP_VC: 9
-  BUILD_PLATFORM: x86
-  PHP_VC: 11
-  PHP_SDK: c:\projects\php-sdk
-  PHP_DEVPACK: c:\projects\php-devpack
 
 matrix:
   fast_finish: true
@@ -29,14 +13,10 @@ init:
 
 install:
   - cinst -y OpenSSL.Light
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - ps: (new-object net.webclient).DownloadFile('http://windows.php.net/downloads/releases/php-' + ${env:PHP_VERSION} + '-Win32-VC' + ${env:PHP_VC} + '-' + ${env:BUILD_PLATFORM} + '.zip', ${env:APPVEYOR_BUILD_FOLDER} + '\..\php.zip')
-  - cd ..
-  - 'mkdir php && mv php.zip php\php.zip && cd php'
-  - 7z.exe x php.zip | FIND /V "ing  "
-  - cd %APPVEYOR_BUILD_FOLDER%\..\php
-  - set PATH=%cd%;%PATH%
-  - echo extension_dir=%APPVEYOR_BUILD_FOLDER%\..\php\ext > php.ini
+  - cinst -y php
+  - cd c:\tools\php
+  - copy php.ini-production php.ini /Y
+  - echo extension_dir=ext >> php.ini
   - echo memory_limit=1G >> php.ini
   - echo date.timezone="UTC" >> php.ini
   - echo extension=php_openssl.dll >> php.ini
@@ -47,7 +27,7 @@ install:
   - echo extension=php_pdo_sqlite.dll >> php.ini
   - cd %APPVEYOR_BUILD_FOLDER%
   - php -r "readfile('http://getcomposer.org/installer');" | php
-  - php composer.phar install --prefer-source --no-interaction --no-progress
+  - php composer.phar install --prefer-dist --no-interaction --no-progress
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%


### PR DESCRIPTION
Appveyor serializes buildings, slowing down PRs tests, so to improve it
we’ll use a single version (currently 5.6, but should be updated
automatically without touching this file).