### PR TITLE
Quoted strings correctly to solve yaml component deprecation

### DIFF
--- a/src/Elcodi/Bundle/AttributeBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/AttributeBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.attribute
-            - @elcodi.repository.attribute
-            - @elcodi.factory.attribute
+            - '@elcodi.object_manager.attribute'
+            - '@elcodi.repository.attribute'
+            - '@elcodi.factory.attribute'
 
     elcodi.director.attribute_value:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.attribute_value
-            - @elcodi.repository.attribute_value
-            - @elcodi.factory.attribute_value
+            - '@elcodi.object_manager.attribute_value'
+            - '@elcodi.repository.attribute_value'
+            - '@elcodi.factory.attribute_value'

--- a/src/Elcodi/Bundle/BannerBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/BannerBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.banner
-            - @elcodi.repository.banner
-            - @elcodi.factory.banner
+            - '@elcodi.object_manager.banner'
+            - '@elcodi.repository.banner'
+            - '@elcodi.factory.banner'
 
     elcodi.director.banner_zone:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.banner_zone
-            - @elcodi.repository.banner_zone
-            - @elcodi.factory.banner_zone
+            - '@elcodi.object_manager.banner_zone'
+            - '@elcodi.repository.banner_zone'
+            - '@elcodi.factory.banner_zone'

--- a/src/Elcodi/Bundle/BannerBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/BannerBundle/Resources/config/services.yml
@@ -6,4 +6,4 @@ services:
     elcodi.manager.banner:
         class: Elcodi\Component\Banner\Services\BannerManager
         arguments:
-            - @elcodi.repository.banner
+            - '@elcodi.repository.banner'

--- a/src/Elcodi/Bundle/BannerBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/BannerBundle/Tests/Functional/app/config.yml
@@ -1,3 +1,3 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/filesystem.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/filesystem.test.yml' }

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/directors.yml
@@ -7,30 +7,30 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.cart
-            - @elcodi.repository.cart
-            - @elcodi.factory.cart
+            - '@elcodi.object_manager.cart'
+            - '@elcodi.repository.cart'
+            - '@elcodi.factory.cart'
 
     elcodi.director.cart_line:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.cart_line
-            - @elcodi.repository.cart_line
-            - @elcodi.factory.cart_line
+            - '@elcodi.object_manager.cart_line'
+            - '@elcodi.repository.cart_line'
+            - '@elcodi.factory.cart_line'
 
     elcodi.director.order:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.order
-            - @elcodi.repository.order
-            - @elcodi.factory.order
+            - '@elcodi.object_manager.order'
+            - '@elcodi.repository.order'
+            - '@elcodi.factory.order'
 
     elcodi.director.order_line:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.order_line
-            - @elcodi.repository.order_line
-            - @elcodi.factory.order_line
+            - '@elcodi.object_manager.order_line'
+            - '@elcodi.repository.order_line'
+            - '@elcodi.factory.order_line'

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -3,7 +3,7 @@ services:
     elcodi.event_listener.load_cart_prices:
         class: Elcodi\Component\Cart\EventListener\LoadCartPricesEventListener
         arguments:
-            - @elcodi.loader.cart_prices
+            - '@elcodi.loader.cart_prices'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: loadCartProductsAmount, priority: 16 }
             - { name: kernel.event_listener, event: cart.onload, method: loadCartTotalAmount, priority: 2 }
@@ -11,57 +11,57 @@ services:
     elcodi.event_listener.load_cart_purchasables_quantity:
         class: Elcodi\Component\Cart\EventListener\LoadCartPurchasablesQuantityEventListener
         arguments:
-            - @elcodi.loader.cart_purchasable_quantity
+            - '@elcodi.loader.cart_purchasable_quantity'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: loadCartPurchasablesQuantities, priority: 8 }
 
     elcodi.event_listener.save_cart:
         class: Elcodi\Component\Cart\EventListener\SaveCartEventListener
         arguments:
-            - @elcodi.cart_saver
+            - '@elcodi.cart_saver'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: saveCart, priority: 0 }
 
     elcodi.event_listener.validate_cart_integrity:
         class: Elcodi\Component\Cart\EventListener\ValidateCartIntegrityEventListener
         arguments:
-            - @elcodi.validator.cart_integrity
+            - '@elcodi.validator.cart_integrity'
         tags:
             - { name: kernel.event_listener, event: cart.preload, method: validateCartIntegrity, priority: 24 }
 
     elcodi.event_listener.validate_cart_amount:
         class: Elcodi\Component\Cart\EventListener\ValidateCartAmountEventListener
         arguments:
-            - @elcodi.validator.cart_amount
+            - '@elcodi.validator.cart_amount'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: validateAmount, priority: 1 }
 
     elcodi.event_listener.update_stock_by_cart_line:
         class: Elcodi\Component\Cart\EventListener\UpdateStockByCartLineEventListener
         arguments:
-            - @elcodi.updater.cart_line_stock
+            - '@elcodi.updater.cart_line_stock'
         tags:
             - { name: kernel.event_listener, event: order_line.oncreated, method: updatePurchasableStockByCartLine, priority: 0 }
 
     elcodi.event_listener.validate_empty_shipping_amount:
         class: Elcodi\Component\Cart\EventListener\ValidateEmptyShippingAmountEventListener
         arguments:
-            - @elcodi.validator.cart_shipping_method
+            - '@elcodi.validator.cart_shipping_method'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: validateEmptyShippingAmount, priority: 4 }
 
     elcodi.event_listener.save_cart_to_session:
         class: Elcodi\Component\Cart\EventListener\SaveCartToSessionEventListener
         arguments:
-            - @elcodi.session_manager.cart
+            - '@elcodi.session_manager.cart'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: saveCartInSession, priority: -2 }
 
     elcodi.event_listener.order_creation:
         class: Elcodi\Component\Cart\EventListener\OrderCreationEventListener
         arguments:
-            - @elcodi.object_manager.order
-            - @elcodi.object_manager.cart
+            - '@elcodi.object_manager.order'
+            - '@elcodi.object_manager.cart'
         tags:
             - { name: kernel.event_listener, event: order.oncreated, method: saveOrder, priority: 0}
             - { name: kernel.event_listener, event: order.oncreated, method: setCartAsOrdered, priority: -16 }
@@ -69,7 +69,7 @@ services:
     elcodi.event_listener.address_clone:
         class: Elcodi\Component\Cart\EventListener\AddressCloneEventListener
         arguments:
-            - @elcodi.repository.cart
-            - @elcodi.object_manager.cart
+            - '@elcodi.repository.cart'
+            - '@elcodi.object_manager.cart'
         tags:
             - { name: kernel.event_listener, event: address.onclone, method: updateCarts, priority: 0}

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
@@ -6,23 +6,23 @@ services:
     elcodi.manager.cart:
         class: Elcodi\Component\Cart\Services\CartManager
         arguments:
-            - @elcodi.event_dispatcher.cart
-            - @elcodi.event_dispatcher.cart_line
-            - @elcodi.factory.cart
-            - @elcodi.factory.cart_line
+            - '@elcodi.event_dispatcher.cart'
+            - '@elcodi.event_dispatcher.cart_line'
+            - '@elcodi.factory.cart'
+            - '@elcodi.factory.cart_line'
 
     elcodi.session_manager.cart:
         class: Elcodi\Component\Cart\Services\CartSessionManager
         arguments:
-            - @session
+            - '@session'
             - %elcodi.cart_session_field_name%
             - %elcodi.cart_save_in_session%
 
     elcodi.loader.cart_prices:
         class: Elcodi\Component\Cart\Services\CartPricesLoader
         arguments:
-            - @elcodi.wrapper.currency
-            - @elcodi.converter.currency
+            - '@elcodi.wrapper.currency'
+            - '@elcodi.converter.currency'
 
     elcodi.loader.cart_purchasable_quantity:
         class: Elcodi\Component\Cart\Services\CartPurchasablesQuantityLoader
@@ -30,14 +30,14 @@ services:
     elcodi.cart_saver:
         class: Elcodi\Component\Cart\Services\CartSaver
         arguments:
-            - @elcodi.object_manager.cart
+            - '@elcodi.object_manager.cart'
 
     elcodi.validator.cart_integrity:
         class: Elcodi\Component\Cart\Services\CartIntegrityValidator
         arguments:
-            - @elcodi.event_dispatcher.cart
-            - @elcodi.manager.cart
-            - @?elcodi.store_uses_stock
+            - '@elcodi.event_dispatcher.cart'
+            - '@elcodi.manager.cart'
+            - '@?elcodi.store_uses_stock'
 
     elcodi.validator.cart_amount:
         class: Elcodi\Component\Cart\Services\CartAmountValidator
@@ -45,10 +45,10 @@ services:
     elcodi.updater.cart_line_stock:
         class: Elcodi\Component\Cart\Services\CartLineStockUpdater
         arguments:
-            - @elcodi.object_manager.product
-            - @elcodi.object_manager.product_variant
+            - '@elcodi.object_manager.product'
+            - '@elcodi.object_manager.product_variant'
 
     elcodi.validator.cart_shipping_method:
         class: Elcodi\Component\Cart\Services\CartShippingAmountValidator
         arguments:
-            - @elcodi.wrapper.empty_money
+            - '@elcodi.wrapper.empty_money'

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/stateMachine.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/stateMachine.yml
@@ -6,7 +6,7 @@ services:
     elcodi.order_payment_states_machine_builder:
         class: Elcodi\Component\StateTransitionMachine\Machine\MachineBuilder
         arguments:
-            - @elcodi.factory.state_transition_machine
+            - '@elcodi.factory.state_transition_machine'
             - %elcodi.order_payment_states_machine_identifier%
             - %elcodi.order_payment_states_machine_states%
             - %elcodi.order_payment_states_machine_point_of_entry%
@@ -14,15 +14,15 @@ services:
     elcodi.order.payment_states_machine:
         class: Elcodi\Component\StateTransitionMachine\Machine\Machine
         factory:
-            - @elcodi.order_payment_states_machine_builder
+            - '@elcodi.order_payment_states_machine_builder'
             - compile
 
     elcodi.order_payment_states_machine_manager:
         class: Elcodi\Component\StateTransitionMachine\Machine\MachineManager
         arguments:
-            - @elcodi.order.payment_states_machine
-            - @elcodi.event_dispatcher.machine
-            - @elcodi.factory.state_transition_machine_state_line
+            - '@elcodi.order.payment_states_machine'
+            - '@elcodi.event_dispatcher.machine'
+            - '@elcodi.factory.state_transition_machine_state_line'
 
 
     #
@@ -31,7 +31,7 @@ services:
     elcodi.order_shipping_states_machine_builder:
         class: Elcodi\Component\StateTransitionMachine\Machine\MachineBuilder
         arguments:
