### PR TITLE
Improved the abstract factory method

### DIFF
--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/services.yml
@@ -47,4 +47,4 @@ services:
         class: Elcodi\Component\Plugin\Entity\Plugin
         factory:
             - '@elcodi.repository.plugin'
-            - findOneByNamespace
+            - find


### PR DESCRIPTION
* Because namespace is the primary key of the entity, using find, repository will make use
  of caching layer (entity instances layer).