### PR TITLE
Exclude tests from production classes map

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -138,6 +138,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "src/**/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\": "src/Elcodi"
         }

--- a/src/Elcodi/Bundle/AttributeBundle/composer.json
+++ b/src/Elcodi/Bundle/AttributeBundle/composer.json
@@ -50,6 +50,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\AttributeBundle\\": ""
         }

--- a/src/Elcodi/Bundle/BannerBundle/composer.json
+++ b/src/Elcodi/Bundle/BannerBundle/composer.json
@@ -52,6 +52,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\BannerBundle\\": ""
         }

--- a/src/Elcodi/Bundle/CartBundle/composer.json
+++ b/src/Elcodi/Bundle/CartBundle/composer.json
@@ -56,6 +56,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\CartBundle\\": ""
         }

--- a/src/Elcodi/Bundle/CartCouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CartCouponBundle/composer.json
@@ -54,6 +54,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\CartCouponBundle\\": ""
         }

--- a/src/Elcodi/Bundle/CommentBundle/composer.json
+++ b/src/Elcodi/Bundle/CommentBundle/composer.json
@@ -51,6 +51,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\CommentBundle\\": ""
         }

--- a/src/Elcodi/Bundle/ConfigurationBundle/composer.json
+++ b/src/Elcodi/Bundle/ConfigurationBundle/composer.json
@@ -52,6 +52,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\ConfigurationBundle\\": ""
         }

--- a/src/Elcodi/Bundle/CoreBundle/composer.json
+++ b/src/Elcodi/Bundle/CoreBundle/composer.json
@@ -56,6 +56,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\CoreBundle\\": ""
         }

--- a/src/Elcodi/Bundle/CouponBundle/composer.json
+++ b/src/Elcodi/Bundle/CouponBundle/composer.json
@@ -52,6 +52,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\CouponBundle\\": ""
         }

--- a/src/Elcodi/Bundle/CurrencyBundle/composer.json
+++ b/src/Elcodi/Bundle/CurrencyBundle/composer.json
@@ -58,6 +58,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\CurrencyBundle\\": ""
         }

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/composer.json
@@ -52,6 +52,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\EntityTranslatorBundle\\": ""
         }

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/composer.json
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/composer.json
@@ -42,6 +42,9 @@
         "elcodi/core-bundle": "^1.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\FixturesBoosterBundle\\": ""
         }

--- a/src/Elcodi/Bundle/GeoBundle/composer.json
+++ b/src/Elcodi/Bundle/GeoBundle/composer.json
@@ -53,6 +53,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\GeoBundle\\": ""
         }

--- a/src/Elcodi/Bundle/LanguageBundle/composer.json
+++ b/src/Elcodi/Bundle/LanguageBundle/composer.json
@@ -53,6 +53,9 @@
         "symfony/twig-bundle": "Required if using Twig extensions"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\LanguageBundle\\": ""
         }

--- a/src/Elcodi/Bundle/MediaBundle/composer.json
+++ b/src/Elcodi/Bundle/MediaBundle/composer.json
@@ -53,6 +53,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\MediaBundle\\": ""
         }

--- a/src/Elcodi/Bundle/MenuBundle/composer.json
+++ b/src/Elcodi/Bundle/MenuBundle/composer.json
@@ -52,6 +52,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\MenuBundle\\": ""
         }

--- a/src/Elcodi/Bundle/MetricBundle/composer.json
+++ b/src/Elcodi/Bundle/MetricBundle/composer.json
@@ -51,6 +51,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\MetricBundle\\": ""
         }

--- a/src/Elcodi/Bundle/NewsletterBundle/composer.json
+++ b/src/Elcodi/Bundle/NewsletterBundle/composer.json
@@ -51,6 +51,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\NewsletterBundle\\": ""
         }

--- a/src/Elcodi/Bundle/PageBundle/composer.json
+++ b/src/Elcodi/Bundle/PageBundle/composer.json
@@ -50,6 +50,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\PageBundle\\": ""
         }

--- a/src/Elcodi/Bundle/PaymentBundle/composer.json
+++ b/src/Elcodi/Bundle/PaymentBundle/composer.json
@@ -46,6 +46,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\PaymentBundle\\": ""
         }