-            - @elcodi.factory.state_transition_machine
+            - '@elcodi.factory.state_transition_machine'
             - %elcodi.order_shipping_states_machine_identifier%
             - %elcodi.order_shipping_states_machine_states%
             - %elcodi.order_shipping_states_machine_point_of_entry%
@@ -39,12 +39,12 @@ services:
     elcodi.order.shipping_states_machine:
         class: Elcodi\Component\StateTransitionMachine\Machine\Machine
         factory:
-            - @elcodi.order_shipping_states_machine_builder
+            - '@elcodi.order_shipping_states_machine_builder'
             - compile
 
     elcodi.order_shipping_states_machine_manager:
         class: Elcodi\Component\StateTransitionMachine\Machine\MachineManager
         arguments:
-            - @elcodi.order.shipping_states_machine
-            - @elcodi.event_dispatcher.machine
-            - @elcodi.factory.state_transition_machine_state_line
+            - '@elcodi.order.shipping_states_machine'
+            - '@elcodi.event_dispatcher.machine'
+            - '@elcodi.factory.state_transition_machine_state_line'

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/transformers.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/transformers.yml
@@ -6,12 +6,12 @@ services:
     elcodi.transformer.cart_order:
         class: Elcodi\Component\Cart\Transformer\CartOrderTransformer
         arguments:
-            - @elcodi.event_dispatcher.order
-            - @elcodi.transformer.cart_line_order_line
-            - @elcodi.factory.order
+            - '@elcodi.event_dispatcher.order'
+            - '@elcodi.transformer.cart_line_order_line'
+            - '@elcodi.factory.order'
 
     elcodi.transformer.cart_line_order_line:
         class: Elcodi\Component\Cart\Transformer\CartLineOrderLineTransformer
         arguments:
-            - @elcodi.event_dispatcher.order_line
-            - @elcodi.factory.order_line
+            - '@elcodi.event_dispatcher.order_line'
+            - '@elcodi.factory.order_line'

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/wrappers.yml
@@ -6,13 +6,13 @@ services:
     elcodi.wrapper.cart:
         class: Elcodi\Component\Cart\Wrapper\CartWrapper
         arguments:
-            - @elcodi.event_dispatcher.cart
-            - @elcodi.factory.cart
-            - @elcodi.wrapper.cart_session
-            - @elcodi.wrapper.customer
+            - '@elcodi.event_dispatcher.cart'
+            - '@elcodi.factory.cart'
+            - '@elcodi.wrapper.cart_session'
+            - '@elcodi.wrapper.customer'
 
     elcodi.wrapper.cart_session:
         class: Elcodi\Component\Cart\Wrapper\CartSessionWrapper
         arguments:
-            - @elcodi.session_manager.cart
-            - @elcodi.repository.cart
+            - '@elcodi.session_manager.cart'
+            - '@elcodi.repository.cart'

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/app/config.yml
@@ -1,4 +1,4 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/cache.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/filesystem.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/cache.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/filesystem.test.yml' }

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.cart_coupon
-            - @elcodi.repository.cart_coupon
-            - @elcodi.factory.cart_coupon
+            - '@elcodi.object_manager.cart_coupon'
+            - '@elcodi.repository.cart_coupon'
+            - '@elcodi.factory.cart_coupon'
 
     elcodi.director.order_coupon:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.order_coupon
-            - @elcodi.repository.order_coupon
-            - @elcodi.factory.order_coupon
+            - '@elcodi.object_manager.order_coupon'
+            - '@elcodi.repository.order_coupon'
+            - '@elcodi.factory.order_coupon'

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/eventListeners.yml
@@ -6,98 +6,98 @@ services:
     elcodi.event_listener.covert_cart_coupons_to_order_coupons:
         class: Elcodi\Component\CartCoupon\EventListener\ConvertCartCouponsToOrderCouponsEventListener
         arguments:
-            - @elcodi.transformer.cart_coupon_to_order_coupon
+            - '@elcodi.transformer.cart_coupon_to_order_coupon'
         tags:
             - { name: kernel.event_listener, event: order.oncreated, method: createOrderCouponsByCartCoupons, priority: -16 }
 
     elcodi.event_listener.create_and_save_cart_coupon:
         class: Elcodi\Component\CartCoupon\EventListener\CreateAndSaveCartCouponEventListener
         arguments:
-            - @elcodi.manager.cart_coupon
+            - '@elcodi.manager.cart_coupon'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: createAndSaveCartCoupon, priority: 1 }
 
     elcodi.event_listener.create_order_coupon_by_coupon:
         class: Elcodi\Component\CartCoupon\EventListener\CreateOrderCouponByCouponEventListener
         arguments:
-            - @elcodi.transformer.coupon_to_order_coupon
+            - '@elcodi.transformer.coupon_to_order_coupon'
         tags:
             - { name: kernel.event_listener, event: order_coupon.onapply, method: createOrderCouponByCoupon, priority: 0 }
 
     elcodi.event_listener.load_cart_coupon_amount:
         class: Elcodi\Component\CartCoupon\EventListener\LoadCartCouponAmountEventListener
         arguments:
-            - @elcodi.loader.cart_coupon_prices
+            - '@elcodi.loader.cart_coupon_prices'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: refreshCouponAmount, priority: 6 }
 
     elcodi.event_listener.remove_cart_coupon:
         class: Elcodi\Component\CartCoupon\EventListener\RemoveCartCouponEventListener
         arguments:
-            - @elcodi.manager.cart_coupon
+            - '@elcodi.manager.cart_coupon'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onremove, method: removeCartCoupon, priority: 0 }
 
     elcodi.event_listener.try_automatic_coupons_application:
         class: Elcodi\Component\CartCoupon\EventListener\TryAutomaticCouponsApplicationEventListener
         arguments:
-            - @elcodi.applicator.automatic_coupon
+            - '@elcodi.applicator.automatic_coupon'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: tryAutomaticCoupons, priority: 16 }
 
     elcodi.event_listener.validate_cart_coupon:
         class: Elcodi\Component\CartCoupon\EventListener\ValidateCartCouponEventListener
         arguments:
-            - @elcodi.event_dispatcher.cart_coupon
+            - '@elcodi.event_dispatcher.cart_coupon'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: validateCoupon, priority: 16 }
 
     elcodi.event_listener.validate_coupon_duplication:
         class: Elcodi\Component\CartCoupon\EventListener\ValidateCouponDuplicationEventListener
         arguments:
-            - @elcodi.validator.duplicated_coupon
+            - '@elcodi.validator.duplicated_coupon'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: validateDuplicatedCoupon, priority: 16 }
 
     elcodi.event_listener.validate_coupon:
         class: Elcodi\Component\CartCoupon\EventListener\ValidateCouponEventListener
         arguments:
-            - @elcodi.validator.cart_coupon
+            - '@elcodi.validator.cart_coupon'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.oncheck, method: validateCoupon, priority: 32 }
 
     elcodi.event_listener.validate_coupon_minimum_price:
         class: Elcodi\Component\CartCoupon\EventListener\ValidateCouponMinimumPriceEventListener
         arguments:
-            - @elcodi.validator.cart_coupon_minimum_price
+            - '@elcodi.validator.cart_coupon_minimum_price'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.oncheck, method: validateCartCouponMinimumPrice, priority: 0 }
 
     elcodi.event_listener.validate_coupon_rules:
         class: Elcodi\Component\CartCoupon\EventListener\ValidateCouponRulesEventListener
         arguments:
-            - @elcodi.validator.cart_coupon_rule
+            - '@elcodi.validator.cart_coupon_rule'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.oncheck, method: validateCartCouponRules, priority: -16 }
 
     elcodi.event_listener.validate_coupons_from_cart:
         class: Elcodi\Component\CartCoupon\EventListener\ValidateCouponsFromCartEventListener
         arguments:
-            - @elcodi.validator.cart_coupon
+            - '@elcodi.validator.cart_coupon'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: refreshCartCoupons, priority: 10 }
 
     elcodi.event_listener.validate_stackable_coupon:
         class: Elcodi\Component\CartCoupon\EventListener\ValidateStackableCouponsEventListener
         arguments:
-            - @elcodi.validator.stackable_coupon
+            - '@elcodi.validator.stackable_coupon'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: validateStackableCoupon, priority: 16 }
 
     elcodi.event_listener.update_cart_after_coupon_change:
         class: Elcodi\Component\CartCoupon\EventListener\CartUpdateAfterCouponChangeEventListener
         arguments:
-            - @elcodi.event_dispatcher.cart
+            - '@elcodi.event_dispatcher.cart'
         tags:
             - { name: kernel.event_listener, event: cart_coupon.onapply, method: updateCart, priority: 0 }
             - { name: kernel.event_listener, event: cart_coupon.onremove, method: updateCart, priority: 0 }

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
@@ -6,16 +6,16 @@ services:
     elcodi.manager.cart_coupon:
         class: Elcodi\Component\CartCoupon\Services\CartCouponManager
         arguments:
-            - @elcodi.event_dispatcher.cart_coupon
-            - @elcodi.repository.coupon
-            - @elcodi.director.cart_coupon
-            - @elcodi.repository.cart_coupon
+            - '@elcodi.event_dispatcher.cart_coupon'
+            - '@elcodi.repository.coupon'
+            - '@elcodi.director.cart_coupon'
+            - '@elcodi.repository.cart_coupon'
 
     elcodi.truncator.order_coupon:
         class: Elcodi\Component\CartCoupon\Services\OrderCouponTruncator
         arguments:
-            - @elcodi.repository.order_coupon
-            - @elcodi.object_manager.order_coupon
+            - '@elcodi.repository.order_coupon'
+            - '@elcodi.object_manager.order_coupon'
 
     #
     # Applicators
@@ -23,8 +23,8 @@ services:
     elcodi.applicator.automatic_coupon:
         class: Elcodi\Component\CartCoupon\Services\AutomaticCouponApplicator
         arguments:
-            - @elcodi.manager.cart_coupon
-            - @elcodi.repository.coupon
+            - '@elcodi.manager.cart_coupon'
+            - '@elcodi.repository.coupon'
 
     #
     # Loaders
@@ -32,9 +32,9 @@ services:
     elcodi.loader.cart_coupon_prices:
         class: Elcodi\Component\CartCoupon\Services\CartCouponPricesLoader
         arguments:
-            - @elcodi.manager.cart_coupon
-            - @elcodi.wrapper.currency
-            - @elcodi.converter.currency
+            - '@elcodi.manager.cart_coupon'
+            - '@elcodi.wrapper.currency'
+            - '@elcodi.converter.currency'
 
     #
     # Validator
@@ -42,26 +42,26 @@ services:
     elcodi.validator.cart_coupon_minimum_price:
         class: Elcodi\Component\CartCoupon\Services\CartCouponMinimumPriceValidator
         arguments:
-            - @elcodi.converter.currency
+            - '@elcodi.converter.currency'
 
     elcodi.validator.cart_coupon_rule:
         class: Elcodi\Component\CartCoupon\Services\CartCouponRuleValidator
         arguments:
-            - @elcodi.manager.rule
+            - '@elcodi.manager.rule'
 
     elcodi.validator.cart_coupon:
         class: Elcodi\Component\CartCoupon\Services\CartCouponValidator
         arguments:
-            - @elcodi.manager.cart_coupon
-            - @elcodi.manager.coupon
-            - @elcodi.event_dispatcher.cart_coupon
+            - '@elcodi.manager.cart_coupon'
+            - '@elcodi.manager.coupon'
+            - '@elcodi.event_dispatcher.cart_coupon'
 
     elcodi.validator.duplicated_coupon:
         class: Elcodi\Component\CartCoupon\Services\DuplicatedCouponValidator
         arguments:
-            - @elcodi.repository.cart_coupon
+            - '@elcodi.repository.cart_coupon'
 
     elcodi.validator.stackable_coupon:
         class: Elcodi\Component\CartCoupon\Services\StackableCouponValidator
         arguments:
-            - @elcodi.repository.cart_coupon
+            - '@elcodi.repository.cart_coupon'

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/transformers.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/transformers.yml
@@ -6,13 +6,13 @@ services:
     elcodi.transformer.coupon_to_order_coupon:
         class: Elcodi\Component\CartCoupon\Transformer\CouponToOrderCouponTransformer
         arguments:
-            - @elcodi.object_manager.order_coupon
-            - @elcodi.event_dispatcher.coupon
-            - @elcodi.factory.order_coupon
+            - '@elcodi.object_manager.order_coupon'
+            - '@elcodi.event_dispatcher.coupon'
+            - '@elcodi.factory.order_coupon'
 
     elcodi.transformer.cart_coupon_to_order_coupon:
         class: Elcodi\Component\CartCoupon\Transformer\CartCouponToOrderCouponTransformer
         arguments:
-            - @elcodi.manager.cart_coupon
-            - @elcodi.truncator.order_coupon
-            - @elcodi.event_dispatcher.order_coupon
+            - '@elcodi.manager.cart_coupon'
+            - '@elcodi.truncator.order_coupon'
+            - '@elcodi.event_dispatcher.order_coupon'

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/app/config.yml
@@ -1,4 +1,4 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/cache.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/filesystem.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/cache.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/filesystem.test.yml' }

--- a/src/Elcodi/Bundle/CartShippingBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartShippingBundle/Resources/config/eventListeners.yml
@@ -3,13 +3,13 @@ services:
     elcodi.event_listener.load_cart_shipping_amount:
         class: Elcodi\Component\CartShipping\EventListener\LoadCartShippingAmountEventListener
         arguments:
-            - @elcodi.loader.cart_shipping_amount
+            - '@elcodi.loader.cart_shipping_amount'
         tags:
             - { name: kernel.event_listener, event: cart.onload, method: loadCartShippingAmount, priority: 6 }
 
     elcodi.event_listener.load_order_shipping_method:
         class: Elcodi\Component\CartShipping\EventListener\LoadOrderShippingMethodEventListener
         arguments:
-            - @elcodi.loader.order_shipping_method
+            - '@elcodi.loader.order_shipping_method'
         tags:
             - { name: kernel.event_listener, event: order.oncreated, method: loadOrderShippingMethod, priority: 16 }

--- a/src/Elcodi/Bundle/CartShippingBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartShippingBundle/Resources/config/services.yml
@@ -3,9 +3,9 @@ services:
     elcodi.loader.cart_shipping_amount:
         class: Elcodi\Component\CartShipping\Services\CartShippingAmountLoader
         arguments:
-            - @elcodi.wrapper.shipping_methods
+            - '@elcodi.wrapper.shipping_methods'
 
     elcodi.loader.order_shipping_method:
         class: Elcodi\Component\CartShipping\Services\OrderShippingMethodLoader
         arguments:
-            - @elcodi.wrapper.shipping_methods
+            - '@elcodi.wrapper.shipping_methods'

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/controllers.yml
@@ -6,6 +6,6 @@ services:
     elcodi.controller.comment:
         class: Elcodi\Component\Comment\Controller\CommentController
         arguments:
-            - @elcodi.manager.comment
-            - @elcodi.comment_cache
-            - @elcodi.repository.comment
+            - '@elcodi.manager.comment'
+            - '@elcodi.comment_cache'
+            - '@elcodi.repository.comment'

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.comment
-            - @elcodi.repository.comment
-            - @elcodi.factory.comment
+            - '@elcodi.object_manager.comment'
+            - '@elcodi.repository.comment'
+            - '@elcodi.factory.comment'
 
     elcodi.director.comment_vote:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.comment_vote
-            - @elcodi.repository.comment_vote
-            - @elcodi.factory.comment_vote
+            - '@elcodi.object_manager.comment_vote'
+            - '@elcodi.repository.comment_vote'
+            - '@elcodi.factory.comment_vote'

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/eventDispatchers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.event_dispatcher.comment:
         class: Elcodi\Component\Comment\EventDispatcher\CommentEventDispatcher
         arguments:
-            - @event_dispatcher
+            - '@event_dispatcher'

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.event_listener.comment_cache_invalidation:
         class: Elcodi\Component\Comment\EventListener\CommentCacheInvalidationEventListener
         arguments:
-            - @elcodi.comment_cache
+            - '@elcodi.comment_cache'
         tags:
             - { name: kernel.event_listener, event: comment.onadd, method: onCommentChange, priority: 0 }
             - { name: kernel.event_listener, event: comment.onedit, method: onCommentChange, priority: 0 }

--- a/src/Elcodi/Bundle/CommentBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Resources/config/services.yml
@@ -6,21 +6,21 @@ services:
     elcodi.manager.comment:
         class: Elcodi\Component\Comment\Services\CommentManager
         arguments:
-            - @elcodi.event_dispatcher.comment
-            - @elcodi.director.comment
+            - '@elcodi.event_dispatcher.comment'
+            - '@elcodi.director.comment'
 
     elcodi.comment_cache:
         class: Elcodi\Component\Comment\Services\CommentCache
         arguments:
-            - @elcodi.repository.comment
-            - @elcodi.manager.comment_vote
+            - '@elcodi.repository.comment'
+            - '@elcodi.manager.comment_vote'
             - %elcodi.comment.cache_key%
         calls:
-            - [setCache, [@doctrine_cache.providers.elcodi_comments]]
-            - [setEncoder, [@elcodi.json_encoder]]
+            - [setCache, ['@doctrine_cache.providers.elcodi_comments']]
+            - [setEncoder, ['@elcodi.json_encoder']]
 
     elcodi.manager.comment_vote:
         class: Elcodi\Component\Comment\Services\VoteManager
         arguments:
-            - @elcodi.event_dispatcher.comment
-            - @elcodi.director.comment_vote
+            - '@elcodi.event_dispatcher.comment'
+            - '@elcodi.director.comment_vote'

--- a/src/Elcodi/Bundle/CommentBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/CommentBundle/Tests/Functional/app/config.yml
@@ -1,3 +1,3 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/cache.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/cache.test.yml' }

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/commands.yml
@@ -6,20 +6,20 @@ services:
     elcodi.command.configuration_set:
         class: Elcodi\Component\Configuration\Command\ConfigurationSetCommand
         arguments:
-            - @elcodi.manager.configuration
+            - '@elcodi.manager.configuration'
         tags:
             - { name: console.command }
 
     elcodi.command.configuration_get:
         class: Elcodi\Component\Configuration\Command\ConfigurationGetCommand
         arguments:
-            - @elcodi.manager.configuration
+            - '@elcodi.manager.configuration'
         tags:
             - { name: console.command }
 
     elcodi.command.configuration_delete:
         class: Elcodi\Component\Configuration\Command\ConfigurationDeleteCommand
         arguments:
-            - @elcodi.manager.configuration
+            - '@elcodi.manager.configuration'
         tags:
             - { name: console.command }

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.configuration
-            - @elcodi.repository.configuration
-            - @elcodi.factory.configuration
+            - '@elcodi.object_manager.configuration'
+            - '@elcodi.repository.configuration'
+            - '@elcodi.factory.configuration'

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/doctrine/Configuration.orm.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/doctrine/Configuration.orm.yml
@@ -9,7 +9,7 @@ Elcodi\Component\Configuration\Entity\Configuration:
             length: 255
             nullable: false
         key:
-            column: `key`
+            column: '`key`'
             type: string
             length: 255
             nullable: false

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/services.yml
@@ -7,10 +7,10 @@ services:
         class: Elcodi\Component\Configuration\Services\ConfigurationManager
         lazy: true
         arguments:
-            - @elcodi.object_manager.configuration
-            - @elcodi.repository.configuration
-            - @elcodi.factory.configuration
-            - @elcodi.container_parameters
+            - '@elcodi.object_manager.configuration'
+            - '@elcodi.repository.configuration'
+            - '@elcodi.factory.configuration'
+            - '@elcodi.container_parameters'
             - %elcodi.configuration_elements%
         calls:
-            - [setCache, [@doctrine_cache.providers.elcodi_configurations]]
+            - [setCache, ['@doctrine_cache.providers.elcodi_configurations']]

--- a/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.configuration:
         class: Elcodi\Component\Configuration\Twig\ConfigurationExtension
         arguments:
-            - @elcodi.manager.configuration
+            - '@elcodi.manager.configuration'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/ConfigurationBundle/Tests/Functional/app/config.yml
@@ -1,6 +1,6 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/cache.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/cache.test.yml' }
 
 parameters:
     my_parameter: my_parameter_value
@@ -31,14 +31,14 @@ services:
     my_class_parameter:
         class: Elcodi\Bundle\ConfigurationBundle\Tests\Functional\Fixtures\MyClass
         arguments:
-            - @=elcodi_config("my_parameter")
+            - '@=elcodi_config("my_parameter")'
 
     my_class_parameter_boolean:
         class: Elcodi\Bundle\ConfigurationBundle\Tests\Functional\Fixtures\MyClass
         arguments:
-            - @=elcodi_config("app.my_boolean_parameter")
+            - '@=elcodi_config("app.my_boolean_parameter")'
 
     my_class_non_existing_parameter:
         class: Elcodi\Bundle\ConfigurationBundle\Tests\Functional\Fixtures\MyClass
         arguments:
-            - @=elcodi_config("my_non_existing_parameter")
+            - '@=elcodi_config("my_non_existing_parameter")'

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/eventDispatchers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.event_dispatcher.abstract:
         abstract: true
         arguments:
-            - @event_dispatcher
+            - '@event_dispatcher'

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/extractor.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/extractor.yml
@@ -14,5 +14,5 @@ services:
     elcodi.extractor:
         class: Mmoreram\Extractor\Extractor
         arguments:
-            - @elcodi.extractor.directory
-            - @elcodi.extractor.extension_resolver
+            - '@elcodi.extractor.directory'
+            - '@elcodi.extractor.extension_resolver'

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/generators.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/generators.yml
@@ -9,7 +9,7 @@ services:
     elcodi.generator.sha1:
         class: Elcodi\Component\Core\Generator\Sha1Generator
         arguments:
-            - @elcodi.generator.random_string
+            - '@elcodi.generator.random_string'
 
     elcodi.generator.uniqid:
         class: Elcodi\Component\Core\Generator\UniqIdGenerator

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/providers.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/providers.yml
@@ -6,20 +6,20 @@ services:
     elcodi.container_parameters:
         class: Symfony\Component\DependencyInjection\ParameterBag\ParameterBag
         factory:
-            - @service_container
+            - '@service_container'
             - getParameterBag
 
     elcodi.provider.manager:
         class: Elcodi\Component\Core\Services\ManagerProvider
         arguments:
-            - @doctrine
-            - @elcodi.container_parameters
+            - '@doctrine'
+            - '@elcodi.container_parameters'
 
     elcodi.provider.repository:
         class: Elcodi\Component\Core\Services\RepositoryProvider
         arguments:
-            - @elcodi.provider.manager
-            - @elcodi.container_parameters
+            - '@elcodi.provider.manager'
+            - '@elcodi.container_parameters'
 
     elcodi.mapping_provider:
         class: Elcodi\Component\Core\Services\MappingProvider
@@ -29,5 +29,5 @@ services:
     elcodi.referrer_provider:
         class: Elcodi\Component\Core\Services\ReferrerProvider
         arguments:
-            - @session
-            - @request_stack
+            - '@session'
+            - '@request_stack'

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/services.yml
@@ -6,7 +6,7 @@ services:
     elcodi.abstract_manager:
         class: Doctrine\Common\Persistence\ObjectManager
         factory:
-            - @elcodi.provider.manager
+            - '@elcodi.provider.manager'
             - getManagerByEntityNamespace
         abstract: true
 
@@ -16,6 +16,6 @@ services:
     elcodi.abstract_repository:
         class: Doctrine\Common\Persistence\ObjectRepository
         factory:
-            - @elcodi.provider.repository
+            - '@elcodi.provider.repository'
             - getRepositoryByEntityNamespace
         abstract: true

--- a/src/Elcodi/Bundle/CoreBundle/Resources/config/test/configuration.test.yml
+++ b/src/Elcodi/Bundle/CoreBundle/Resources/config/test/configuration.test.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/parameters.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/parameters.test.yml' }
 
 framework:
     test:            ~

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.coupon
-            - @elcodi.repository.coupon
-            - @elcodi.factory.coupon
+            - '@elcodi.object_manager.coupon'
+            - '@elcodi.repository.coupon'
+            - '@elcodi.factory.coupon'

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/eventListeners.yml
@@ -6,6 +6,6 @@ services:
     elcodi.event_listener.make_coupon_used:
         class: Elcodi\Component\Coupon\EventListener\MakeCouponUsedEventListener
         arguments:
-            - @elcodi.object_manager.coupon
+            - '@elcodi.object_manager.coupon'
         tags:
             - { name: kernel.event_listener, event: coupon.onused, method: makeUse, priority: 0 }

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/services.yml
@@ -6,6 +6,6 @@ services:
     elcodi.manager.coupon:
         class: Elcodi\Component\Coupon\Services\CouponManager
         arguments:
-            - @elcodi.factory.coupon
-            - @elcodi.generator.random_string
-            - @elcodi.factory.datetime
+            - '@elcodi.factory.coupon'
+            - '@elcodi.generator.random_string'
+            - '@elcodi.factory.datetime'

--- a/src/Elcodi/Bundle/CouponBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Tests/Functional/app/config.yml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/adapters.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/adapters.yml
@@ -6,7 +6,7 @@ services:
     elcodi.currency_exchange_rate_adapter.yahoo_finances:
         class: Elcodi\Component\Currency\Adapter\CurrencyExchangeRatesProvider\YahooFinanceProviderAdapter
         arguments:
-            - @elcodi.guzzle_client
+            - '@elcodi.guzzle_client'
 
     elcodi.currency_exchange_rate_adapter.dummy:
         class: Elcodi\Component\Currency\Adapter\CurrencyExchangeRatesProvider\DummyProviderAdapter

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/commands.yml
@@ -6,6 +6,6 @@ services:
     elcodi.command.populate_currency_rates:
         class: Elcodi\Component\Currency\Command\CurrencyExchangeRatesPopulateCommand
         arguments:
-            - @elcodi.populator.currency_exchange_rate
+            - '@elcodi.populator.currency_exchange_rate'
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.currency
-            - @elcodi.repository.currency
-            - @elcodi.factory.currency
+            - '@elcodi.object_manager.currency'
+            - '@elcodi.repository.currency'
+            - '@elcodi.factory.currency'
 
     elcodi.director.currency_exchange_rate:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.currency_exchange_rate
-            - @elcodi.repository.currency_exchange_rate
-            - @elcodi.factory.currency_exchange_rate
+            - '@elcodi.object_manager.currency_exchange_rate'
+            - '@elcodi.repository.currency_exchange_rate'
+            - '@elcodi.factory.currency_exchange_rate'

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/expressionLanguage.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/expressionLanguage.yml
@@ -6,7 +6,7 @@ services:
     elcodi.expression_language.money_provider:
         class: Elcodi\Component\Currency\ExpressionLanguage\MoneyProvider
         arguments:
-            - @elcodi.wrapper.default_currency
-            - @elcodi.repository.currency
+            - '@elcodi.wrapper.default_currency'
+            - '@elcodi.repository.currency'
         tags:
             - { name: elcodi.rule_configuration }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/factories.yml
@@ -11,7 +11,7 @@ services:
         class: Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory
         abstract: true
         arguments:
-            - @elcodi.wrapper.empty_money
+            - '@elcodi.wrapper.empty_money'
 
     #
     # Factory for Currency entities

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/services.yml
@@ -6,40 +6,40 @@ services:
     elcodi.manager.currency:
         class: Elcodi\Component\Currency\Services\CurrencyManager
         arguments:
-            - @elcodi.repository.currency
-            - @elcodi.repository.currency_exchange_rate
+            - '@elcodi.repository.currency'
+            - '@elcodi.repository.currency_exchange_rate'
             - %elcodi.default_currency%
 
     elcodi.manager.currency_session:
         class: Elcodi\Component\Currency\Services\CurrencySessionManager
         arguments:
-            - @session
+            - '@session'
             - %elcodi.currency_session_field_name%
 
     elcodi.converter.currency:
         class: Elcodi\Component\Currency\Services\CurrencyConverter
         arguments:
-            - @elcodi.calculator.exchange_rate
+            - '@elcodi.calculator.exchange_rate'
 
     elcodi.money_printer:
         class: Elcodi\Component\Currency\Services\MoneyPrinter
         arguments:
-            - @elcodi.converter.currency
-            - @elcodi.wrapper.currency
-            - @elcodi.locale
+            - '@elcodi.converter.currency'
+            - '@elcodi.wrapper.currency'
+            - '@elcodi.locale'
 
     elcodi.populator.currency_exchange_rate:
         class: Elcodi\Component\Currency\Populator\CurrencyExchangeRatesPopulator
         lazy: true
         arguments:
-            - @elcodi.adapter.currency_exchange_rate
-            - @elcodi.director.currency_exchange_rate
-            - @elcodi.repository.currency
+            - '@elcodi.adapter.currency_exchange_rate'
+            - '@elcodi.director.currency_exchange_rate'
+            - '@elcodi.repository.currency'
             - %elcodi.default_currency%
 
     elcodi.calculator.exchange_rate:
         class: Elcodi\Component\Currency\Services\ExchangeRateCalculator
         lazy: true
         arguments:
-            - @elcodi.manager.currency
+            - '@elcodi.manager.currency'
             - %elcodi.default_currency%

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.money_printer:
         class: Elcodi\Component\Currency\Twig\MoneyPrinterExtension
         arguments:
-            - @elcodi.money_printer
+            - '@elcodi.money_printer'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/CurrencyBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/CurrencyBundle/Resources/config/wrappers.yml
@@ -6,17 +6,17 @@ services:
     elcodi.wrapper.currency:
         class: Elcodi\Component\Currency\Wrapper\CurrencyWrapper
         arguments:
-            - @elcodi.manager.currency_session
-            - @elcodi.repository.currency
-            - @elcodi.wrapper.default_currency
+            - '@elcodi.manager.currency_session'
+            - '@elcodi.repository.currency'
+            - '@elcodi.wrapper.default_currency'
 
     elcodi.wrapper.default_currency:
         class: Elcodi\Component\Currency\Wrapper\DefaultCurrencyWrapper
         arguments:
-            - @elcodi.repository.currency
+            - '@elcodi.repository.currency'
             - %elcodi.default_currency%
 
     elcodi.wrapper.empty_money:
         class: Elcodi\Component\Currency\Wrapper\EmptyMoneyWrapper
         arguments:
-            - @elcodi.wrapper.default_currency
+            - '@elcodi.wrapper.default_currency'

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/autoloadEventListeners.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/autoloadEventListeners.yml
@@ -7,7 +7,7 @@ services:
         class: Elcodi\Component\EntityTranslator\EventListener\EntityTranslatorEntityEventListener
         lazy: true
         arguments:
-            - @service_container
-            - @elcodi.locale
+            - '@service_container'
+            - '@elcodi.locale'
         tags:
             - { name: doctrine.event_listener, event: postLoad }

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/commands.yml
@@ -6,4 +6,4 @@ services:
     elcodi.command.translations_warmup:
         class: Elcodi\Component\EntityTranslator\Console\TranslationsWarmupCommand
         arguments:
-            - @elcodi.event_dispatcher.entity_translator
+            - '@elcodi.event_dispatcher.entity_translator'

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.entity_translation
-            - @elcodi.repository.entity_translation
-            - @elcodi.factory.entity_translation
+            - '@elcodi.object_manager.entity_translation'
+            - '@elcodi.repository.entity_translation'
+            - '@elcodi.factory.entity_translation'

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventDispatchers.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventDispatchers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.event_dispatcher.entity_translator:
         class: Elcodi\Component\EntityTranslator\EventDispatcher\EntityTranslatorEventDispatcher
         arguments:
-            - @event_dispatcher
+            - '@event_dispatcher'

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/eventListeners.yml
@@ -6,12 +6,12 @@ services:
     elcodi.event_listener.entity_translator_form:
         class: Elcodi\Component\EntityTranslator\EventListener\EntityTranslatorFormEventListener
         arguments:
-            - @elcodi.entity_translation_provider
+            - '@elcodi.entity_translation_provider'
             - %elcodi.entity_translator_configuration%