--- a/src/Elcodi/Bundle/PluginBundle/composer.json
+++ b/src/Elcodi/Bundle/PluginBundle/composer.json
@@ -31,6 +31,9 @@
         "elcodi/plugin": "^1.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\PluginBundle\\": ""
         }

--- a/src/Elcodi/Bundle/ProductBundle/composer.json
+++ b/src/Elcodi/Bundle/ProductBundle/composer.json
@@ -59,6 +59,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\ProductBundle\\": ""
         }

--- a/src/Elcodi/Bundle/RuleBundle/composer.json
+++ b/src/Elcodi/Bundle/RuleBundle/composer.json
@@ -51,6 +51,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\RuleBundle\\": ""
         }

--- a/src/Elcodi/Bundle/ShippingBundle/composer.json
+++ b/src/Elcodi/Bundle/ShippingBundle/composer.json
@@ -46,6 +46,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\ShippingBundle\\": ""
         }

--- a/src/Elcodi/Bundle/SitemapBundle/composer.json
+++ b/src/Elcodi/Bundle/SitemapBundle/composer.json
@@ -49,6 +49,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\SitemapBundle\\": ""
         }

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/composer.json
@@ -47,6 +47,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\StateTransitionMachineBundle\\": ""
         }

--- a/src/Elcodi/Bundle/StoreBundle/composer.json
+++ b/src/Elcodi/Bundle/StoreBundle/composer.json
@@ -52,6 +52,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\StoreBundle\\": ""
         }

--- a/src/Elcodi/Bundle/TaxBundle/composer.json
+++ b/src/Elcodi/Bundle/TaxBundle/composer.json
@@ -50,6 +50,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\TaxBundle\\": ""
         }

--- a/src/Elcodi/Bundle/TestCommonBundle/composer.json
+++ b/src/Elcodi/Bundle/TestCommonBundle/composer.json
@@ -45,6 +45,9 @@
         "symfony/finder": "^2.7"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\TestCommonBundle\\": ""
         }

--- a/src/Elcodi/Bundle/UserBundle/composer.json
+++ b/src/Elcodi/Bundle/UserBundle/composer.json
@@ -55,6 +55,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\UserBundle\\": ""
         }

--- a/src/Elcodi/Bundle/ZoneBundle/composer.json
+++ b/src/Elcodi/Bundle/ZoneBundle/composer.json
@@ -51,6 +51,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Bundle\\ZoneBundle\\": ""
         }

--- a/src/Elcodi/Component/Attribute/composer.json
+++ b/src/Elcodi/Component/Attribute/composer.json
@@ -41,6 +41,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Attribute\\": ""
         }

--- a/src/Elcodi/Component/Banner/composer.json
+++ b/src/Elcodi/Component/Banner/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Banner\\": ""
         }

--- a/src/Elcodi/Component/Cart/composer.json
+++ b/src/Elcodi/Component/Cart/composer.json
@@ -47,6 +47,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Cart\\": ""
         }

--- a/src/Elcodi/Component/CartCoupon/composer.json
+++ b/src/Elcodi/Component/CartCoupon/composer.json
@@ -46,6 +46,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\CartCoupon\\": ""
         }

--- a/src/Elcodi/Component/Comment/composer.json
+++ b/src/Elcodi/Component/Comment/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Comment\\": ""
         }

--- a/src/Elcodi/Component/Configuration/composer.json
+++ b/src/Elcodi/Component/Configuration/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Configuration\\": ""
         }

--- a/src/Elcodi/Component/Core/composer.json
+++ b/src/Elcodi/Component/Core/composer.json
@@ -47,6 +47,9 @@
         "michelf/php-markdown": "Needed for the markdown parsing adapter"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Core\\": ""
         }

--- a/src/Elcodi/Component/Coupon/composer.json
+++ b/src/Elcodi/Component/Coupon/composer.json
@@ -44,6 +44,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Coupon\\": ""
         }

--- a/src/Elcodi/Component/Currency/composer.json
+++ b/src/Elcodi/Component/Currency/composer.json
@@ -48,6 +48,9 @@
         "guzzle/http": "Required for OpenExchangeRates adapter"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Currency\\": ""
         }