-            - @elcodi.languages_iso_array
+            - '@elcodi.languages_iso_array'
             - %elcodi.entity_translator_language_master_locale%
             - %elcodi.entity_translator_language_fallback%
-            - @elcodi.entity_translator_changes
+            - '@elcodi.entity_translator_changes'
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: saveEntityTranslations }
 

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Resources/config/services.yml
@@ -4,18 +4,18 @@ services:
         class: Elcodi\Component\EntityTranslator\Services\EntityTranslationProvider
         lazy: true
         arguments:
-            - @elcodi.repository.entity_translation
-            - @elcodi.factory.entity_translation
-            - @elcodi.object_manager.entity_translation
+            - '@elcodi.repository.entity_translation'
+            - '@elcodi.factory.entity_translation'
+            - '@elcodi.object_manager.entity_translation'
 
     elcodi.services.cached_entity_translation_provider:
         class: Elcodi\Component\EntityTranslator\Services\CachedEntityTranslationProvider
         arguments:
-            - @elcodi.services.entity_translation_provider
-            - @elcodi.repository.entity_translation
+            - '@elcodi.services.entity_translation_provider'
+            - '@elcodi.repository.entity_translation'
             - %elcodi.entity_translator_cache_prefix%
         calls:
-            - [setCache, [@doctrine_cache.providers.elcodi_translations]]
+            - [setCache, ['@doctrine_cache.providers.elcodi_translations']]
         tags:
             - { name: kernel.event_listener, event: translator.warmup, method: warmUp }
 
@@ -28,13 +28,13 @@ services:
     elcodi.entity_translator_builder:
         class: Elcodi\Component\EntityTranslator\Services\EntityTranslatorBuilder
         arguments:
-            - @elcodi.entity_translation_provider
-            - @elcodi.factory.entity_translator
+            - '@elcodi.entity_translation_provider'
+            - '@elcodi.factory.entity_translator'
             - %elcodi.entity_translator_configuration%
             - %elcodi.entity_translator_language_fallback%
 
     elcodi.entity_translator:
         class: Elcodi\Component\EntityTranslator\Services\EntityTranslator
         factory:
-            - @elcodi.entity_translator_builder
+            - '@elcodi.entity_translator_builder'
             - compile

--- a/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/EntityTranslatorBundle/Tests/Functional/app/config.yml
@@ -1,6 +1,6 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/cache.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/cache.test.yml' }
 
 elcodi_entity_translator:
     configuration:

--- a/src/Elcodi/Bundle/FixturesBoosterBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/FixturesBoosterBundle/Resources/config/commands.yml
@@ -6,7 +6,7 @@ services:
     store.fixtures_booster.command.load_fixtures:
         class: Elcodi\Bundle\FixturesBoosterBundle\Command\LoadDataFixturesDoctrineCommand
         arguments:
-            - @kernel
+            - '@kernel'
             - %database_path%
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/adapters.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/adapters.yml
@@ -13,8 +13,8 @@ services:
     elcodi.location_populator_adapter.geonames:
         class: Elcodi\Component\Geo\Adapter\LocationPopulator\GeonamesLocationPopulatorAdapter
         arguments:
-            - @elcodi.extractor
-            - @elcodi.location_builder
+            - '@elcodi.extractor'
+            - '@elcodi.location_builder'
 
     #
     # Adapters for Location provider
@@ -22,13 +22,13 @@ services:
     elcodi.location_provider_adapter.service:
         class: Elcodi\Component\Geo\Adapter\LocationProvider\LocationServiceProviderAdapter
         arguments:
-            - @elcodi.repository.location
-            - @elcodi.transformer.location_to_location_data
+            - '@elcodi.repository.location'
+            - '@elcodi.transformer.location_to_location_data'
 
     elcodi.location_provider_adapter.api:
         class: Elcodi\Component\Geo\Adapter\LocationProvider\LocationApiProviderAdapter
         arguments:
-            - @elcodi.factory.location_data
-            - @router
-            - @elcodi.location_api_urls
+            - '@elcodi.factory.location_data'
+            - '@router'
+            - '@elcodi.location_api_urls'
             - %elcodi.location_api_host%

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/commands.yml
@@ -6,22 +6,22 @@ services:
     elcodi.command.location_populate:
         class: Elcodi\Component\Geo\Command\LocationPopulateCommand
         arguments:
-            - @elcodi.director.location
-            - @elcodi.location_populator
+            - '@elcodi.director.location'
+            - '@elcodi.location_populator'
         tags:
             -  { name: console.command }
 
     elcodi.command.location_load:
         class: Elcodi\Component\Geo\Command\LocationLoadCommand
         arguments:
-            - @elcodi.director.location
-            - @elcodi.location_loader
+            - '@elcodi.director.location'
+            - '@elcodi.location_loader'
         tags:
             -  { name: console.command }
 
     elcodi.command.location_drop:
         class: Elcodi\Component\Geo\Command\LocationDropCommand
         arguments:
-            - @elcodi.director.location
+            - '@elcodi.director.location'
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/controllers.yml
@@ -6,5 +6,5 @@ services:
     elcodi.controller.location_api:
         class: Elcodi\Component\Geo\Controller\LocationApiController
         arguments:
-            - @request_stack
-            - @elcodi.location_provider_adapter.service
+            - '@request_stack'
+            - '@elcodi.location_provider_adapter.service'

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.address
-            - @elcodi.repository.address
-            - @elcodi.factory.address
+            - '@elcodi.object_manager.address'
+            - '@elcodi.repository.address'
+            - '@elcodi.factory.address'
 
     elcodi.director.location:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.location
-            - @elcodi.repository.location
-            - @elcodi.factory.location
+            - '@elcodi.object_manager.location'
+            - '@elcodi.repository.location'
+            - '@elcodi.factory.location'

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/factories.yml
@@ -24,4 +24,4 @@ services:
     elcodi.factory.address_view:
         class: Elcodi\Component\Geo\Factory\AddressViewFactory
         arguments:
-            - @elcodi.location_provider
+            - '@elcodi.location_provider'

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/formatters.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/formatters.yml
@@ -6,4 +6,4 @@ services:
     elcodi.formatter.address:
         class: Elcodi\Component\Geo\Formatter\AddressFormatter
         arguments:
-            - @elcodi.location_provider
+            - '@elcodi.location_provider'

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/services.yml
@@ -6,25 +6,25 @@ services:
     elcodi.location_builder:
         class: Elcodi\Component\Geo\Services\LocationBuilder
         arguments:
-            - @elcodi.factory.location
+            - '@elcodi.factory.location'
 
     elcodi.location_populator:
         class: Elcodi\Component\Geo\Services\LocationPopulator
         arguments:
-            - @elcodi.location_populator_adapter
-            - @elcodi.object_manager.location
+            - '@elcodi.location_populator_adapter'
+            - '@elcodi.object_manager.location'
 
     elcodi.location_loader:
         class: Elcodi\Component\Geo\Services\LocationLoader
         arguments:
-            - @elcodi.object_manager.location
-            - @elcodi.location_loader_adapter
+            - '@elcodi.object_manager.location'
+            - '@elcodi.location_loader_adapter'
 
     elcodi.manager.address:
         class: Elcodi\Component\Geo\Services\AddressManager
         arguments:
-            - @elcodi.object_manager.address
-            - @elcodi.event_dispatcher.address
+            - '@elcodi.object_manager.address'
+            - '@elcodi.event_dispatcher.address'
 
 
     elcodi.location_api_urls:

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/transformers.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/transformers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.transformer.location_to_location_data:
         class: Elcodi\Component\Geo\Transformer\LocationToLocationDataTransformer
         arguments:
-            - @elcodi.factory.location_data
+            - '@elcodi.factory.location_data'

--- a/src/Elcodi/Bundle/GeoBundle/Resources/config/validator.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Resources/config/validator.yml
@@ -6,6 +6,6 @@ services:
     elcodi.validator.city_exists:
         class: Elcodi\Component\Geo\Validator\Constraints\CityExistsValidator
         arguments:
-            - @elcodi.location_provider
+            - '@elcodi.location_provider'
         tags:
             - { name: validator.constraint_validator, alias: city_exists }

--- a/src/Elcodi/Bundle/GeoBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/GeoBundle/Tests/Functional/app/config.yml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.language
-            - @elcodi.repository.language
-            - @elcodi.factory.language
+            - '@elcodi.object_manager.language'
+            - '@elcodi.repository.language'
+            - '@elcodi.factory.language'

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/services.yml
@@ -6,13 +6,13 @@ services:
     elcodi.provider.locale:
         class: Elcodi\Component\Language\Services\LocaleProvider
         arguments:
-            - @request_stack
+            - '@request_stack'
             - %locale%
 
     elcodi.provider.locale.locale:
         class: Elcodi\Component\Language\Entity\Locale
         factory:
-            - @elcodi.provider.locale
+            - '@elcodi.provider.locale'
             - getLocale
         public: false
 
@@ -22,18 +22,18 @@ services:
     elcodi.manager.language:
         class: Elcodi\Component\Language\Services\LanguageManager
         arguments:
-            - @elcodi.repository.language
+            - '@elcodi.repository.language'
 
     elcodi.manager.promoted_language:
         class: Elcodi\Component\Language\Services\PromotedLanguageManager
         arguments:
-            - @elcodi.manager.language
-            - @elcodi.locale
+            - '@elcodi.manager.language'
+            - '@elcodi.locale'
 
     elcodi.manager.locale:
         class: Elcodi\Component\Language\Services\LocaleManager
         arguments:
-            - @elcodi.provider.locale.locale
+            - '@elcodi.provider.locale.locale'
         calls:
             - [initialize, []]
 
@@ -43,23 +43,23 @@ services:
     elcodi.languages:
         class: Doctrine\Common\Collections\Collection
         factory:
-            - @elcodi.manager.language
+            - '@elcodi.manager.language'
             - getLanguages
 
     elcodi.languages_iso:
         class: Doctrine\Common\Collections\Collection
         factory:
-            - @elcodi.manager.language
+            - '@elcodi.manager.language'
             - getLanguagesIso
 
     elcodi.languages_iso_array:
         class: stdClass
         factory:
-            - @elcodi.languages_iso
+            - '@elcodi.languages_iso'
             - toArray
 
     elcodi.locale:
         class: Elcodi\Component\Language\Entity\Locale
         factory:
-            - @elcodi.manager.locale
+            - '@elcodi.manager.locale'
             - getLocale

--- a/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.language:
         class: Elcodi\Component\Language\Twig\LanguageExtension
         arguments:
-            - @elcodi.manager.promoted_language
+            - '@elcodi.manager.promoted_language'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/LanguageBundle/Tests/Functional/app/config.yml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/controllers.yml
@@ -6,19 +6,19 @@ services:
     elcodi.controller.image_resize:
         class: Elcodi\Component\Media\Controller\ImageResizeController
         arguments:
-            - @request_stack
-            - @elcodi.repository.image
-            - @elcodi.manager.media_image
-            - @elcodi.transformer.media_image_etag
+            - '@request_stack'
+            - '@elcodi.repository.image'
+            - '@elcodi.manager.media_image'
+            - '@elcodi.transformer.media_image_etag'
             - %elcodi.image_view_max_age%
             - %elcodi.image_view_shared_max_age%
 
     elcodi.controller.image_upload:
         class: Elcodi\Component\Media\Controller\ImageUploadController
         arguments:
-            - @request_stack
-            - @elcodi.uploader.image
-            - @router
+            - '@request_stack'
+            - '@elcodi.uploader.image'
+            - '@router'
             - %elcodi.image_upload_field_name%
             - elcodi.route.image_view
             - elcodi.route.image_resize

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.image
-            - @elcodi.repository.image
-            - @elcodi.factory.image
+            - '@elcodi.object_manager.image'
+            - '@elcodi.repository.image'
+            - '@elcodi.factory.image'

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/services.yml
@@ -6,20 +6,20 @@ services:
     elcodi.manager.media_image:
         class: Elcodi\Component\Media\Services\ImageManager
         arguments:
-            - @elcodi.factory.image
-            - @elcodi.manager.media_file
-            - @elcodi.media_resize_adapter
+            - '@elcodi.factory.image'
+            - '@elcodi.manager.media_file'
+            - '@elcodi.media_resize_adapter'
 
     elcodi.manager.media_file:
         class: Elcodi\Component\Media\Services\FileManager
         arguments:
-            - @elcodi.media_filesystem
-            - @elcodi.transformer.media_file_identifier
+            - '@elcodi.media_filesystem'
+            - '@elcodi.transformer.media_file_identifier'
 
     elcodi.uploader.image:
         class: Elcodi\Component\Media\Services\ImageUploader
         arguments:
-            - @elcodi.object_manager.image
-            - @elcodi.manager.media_file
-            - @elcodi.manager.media_image
-            - @elcodi.event_dispatcher.media
+            - '@elcodi.object_manager.image'
+            - '@elcodi.manager.media_file'
+            - '@elcodi.manager.media_image'
+            - '@elcodi.event_dispatcher.media'

--- a/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Resources/config/twig.yml
@@ -6,7 +6,7 @@ services:
     elcodi.twig_extension.media_image:
         class: Elcodi\Component\Media\Twig\ImageExtension
         arguments:
-            - @router
+            - '@router'
             - elcodi.route.image_resize
             - elcodi.route.image_view
             - %elcodi.image_generated_route_host%

--- a/src/Elcodi/Bundle/MediaBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/MediaBundle/Tests/Functional/app/config.yml
@@ -1,6 +1,6 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/filesystem.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/filesystem.test.yml' }
 
 framework:
     router:

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.menu_node
-            - @elcodi.repository.menu_node
-            - @elcodi.factory.menu_node
+            - '@elcodi.object_manager.menu_node'
+            - '@elcodi.repository.menu_node'
+            - '@elcodi.factory.menu_node'
 
     elcodi.director.menu:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.menu
-            - @elcodi.repository.menu
-            - @elcodi.factory.menu
+            - '@elcodi.object_manager.menu'
+            - '@elcodi.repository.menu'
+            - '@elcodi.factory.menu'

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/symfonyRouter.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/routeGeneratorAdapters/symfonyRouter.yml
@@ -6,7 +6,7 @@ services:
     elcodi.adapter.menu_route_generator.symfony_routing:
         class: Elcodi\Component\Menu\Adapter\RouteGenerator\SymfonyRouteGeneratorAdapter
         arguments:
-            - @router
+            - '@router'
 
     elcodi.adapter.menu_route_generator:
         alias: elcodi.adapter.menu_route_generator.symfony_routing

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/services.yml
@@ -6,12 +6,12 @@ services:
     elcodi.manager.menu:
         class: Elcodi\Component\Menu\Services\MenuManager
         arguments:
-            - @elcodi.repository.menu
-            - @elcodi.object_manager.menu
+            - '@elcodi.repository.menu'
+            - '@elcodi.object_manager.menu'
             - %elcodi.menu_cache_key%
         calls:
-            - [setCache, [@doctrine_cache.providers.elcodi_menus]]
-            - [setEncoder, [@elcodi.php_encoder]]
+            - [setCache, ['@doctrine_cache.providers.elcodi_menus']]
+            - [setEncoder, ['@elcodi.php_encoder']]
 
     elcodi.menu_builder:
         class: Elcodi\Component\Menu\Services\MenuBuilder

--- a/src/Elcodi/Bundle/MenuBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.menu_print_route:
         class: Elcodi\Component\Menu\Twig\PrintRouteExtension
         arguments:
-            - @router
+            - '@router'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/MenuBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/MenuBundle/Tests/Functional/app/config.yml
@@ -1,3 +1,3 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/cache.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/cache.test.yml' }

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/buckets.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/buckets.yml
@@ -6,4 +6,4 @@ services:
     elcodi.redis_metrics_bucket:
         class: Elcodi\Component\Metric\Core\Bucket\RedisMetricsBucket
         arguments:
-            - @snc_redis.metric
+            - '@snc_redis.metric'

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/commands.yml
@@ -6,6 +6,6 @@ services:
     elcodi.command.metrics_load:
         class: Elcodi\Component\Metric\Core\Command\MetricsLoadCommand
         arguments:
-            - @elcodi.metric_loader
+            - '@elcodi.metric_loader'
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/controllers.yml
@@ -6,6 +6,6 @@ services:
     elcodi.controller.metric_input:
         class: Elcodi\Component\Metric\Input\Controller\InputController
         arguments:
-            - @request_stack
-            - @elcodi.metric_manager
-            - @elcodi.factory.datetime
+            - '@request_stack'
+            - '@elcodi.metric_manager'
+            - '@elcodi.factory.datetime'

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/objectManagers.yml
@@ -6,7 +6,7 @@ services:
     elcodi.object_manager.entry:
         class: Doctrine\Common\Persistence\ObjectManager
         factory:
-            - @elcodi.provider.manager
+            - '@elcodi.provider.manager'
             - getManagerByEntityNamespace
         arguments:
             - %elcodi.entity.metric_entry.class%

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/services.yml
@@ -6,13 +6,13 @@ services:
     elcodi.metric_manager:
         class: Elcodi\Component\Metric\Core\Services\MetricManager
         arguments:
-            - @elcodi.metrics_bucket
-            - @elcodi.factory.metric_entry
-            - @elcodi.object_manager.entry
+            - '@elcodi.metrics_bucket'
+            - '@elcodi.factory.metric_entry'
+            - '@elcodi.object_manager.entry'
 
     elcodi.metric_loader:
         class: Elcodi\Component\Metric\Core\Services\MetricLoader
         lazy: true
         arguments:
-            - @elcodi.metrics_bucket
-            - @elcodi.repository.metric_entry
+            - '@elcodi.metrics_bucket'
+            - '@elcodi.repository.metric_entry'

--- a/src/Elcodi/Bundle/MetricBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/MetricBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.api_metric_twig_extension:
         class: Elcodi\Component\Metric\API\Twig\APIMetricExtension
         arguments:
-            - @elcodi.metrics_bucket
+            - '@elcodi.metrics_bucket'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.newsletter_subscription
-            - @elcodi.repository.newsletter_subscription
-            - @elcodi.factory.newsletter_subscription
+            - '@elcodi.object_manager.newsletter_subscription'
+            - '@elcodi.repository.newsletter_subscription'
+            - '@elcodi.factory.newsletter_subscription'

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.event_listener.newsletter:
         class: Elcodi\Component\Newsletter\EventListener\NewsletterEventListener
         arguments:
-            - @elcodi.object_manager.newsletter_subscription
+            - '@elcodi.object_manager.newsletter_subscription'
         tags:
             - { name: kernel.event_listener, event: newsletter.onsubscribe, method: onNewsletterSubscribeFlush, priority: 0 }
             - { name: kernel.event_listener, event: newsletter.onunsubscribe, method: onNewsletterUnsubscribeFlush, priority: 0 }

--- a/src/Elcodi/Bundle/NewsletterBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Resources/config/services.yml
@@ -6,8 +6,8 @@ services:
     elcodi.manager.newsletter:
         class: Elcodi\Component\Newsletter\Services\NewsletterManager
         arguments:
-            - @elcodi.event_dispatcher.newsletter
-            - @validator
-            - @elcodi.factory.newsletter_subscription
-            - @elcodi.repository.newsletter_subscription
-            - @elcodi.generator.sha1
+            - '@elcodi.event_dispatcher.newsletter'
+            - '@validator'
+            - '@elcodi.factory.newsletter_subscription'
+            - '@elcodi.repository.newsletter_subscription'
+            - '@elcodi.generator.sha1'

--- a/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/NewsletterBundle/Tests/Functional/app/config.yml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/controllers.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/controllers.yml
@@ -6,5 +6,5 @@ services:
     elcodi.controller.page:
         class: Elcodi\Component\Page\Controller\PageController
         arguments:
-            - @elcodi.repository.page
-            - @elcodi.transformer.page_response
+            - '@elcodi.repository.page'
+            - '@elcodi.transformer.page_response'

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.page
-            - @elcodi.repository.page
-            - @elcodi.factory.page
+            - '@elcodi.object_manager.page'
+            - '@elcodi.repository.page'
+            - '@elcodi.factory.page'

--- a/src/Elcodi/Bundle/PageBundle/Resources/config/transformers.yml
+++ b/src/Elcodi/Bundle/PageBundle/Resources/config/transformers.yml
@@ -6,7 +6,7 @@ services:
     elcodi.transformer.page_response:
         class: Elcodi\Component\Page\Transformer\PageResponseTransformer
         arguments:
-            - @request_stack
-            - @router
-            - @elcodi.page_renderer_chain
+            - '@request_stack'
+            - '@router'
+            - '@elcodi.page_renderer_chain'
             - elcodi.route.page_render

--- a/src/Elcodi/Bundle/PageBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/PageBundle/Tests/Functional/app/config.yml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }

--- a/src/Elcodi/Bundle/PaymentBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/PaymentBundle/Resources/config/services.yml
@@ -6,7 +6,7 @@ services:
     elcodi.payment_plugins:
         class: StdClass
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findBy
         arguments:
             - {type: plugin, category: payment}
@@ -14,7 +14,7 @@ services:
     elcodi.enabled_payment_plugins:
         class: StdClass
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findBy
         arguments:
             - {enabled: true, type: plugin, category: payment}

--- a/src/Elcodi/Bundle/PaymentBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/PaymentBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.payment:
         class: Elcodi\Component\Payment\Twig\PaymentExtension
         arguments:
-            - @elcodi.wrapper.payment_methods
+            - '@elcodi.wrapper.payment_methods'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/PaymentBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/PaymentBundle/Resources/config/wrappers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.wrapper.payment_methods:
         class: Elcodi\Component\Payment\Wrapper\PaymentWrapper
         arguments:
-            - @elcodi.event_dispatcher.payment
+            - '@elcodi.event_dispatcher.payment'

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/commands.yml
@@ -6,22 +6,22 @@ services:
     elcodi.command.plugins_load:
         class: Elcodi\Component\Plugin\Command\PluginsLoadCommand
         arguments:
-            - @elcodi.manager.plugin
+            - '@elcodi.manager.plugin'
         tags:
             - { name: console.command }
 
     elcodi.command.plugins_list:
         class: Elcodi\Component\Plugin\Command\PluginsListCommand
         arguments:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
         tags:
             - { name: console.command }
 
     elcodi.command.plugin_enable_abstract:
         abstract: true
         arguments:
-            - @elcodi.repository.plugin
-            - @elcodi.object_manager.plugin
+            - '@elcodi.repository.plugin'
+            - '@elcodi.object_manager.plugin'
 
     elcodi.command.plugin_enable:
         class: Elcodi\Component\Plugin\Command\PluginEnableCommand

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
@@ -6,10 +6,10 @@ services:
     elcodi.manager.plugin:
         class: Elcodi\Component\Plugin\Services\PluginManager
         arguments:
-            - @kernel
-            - @elcodi.repository.plugin
-            - @elcodi.object_manager.plugin
-            - @elcodi.loader.plugin
+            - '@kernel'
+            - '@elcodi.repository.plugin'
+            - '@elcodi.object_manager.plugin'
+            - '@elcodi.loader.plugin'
 
     elcodi.loader.plugin:
         class: Elcodi\Component\Plugin\Services\PluginLoader
@@ -20,8 +20,8 @@ services:
     elcodi.loader.plugin_routes:
         class: Elcodi\Component\Plugin\Loader\RouterLoader
         arguments:
-            - @kernel
-            - @elcodi.plugins
+            - '@kernel'
+            - '@elcodi.plugins'
         tags:
             - { name: routing.loader }
 
@@ -31,7 +31,7 @@ services:
     elcodi.enabled_plugins:
         class: StdClass
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findBy
         arguments:
             - {enabled: true}
@@ -39,12 +39,12 @@ services:
     elcodi.plugins:
         class: StdClass
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findAll
 
     elcodi.abstract_plugin:
         abstract: true
         class: Elcodi\Component\Plugin\Entity\Plugin
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findOneByNamespace

--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.plugin_hook:
         class: Elcodi\Component\Plugin\Twig\HookExtension
         arguments:
-            - @elcodi.event_dispatcher.hook_system
+            - '@elcodi.event_dispatcher.hook_system'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/adapters.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/adapters.yml
@@ -6,4 +6,4 @@ services:
     elcodi.related_purchasables_provider.same_category:
         class: Elcodi\Component\Product\Adapter\SimilarPurchasablesProvider\SameCategoryRelatedPurchasableProvider
         arguments:
-            - @elcodi.repository.product
+            - '@elcodi.repository.product'

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/directors.yml
@@ -7,30 +7,30 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.product
-            - @elcodi.repository.product
-            - @elcodi.factory.product
+            - '@elcodi.object_manager.product'
+            - '@elcodi.repository.product'
+            - '@elcodi.factory.product'
 
     elcodi.director.product_variant:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.product_variant
-            - @elcodi.repository.product_variant
-            - @elcodi.factory.product_variant
+            - '@elcodi.object_manager.product_variant'
+            - '@elcodi.repository.product_variant'
+            - '@elcodi.factory.product_variant'
 
     elcodi.director.category:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.category
-            - @elcodi.repository.category
-            - @elcodi.factory.category
+            - '@elcodi.object_manager.category'
+            - '@elcodi.repository.category'
+            - '@elcodi.factory.category'
 
     elcodi.director.manufacturer:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.manufacturer
-            - @elcodi.repository.manufacturer
-            - @elcodi.factory.manufacturer
+            - '@elcodi.object_manager.manufacturer'
+            - '@elcodi.repository.manufacturer'
+            - '@elcodi.factory.manufacturer'

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/eventListeners.yml
@@ -6,7 +6,7 @@ services:
     elcodi.event_listener.product_category_integrity:
         class: Elcodi\Component\Product\EventListener\ProductCategoryIntegrityEventListener
         arguments:
-            - @elcodi.service.category_integrity_fixer
+            - '@elcodi.service.category_integrity_fixer'
         tags:
             - { name: doctrine.event_listener, event: preFlush, method: preFlush }
 

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/services.yml
@@ -6,13 +6,13 @@ services:
     elcodi.provider.category_tree:
         class: Elcodi\Component\Product\Services\CategoryTree
         arguments:
-            - @elcodi.repository.category
+            - '@elcodi.repository.category'
 
     elcodi.provider.product_collection:
         class: Elcodi\Component\Product\Services\ProductCollectionProvider
         arguments:
-            - @elcodi.repository.product
-            - @elcodi.store_uses_stock
+            - '@elcodi.repository.product'
+            - '@elcodi.store_uses_stock'
 
     elcodi.service.category_integrity_fixer:
         class: Elcodi\Component\Product\Services\CategoryIntegrityFixer

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/twig.yml
@@ -6,13 +6,13 @@ services:
     elcodi.twig_extension.product:
         class: Elcodi\Component\Product\Twig\ProductExtension
         arguments:
-            - @elcodi.resolver.product_options
+            - '@elcodi.resolver.product_options'
         tags:
             - { name: twig.extension }
 
     elcodi.twig_extension.purchasable:
         class: Elcodi\Component\Product\Twig\PurchasableExtension
         arguments:
-            - @elcodi.resolver.purchasable_name
+            - '@elcodi.resolver.purchasable_name'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/app/config.yml
@@ -1,4 +1,4 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/cache.test.yml }
-    - { resource: @ElcodiCoreBundle/Resources/config/test/filesystem.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/cache.test.yml' }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/filesystem.test.yml' }

--- a/src/Elcodi/Bundle/RuleBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.rule
-            - @elcodi.repository.rule
-            - @elcodi.factory.rule
+            - '@elcodi.object_manager.rule'
+            - '@elcodi.repository.rule'
+            - '@elcodi.factory.rule'

--- a/src/Elcodi/Bundle/RuleBundle/Resources/config/expressionLanguage.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Resources/config/expressionLanguage.yml
@@ -15,14 +15,14 @@ services:
     elcodi.expression_language_container_provider:
         class: Elcodi\Component\Rule\ExpressionLanguage\Provider\ContainerProvider
         arguments:
-            - @service_container
+            - '@service_container'
         tags:
             - { name: elcodi.rule_configuration }
 
     elcodi.expression_language_rule_provider:
         class: Elcodi\Component\Rule\ExpressionLanguage\Provider\RuleProvider
         arguments:
-            - @elcodi.repository.rule
-            - @elcodi.manager.rule
+            - '@elcodi.repository.rule'
+            - '@elcodi.manager.rule'
         tags:
             - { name: elcodi.rule_configuration }

--- a/src/Elcodi/Bundle/RuleBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Resources/config/services.yml
@@ -7,5 +7,5 @@ services:
         class: Elcodi\Component\Rule\Services\RuleManager
         lazy: true
         arguments:
-            - @elcodi.expression_language
-            - @elcodi.expression_language_context_collector
+            - '@elcodi.expression_language'
+            - '@elcodi.expression_language_context_collector'

--- a/src/Elcodi/Bundle/RuleBundle/Tests/Functional/app/config.yml
+++ b/src/Elcodi/Bundle/RuleBundle/Tests/Functional/app/config.yml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: @ElcodiCoreBundle/Resources/config/test/configuration.test.yml }
+    - { resource: '@ElcodiCoreBundle/Resources/config/test/configuration.test.yml' }

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/resolvers.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/resolvers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.resolver.shipping:
         class: Elcodi\Component\Shipping\Resolver\ShippingResolver
         arguments:
-            - @elcodi.converter.currency
+            - '@elcodi.converter.currency'

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/services.yml
@@ -6,7 +6,7 @@ services:
     elcodi.shipping_plugins:
         class: StdClass
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findBy
         arguments:
             - {type: plugin, category: shipping}
@@ -14,7 +14,7 @@ services:
     elcodi.enabled_shipping_plugins:
         class: StdClass
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findBy
         arguments:
             - {enabled: true, type: plugin, category: shipping}

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/twig.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/twig.yml
@@ -6,6 +6,6 @@ services:
     elcodi.twig_extension.shipping:
         class: Elcodi\Component\Shipping\Twig\ShippingExtension
         arguments:
-            - @elcodi.wrapper.shipping_methods
+            - '@elcodi.wrapper.shipping_methods'
         tags:
             - { name: twig.extension }

--- a/src/Elcodi/Bundle/ShippingBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/ShippingBundle/Resources/config/wrappers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.wrapper.shipping_methods:
         class: Elcodi\Component\Shipping\Wrapper\ShippingWrapper
         arguments:
-            - @elcodi.event_dispatcher.shipping
+            - '@elcodi.event_dispatcher.shipping'

--- a/src/Elcodi/Bundle/SitemapBundle/Resources/config/commands.yml
+++ b/src/Elcodi/Bundle/SitemapBundle/Resources/config/commands.yml
@@ -6,13 +6,13 @@ services:
     elcodi.command.sitemap_dump:
         class: Elcodi\Component\Sitemap\Command\SitemapDumpCommand
         arguments:
-            - @service_container
+            - '@service_container'
         tags:
             -  { name: console.command }
 
     elcodi.command.sitemap_profile:
         class: Elcodi\Component\Sitemap\Command\SitemapProfileCommand
         arguments:
-            - @service_container
+            - '@service_container'
         tags:
             -  { name: console.command }

--- a/src/Elcodi/Bundle/SitemapBundle/Resources/config/sitemapTransformers.yml
+++ b/src/Elcodi/Bundle/SitemapBundle/Resources/config/sitemapTransformers.yml
@@ -6,4 +6,4 @@ services:
     elcodi.sitemap_transformer.static:
         class: Elcodi\Component\Sitemap\Transformer\StaticRouteTransformer
         arguments:
-            - @router
+            - '@router'

--- a/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/StateTransitionMachineBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.state_transition_machine_state_line
-            - @elcodi.repository.state_transition_machine_state_line
-            - @elcodi.factory.state_transition_machine_state_line
+            - '@elcodi.object_manager.state_transition_machine_state_line'
+            - '@elcodi.repository.state_transition_machine_state_line'
+            - '@elcodi.factory.state_transition_machine_state_line'

--- a/src/Elcodi/Bundle/StoreBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/StoreBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.store
-            - @elcodi.repository.store
-            - @elcodi.factory.store
+            - '@elcodi.object_manager.store'
+            - '@elcodi.repository.store'
+            - '@elcodi.factory.store'

--- a/src/Elcodi/Bundle/StoreBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/StoreBundle/Resources/config/services.yml
@@ -6,84 +6,84 @@ services:
     elcodi.store:
         class: Elcodi\Component\Store\Entity\Interfaces\StoreInterface
         factory:
-            - @elcodi.wrapper.store
+            - '@elcodi.wrapper.store'
             - get
 
     elcodi.store_uses_stock:
         class: StdClass
         public: false
         factory:
-            - @elcodi.store
+            - '@elcodi.store'
             - getUseStock
 
     elcodi.store_tracker:
         class: StdClass
         public: false
         factory:
-            - @elcodi.store
+            - '@elcodi.store'
             - getTracker
 
     elcodi.store_address:
         class: %elcodi.entity.address.class%
         public: false
         factory:
-            - @elcodi.store
+            - '@elcodi.store'
             - getAddress
 
     elcodi.store_template_hash:
         class: StdClass
         public: false
         factory:
-            - @elcodi.store
+            - '@elcodi.store'
             - getTemplate
 
     elcodi.store_template:
         class: Elcodi\Component\Plugin\Entity\Plugin
         public: false
         factory:
-            - @elcodi.repository.plugin
+            - '@elcodi.repository.plugin'
             - findOneBy
         arguments:
-            - { hash: @elcodi.store_template_hash }
+            - { hash: '@elcodi.store_template_hash' }
 
     elcodi.store_template_bundle:
         class: StdClass
         public: false
         factory:
-            - @elcodi.store_template
+            - '@elcodi.store_template'
             - getBundleName
 
     elcodi.store_default_language:
         class: Elcodi\Component\Language\Entity\Interfaces\LanguageInterface
         public: false
         factory:
-            - @elcodi.store
+            - '@elcodi.store'
             - getDefaultLanguage
 
     elcodi.store_default_language_iso:
         class: StdClass
         public: false
         factory:
-            - @elcodi.store_default_language
+            - '@elcodi.store_default_language'
             - getIso
 
     elcodi.store_routing_strategy:
         class: StdClass
         public: false
         factory:
-            - @elcodi.store
+            - '@elcodi.store'
             - getRoutingStrategy
 
     elcodi.store_default_currency:
         class: Elcodi\Component\Language\Entity\Interfaces\CurrencyInterface
         public: false
         factory:
-            - @elcodi.store
+            - '@elcodi.store'
             - getDefaultCurrency
 
     elcodi.store_default_currency_iso:
         class: StdClass
         public: false
         factory:
-            - @elcodi.store_default_currency
+            - '@elcodi.store_default_currency'
             - getIso

--- a/src/Elcodi/Bundle/StoreBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/StoreBundle/Resources/config/wrappers.yml
@@ -7,4 +7,4 @@ services:
         class: Elcodi\Component\Store\Wrapper\StoreWrapper
         lazy: true
         arguments:
-            - @elcodi.repository.store
+            - '@elcodi.repository.store'

--- a/src/Elcodi/Bundle/TaxBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/TaxBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.tax
-            - @elcodi.repository.tax
-            - @elcodi.factory.tax
+            - '@elcodi.object_manager.tax'
+            - '@elcodi.repository.tax'
+            - '@elcodi.factory.tax'

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/directors.yml
@@ -7,14 +7,14 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.customer
-            - @elcodi.repository.customer
-            - @elcodi.factory.customer
+            - '@elcodi.object_manager.customer'
+            - '@elcodi.repository.customer'
+            - '@elcodi.factory.customer'
 
     elcodi.director.admin_user:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.admin_user
-            - @elcodi.repository.admin_user
-            - @elcodi.factory.admin_user
+            - '@elcodi.object_manager.admin_user'
+            - '@elcodi.repository.admin_user'
+            - '@elcodi.factory.admin_user'

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/eventListeners.yml
@@ -6,15 +6,15 @@ services:
     elcodi.event_listener.update_cart_with_user:
         class: Elcodi\Component\User\EventListener\UpdateCartWithUserListener
         arguments:
-            - @elcodi.wrapper.cart
-            - @elcodi.object_manager.cart
+            - '@elcodi.wrapper.cart'
+            - '@elcodi.object_manager.cart'
         tags:
             - { name: kernel.event_listener, event: security.authentication.success, method: onAuthenticationSuccess  }
 
     elcodi.event_listener.update_last_login:
         class: Elcodi\Component\User\EventListener\UpdateLastLoginEventListener
         arguments:
-            - @elcodi.provider.manager
-            - @elcodi.factory.datetime
+            - '@elcodi.provider.manager'
+            - '@elcodi.factory.datetime'
         tags:
             - { name: 'kernel.event_listener', event: 'security.interactive_login', method: updateLastLogin}

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/factories.yml
@@ -12,7 +12,7 @@ services:
         calls:
             - [setEntityNamespace, ["%elcodi.entity.customer.class%"]]
             - [setDateTimeFactory, ["@elcodi.factory.datetime"]]
-            - [setGenerator, [@elcodi.generator.random_string]]
+            - [setGenerator, ['@elcodi.generator.random_string']]
 
     #
     # Factory for entity admin user
@@ -22,4 +22,4 @@ services:
         calls:
             - [setEntityNamespace, ["%elcodi.entity.admin_user.class%"]]
             - [setDateTimeFactory, ["@elcodi.factory.datetime"]]
-            - [setGenerator, [@elcodi.generator.random_string]]
+            - [setGenerator, ['@elcodi.generator.random_string']]

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/providers.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/providers.yml
@@ -6,13 +6,13 @@ services:
     elcodi.customer_provider_entity_instance:
         class: %elcodi.entity.customer.class%
         factory:
-            - @elcodi.factory.customer
+            - '@elcodi.factory.customer'
             - create
 
     elcodi.admin_user_provider_entity_instance:
         class: %elcodi.entity.admin_user.class%
         factory:
-            - @elcodi.factory.admin_user
+            - '@elcodi.factory.admin_user'
             - create
 
     #
@@ -21,15 +21,15 @@ services:
     elcodi.provider.customer_provider:
         class: Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface
         factory:
-            - @security.encoder_factory
+            - '@security.encoder_factory'
             - getEncoder
         arguments:
-            - @elcodi.customer_provider_entity_instance
+            - '@elcodi.customer_provider_entity_instance'
 
     elcodi.provider.admin_user_provider:
         class: Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface
         factory:
-            - @security.encoder_factory
+            - '@security.encoder_factory'
             - getEncoder
         arguments:
-            - @elcodi.admin_user_provider_entity_instance
+            - '@elcodi.admin_user_provider_entity_instance'

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/services.yml
@@ -6,17 +6,17 @@ services:
     elcodi.manager.password:
         class: Elcodi\Component\User\Services\PasswordManager
         arguments:
-            - @doctrine.orm.entity_manager
-            - @router
-            - @elcodi.event_dispatcher.password
-            - @elcodi.generator.sha1
+            - '@doctrine.orm.entity_manager'
+            - '@router'
+            - '@elcodi.event_dispatcher.password'
+            - '@elcodi.generator.sha1'
 
     elcodi.manager.customer:
         class: Elcodi\Component\User\Services\CustomerManager
         arguments:
-            - @elcodi.event_dispatcher.user
+            - '@elcodi.event_dispatcher.user'
 
     elcodi.manager.admin_user:
         class: Elcodi\Component\User\Services\AdminUserManager
         arguments:
-            - @elcodi.event_dispatcher.user
+            - '@elcodi.event_dispatcher.user'

--- a/src/Elcodi/Bundle/UserBundle/Resources/config/wrappers.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/config/wrappers.yml
@@ -6,11 +6,11 @@ services:
     elcodi.wrapper.customer:
         class: Elcodi\Component\User\Wrapper\CustomerWrapper
         arguments:
-            - @elcodi.factory.customer
-            - @?security.token_storage
+            - '@elcodi.factory.customer'
+            - '@?security.token_storage'
 
     elcodi.wrapper.admin_user:
         class: Elcodi\Component\User\Wrapper\AdminUserWrapper
         arguments:
-            - @elcodi.factory.admin_user
-            - @?security.token_storage
+            - '@elcodi.factory.admin_user'
+            - '@?security.token_storage'

--- a/src/Elcodi/Bundle/UserBundle/Resources/security/providers.yml
+++ b/src/Elcodi/Bundle/UserBundle/Resources/security/providers.yml
@@ -14,7 +14,7 @@ services:
     elcodi.event_listener.customer_password:
         class: Elcodi\Component\User\EventListener\CustomerPasswordEventListener
         arguments:
-            - @elcodi.provider.customer_provider
+            - '@elcodi.provider.customer_provider'
         tags:
             - { name: doctrine.event_listener, event: preUpdate, method: preUpdate }
             - { name: doctrine.event_listener, event: prePersist, method: prePersist }
@@ -22,7 +22,7 @@ services:
     elcodi.event_listener.admin_user_password:
         class: Elcodi\Component\User\EventListener\AdminUserPasswordEventListener
         arguments:
-            - @elcodi.provider.admin_user_provider
+            - '@elcodi.provider.admin_user_provider'
         tags:
             - { name: doctrine.event_listener, event: preUpdate, method: preUpdate }
             - { name: doctrine.event_listener, event: prePersist, method: prePersist }

--- a/src/Elcodi/Bundle/ZoneBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/ZoneBundle/Resources/config/directors.yml
@@ -7,6 +7,6 @@ services:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true
         arguments:
-            - @elcodi.object_manager.zone
-            - @elcodi.repository.zone
-            - @elcodi.factory.zone
+            - '@elcodi.object_manager.zone'
+            - '@elcodi.repository.zone'
+            - '@elcodi.factory.zone'

--- a/src/Elcodi/Bundle/ZoneBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/ZoneBundle/Resources/config/services.yml
@@ -6,10 +6,10 @@ services:
     elcodi.matcher.zone:
         class: Elcodi\Component\Zone\Services\ZoneMatcher
         arguments:
-            - @elcodi.location_provider
+            - '@elcodi.location_provider'
 
     elcodi.finder.zone:
         class: Elcodi\Component\Zone\Services\ZoneFinder
         arguments:
-            - @elcodi.repository.zone
-            - @elcodi.matcher.zone
+            - '@elcodi.repository.zone'
+            - '@elcodi.matcher.zone'


### PR DESCRIPTION
Closes https://github.com/elcodi/elcodi/issues/1016

> Starting an unquoted string with `@`, `` ` ``, `|`, or `>` leads to a `ParseException`.

Reference: https://github.com/symfony/symfony/blob/2.8/UPGRADE-3.0.md#yaml