--- a/src/Elcodi/Component/EntityTranslator/composer.json
+++ b/src/Elcodi/Component/EntityTranslator/composer.json
@@ -45,6 +45,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\EntityTranslator\\": ""
         }

--- a/src/Elcodi/Component/Geo/composer.json
+++ b/src/Elcodi/Component/Geo/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Geo\\": ""
         }

--- a/src/Elcodi/Component/Language/composer.json
+++ b/src/Elcodi/Component/Language/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Language\\": ""
         }

--- a/src/Elcodi/Component/Media/composer.json
+++ b/src/Elcodi/Component/Media/composer.json
@@ -49,6 +49,9 @@
         "twig/twig": "Required if using Twig extensions"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Media\\": ""
         }

--- a/src/Elcodi/Component/Menu/composer.json
+++ b/src/Elcodi/Component/Menu/composer.json
@@ -46,6 +46,9 @@
         "symfony/routing": "^2.7"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Menu\\": ""
         }

--- a/src/Elcodi/Component/MetaData/composer.json
+++ b/src/Elcodi/Component/MetaData/composer.json
@@ -34,6 +34,9 @@
         "php": "^5.4|^7.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\MetaData\\": ""
         }

--- a/src/Elcodi/Component/Metric/composer.json
+++ b/src/Elcodi/Component/Metric/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Metric\\": ""
         }

--- a/src/Elcodi/Component/Newsletter/composer.json
+++ b/src/Elcodi/Component/Newsletter/composer.json
@@ -44,6 +44,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Newsletter\\": ""
         }

--- a/src/Elcodi/Component/Page/composer.json
+++ b/src/Elcodi/Component/Page/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Page\\": ""
         }

--- a/src/Elcodi/Component/Payment/composer.json
+++ b/src/Elcodi/Component/Payment/composer.json
@@ -41,6 +41,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Payment\\": ""
         }

--- a/src/Elcodi/Component/Plugin/composer.json
+++ b/src/Elcodi/Component/Plugin/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Plugin\\": ""
         }

--- a/src/Elcodi/Component/Product/composer.json
+++ b/src/Elcodi/Component/Product/composer.json
@@ -47,6 +47,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Product\\": ""
         }

--- a/src/Elcodi/Component/Rule/composer.json
+++ b/src/Elcodi/Component/Rule/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Rule\\": ""
         }

--- a/src/Elcodi/Component/Shipping/composer.json
+++ b/src/Elcodi/Component/Shipping/composer.json
@@ -43,6 +43,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Shipping\\": ""
         }

--- a/src/Elcodi/Component/Sitemap/composer.json
+++ b/src/Elcodi/Component/Sitemap/composer.json
@@ -40,6 +40,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Sitemap\\": ""
         }

--- a/src/Elcodi/Component/StateTransitionMachine/composer.json
+++ b/src/Elcodi/Component/StateTransitionMachine/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\StateTransitionMachine\\": ""
         }

--- a/src/Elcodi/Component/Store/composer.json
+++ b/src/Elcodi/Component/Store/composer.json
@@ -45,6 +45,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Store\\": ""
         }

--- a/src/Elcodi/Component/Tax/composer.json
+++ b/src/Elcodi/Component/Tax/composer.json
@@ -41,6 +41,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Tax\\": ""
         }

--- a/src/Elcodi/Component/User/composer.json
+++ b/src/Elcodi/Component/User/composer.json
@@ -48,6 +48,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\User\\": ""
         }

--- a/src/Elcodi/Component/Zone/composer.json
+++ b/src/Elcodi/Component/Zone/composer.json
@@ -42,6 +42,9 @@
         "phpunit/phpunit": "4.5.0"
     },
     "autoload": {
+        "exclude-from-classmap": [
+            "/Tests/"
+        ],
         "psr-4": {
             "Elcodi\\Component\\Zone\\": ""
         }


### PR DESCRIPTION
The Composer production classmap generator will ignore all files in
these paths. The paths are absolute from the package root directory,
`**` is implicitly added to the end of the paths.

Ref: https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps