### PR TITLE
Added Product Pack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,9 +154,9 @@
     },
     "scripts": {
         "check-style": [
-            "bin/php-cs-fixer fix --config-file=.php_cs",
-            "bin/php-formatter f:h:f src",
-            "bin/php-formatter f:u:s src"
+            "bin/php-cs-fixer fix --config-file=.php_cs || true",
+            "bin/php-formatter f:h:f src || true",
+            "bin/php-formatter f:u:s src || true"
         ],
         "test": "phpunit"
     }

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/doctrine/CartLine.orm.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/doctrine/CartLine.orm.yml
@@ -38,29 +38,31 @@ Elcodi\Component\Cart\Entity\CartLine:
                 nullable: false
         productCurrency:
             targetEntity: Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface
-            fetch: EAGER
             joinColumn:
                  name: product_currency_iso
                  referencedColumnName: iso
                  nullable: false
         currency:
             targetEntity: Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface
-            fetch: EAGER
             joinColumn:
                  name: currency_iso
                  referencedColumnName: iso
                  nullable: false
         product:
             targetEntity: Elcodi\Component\Product\Entity\Interfaces\ProductInterface
-            fetch: EAGER
             joinColumn:
                 name: product_id
                 referencedColumnName: id
-                nullable: false
+                nullable: true
         variant:
             targetEntity: Elcodi\Component\Product\Entity\Interfaces\VariantInterface
-            fetch: EAGER
             joinColumn:
                 name: variant_id
+                referencedColumnName: id
+                nullable: true
+        pack:
+            targetEntity: Elcodi\Component\Product\Entity\Interfaces\PackInterface
+            joinColumn:
+                name: pack_id
                 referencedColumnName: id
                 nullable: true

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/doctrine/OrderLine.orm.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/doctrine/OrderLine.orm.yml
@@ -51,7 +51,6 @@ Elcodi\Component\Cart\Entity\OrderLine:
                 nullable: false
         productCurrency:
             targetEntity: Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface
-            fetch: EAGER
             joinColumn:
                  name: product_currency_iso
                  referencedColumnName: iso
@@ -67,10 +66,16 @@ Elcodi\Component\Cart\Entity\OrderLine:
             joinColumn:
                 name: product_id
                 referencedColumnName: id
-                nullable: false
+                nullable: true
         variant:
             targetEntity: Elcodi\Component\Product\Entity\Interfaces\VariantInterface
             joinColumn:
                 name: variant_id
+                referencedColumnName: id
+                nullable: true
+        pack:
+            targetEntity: Elcodi\Component\Product\Entity\Interfaces\PackInterface
+            joinColumn:
+                name: pack_id
                 referencedColumnName: id
                 nullable: true

--- a/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/services.yml
@@ -36,6 +36,7 @@ services:
         class: Elcodi\Component\Cart\Services\CartIntegrityValidator
         arguments:
             - '@elcodi.event_dispatcher.cart'
+            - '@elcodi.stock_validator.purchasable'
             - '@elcodi.manager.cart'
             - '@?elcodi.store_uses_stock'
 
@@ -45,8 +46,7 @@ services:
     elcodi.updater.cart_line_stock:
         class: Elcodi\Component\Cart\Services\CartLineStockUpdater
         arguments:
-            - '@elcodi.object_manager.product'
-            - '@elcodi.object_manager.product_variant'
+            - '@elcodi.stock_updater.purchasable'
 
     elcodi.validator.cart_shipping_method:
         class: Elcodi\Component\Cart\Services\CartShippingAmountValidator

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/EventListener/OrderLineCreationEventListenerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/EventListener/OrderLineCreationEventListenerTest.php
@@ -49,6 +49,8 @@ class OrderLineCreationEventListenerTest extends WebTestCase
         $quantity,
         $finalStock
     ) {
+        $this->reloadScenario();
+
         /**
          * @var CartOrderTransformer $cartOrderTransformer
          */
@@ -60,7 +62,6 @@ class OrderLineCreationEventListenerTest extends WebTestCase
          * @var CartLineInterface $cartLine
          */
         $cart = $this->find('cart', 2);
-
         $cartLine = $cart
             ->getCartLines()
             ->first()

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/Abstracts/AbstractCartManagerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/Abstracts/AbstractCartManagerTest.php
@@ -79,8 +79,6 @@ abstract class AbstractCartManagerTest extends WebTestCase
 
     /**
      * Test add line.
-     *
-     * @group cart
      */
     public function testAddLine()
     {
@@ -88,7 +86,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->get('elcodi.manager.cart')
             ->addPurchasable(
                 $this->cart,
-                $this->cartLine->getProduct(),
+                $this->cartLine->getPurchasable(),
                 $this->cartLine->getQuantity()
             );
 
@@ -124,8 +122,6 @@ abstract class AbstractCartManagerTest extends WebTestCase
 
     /**
      * Test remove line.
-     *
-     * @group cart
      */
     public function testRemoveLine()
     {
@@ -133,7 +129,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->get('elcodi.manager.cart')
             ->addPurchasable(
                 $this->cart,
-                $this->cartLine->getProduct(),
+                $this->cartLine->getPurchasable(),
                 $this->cartLine->getQuantity()
             );
 
@@ -148,8 +144,6 @@ abstract class AbstractCartManagerTest extends WebTestCase
 
     /**
      * Test empty lines.
-     *
-     * @group cart
      */
     public function testEmptyLines()
     {
@@ -157,7 +151,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->get('elcodi.manager.cart')
             ->addPurchasable(
                 $this->cart,
-                $this->cartLine->getProduct(),
+                $this->cartLine->getPurchasable(),
                 $this->cartLine->getQuantity()
             );
 
@@ -172,8 +166,6 @@ abstract class AbstractCartManagerTest extends WebTestCase
 
     /**
      * Test edit cart line.
-     *
-     * @group cart
      */
     public function testEditCartLine()
     {
@@ -181,7 +173,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->get('elcodi.manager.cart')
             ->addPurchasable(
                 $this->cart,
-                $this->cartLine->getProduct(),
+                $this->cartLine->getPurchasable(),
                 $this->cartLine->getQuantity()
             );
 
@@ -223,9 +215,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
      * @param mixed $quantitySetted Quantity to set
      * @param mixed $quantityEnd    Quantity to check against
      *
-     * @skip
      * @dataProvider dataSetCartLineQuantity
-     * @group        cart
      */
     public function testSetCartLineQuantity(
         $quantityStart,
@@ -238,10 +228,9 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->get('elcodi.manager.cart')
             ->addPurchasable(
                 $this->cart,
-                $this->cartLine->getProduct(),
+                $this->cartLine->getPurchasable(),
                 $this->cartLine->getQuantity()
             );
-
         $line = $this->cart->getCartLines()->last();
 
         $this
@@ -259,14 +248,16 @@ abstract class AbstractCartManagerTest extends WebTestCase
      * @param mixed $quantityEnd   Quantity to check against
      *
      * @dataProvider dataIncreaseCartLineQuantity
-     * @group        cart
      */
     public function testIncreaseCartLineQuantity(
         $quantityStart,
         $quantityAdded,
         $quantityEnd
     ) {
-        $line = $this
+        /**
+         * @var CartLineInterface $cartLine
+         */
+        $cartLine = $this
             ->get('elcodi.factory.cart_line')
             ->create()
             ->setPurchasable($this->purchasable)
@@ -276,14 +267,14 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->get('elcodi.manager.cart')
             ->addPurchasable(
                 $this->cart,
-                $line->getProduct(),
-                $line->getQuantity()
+                $cartLine->getPurchasable(),
+                $cartLine->getQuantity()
             );
 
-        if ($line->getQuantity() == 0) {
+        if ($cartLine->getQuantity() == 0) {
             $this->assertFalse($this->cart->getCartLines()->last());
 
-            return null;
+            return;
         }
 
         $this
@@ -301,7 +292,6 @@ abstract class AbstractCartManagerTest extends WebTestCase
      * @param mixed $quantityEnd     Quantity to check against
      *
      * @dataProvider dataDecreaseCartLineQuantity
-     * @group        cart
      */
     public function testDecreaseCartLineQuantity(
         $quantityStart,
@@ -314,7 +304,7 @@ abstract class AbstractCartManagerTest extends WebTestCase
             ->get('elcodi.manager.cart')
             ->addPurchasable(
                 $this->cart,
-                $this->cartLine->getProduct(),
+                $this->cartLine->getPurchasable(),
                 $this->cartLine->getQuantity()
             );
 
@@ -333,10 +323,9 @@ abstract class AbstractCartManagerTest extends WebTestCase
      * @param mixed $quantitySet the quantity to set
      * @param mixed $quantityEnd the quantity to check against
      *
-     * @dataProvider dataAddProduct
-     * @group        cart
+     * @dataProvider dataAddPurchasable
      */
-    public function testAddProduct(
+    public function testAddPurchasable(
         $quantitySet,
         $quantityEnd
     ) {
@@ -361,10 +350,11 @@ abstract class AbstractCartManagerTest extends WebTestCase
                 $this->cart->getAmount(),
                 $cartLine->getAmount()
             );
+            $purchasable = $cartLine->getPurchasable();
 
             $this->assertEquals(
                 $this->cart->getAmount()->getAmount(),
-                $cartLine->getPurchasable()->getPrice()->getAmount() * $quantity
+                $purchasable->getPrice()->getAmount() * $quantity
             );
 
             $this->assertNotNull($cartLine->getId());

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerPackWithInheritanceStockTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerPackWithInheritanceStockTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CartBundle\Tests\Functional\Services;
+
+use Elcodi\Bundle\CartBundle\Tests\Functional\Services\Abstracts\AbstractCartManagerTest;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+
+/**
+ * Class CartManagerVariantTest.
+ *
+ * This will test CartManager common methods using a Pack with inheritance stock
+ */
+class CartManagerPackWithInheritanceStockTest extends AbstractCartManagerTest
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCartBundle',
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Creates, flushes and returns a Purchasable.
+     *
+     * @return PurchasableInterface
+     */
+    protected function createPurchasable()
+    {
+        return $this->find('product_pack', 2);
+    }
+
+    /**
+     * Data for testIncreaseCartLineQuantity.
+     */
+    public function dataIncreaseCartLineQuantity()
+    {
+        return [
+            [0, 1, 0],
+            [1, 1, 2],
+            [0, 0, 0],
+            [1, -1, 0],
+            [1, -2, 0],
+            [1, 20, 5],
+            [1, false, 1],
+            [1, null, 1],
+            [1, true, 1],
+            [1, 'true', 1],
+            [1, '', 1],
+            [1, [], 1],
+        ];
+    }
+
+    /**
+     * Data for testDecreaseCartLineQuantity.
+     */
+    public function dataDecreaseCartLineQuantity()
+    {
+        return [
+            [1, 1, 0],
+            [1, 0, 1],
+            [1, 2, 0],
+            [1, -1, 2],
+            [1, -20, 5],
+            [1, false, 1],
+            [1, null, 1],
+            [1, true, 1],
+            [1, 'true', 1],
+            [1, '', 1],
+            [1, [], 1],
+        ];
+    }
+
+    /**
+     * Data for testSetCartLineQuantity.
+     */
+    public function dataSetCartLineQuantity()
+    {
+        return [
+            [1, 21, 5],
+            [1, 1, 1],
+            [1, 0, 0],
+            [1, 2, 2],
+            [1, -1, 0],
+            [1, 5, 5],
+            [1, false, 1],
+            [1, null, 1],
+            [1, true, 1],
+            [1, 'true', 1],
+            [1, '', 1],
+            [1, [], 1],
+        ];
+    }
+
+    /**
+     * Data for testAddPurchasable.
+     */
+    public function dataAddPurchasable()
+    {
+        return [
+            [1, 1],
+            [0, 0],
+            [21, 5],
+            [false, 0],
+            [null, 0],
+            [true, 0],
+            ['true', 0],
+            ['', 0],
+            [[], 0],
+        ];
+    }
+}

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerPackWithSpecificStockTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerPackWithSpecificStockTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CartBundle\Tests\Functional\Services;
+
+use Elcodi\Bundle\CartBundle\Tests\Functional\Services\Abstracts\AbstractCartManagerTest;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+
+/**
+ * Class CartManagerPackWithSpecificStockTest.
+ *
+ * This will test CartManager common methods using a Pack with specific stock
+ */
+class CartManagerPackWithSpecificStockTest extends AbstractCartManagerTest
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCartBundle',
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Creates, flushes and returns a Purchasable.
+     *
+     * @return PurchasableInterface
+     */
+    protected function createPurchasable()
+    {
+        return $this->find('product_pack', 1);
+    }
+
+    /**
+     * Data for testIncreaseCartLineQuantity.
+     */
+    public function dataIncreaseCartLineQuantity()
+    {
+        return [
+            [0, 1, 0],
+            [1, 1, 2],
+            [0, 0, 0],
+            [1, -1, 0],
+            [1, -2, 0],
+            [1, 20, 10],
+            [1, false, 1],
+            [1, null, 1],
+            [1, true, 1],
+            [1, 'true', 1],
+            [1, '', 1],
+            [1, [], 1],
+        ];
+    }
+
+    /**
+     * Data for testDecreaseCartLineQuantity.
+     */
+    public function dataDecreaseCartLineQuantity()
+    {
+        return [
+            [1, 1, 0],
+            [1, 0, 1],
+            [1, 2, 0],
+            [1, -1, 2],
+            [1, -20, 10],
+            [1, false, 1],
+            [1, null, 1],
+            [1, true, 1],
+            [1, 'true', 1],
+            [1, '', 1],
+            [1, [], 1],
+        ];
+    }
+
+    /**
+     * Data for testSetCartLineQuantity.
+     */
+    public function dataSetCartLineQuantity()
+    {
+        return [
+            [1, 1, 1],
+            [1, 0, 0],
+            [1, 2, 2],
+            [1, -1, 0],
+            [1, 10, 10],
+            [1, 21, 10],
+            [1, false, 1],
+            [1, null, 1],
+            [1, true, 1],
+            [1, 'true', 1],
+            [1, '', 1],
+            [1, [], 1],
+        ];
+    }
+
+    /**
+     * Data for testAddPurchasable.
+     */
+    public function dataAddPurchasable()
+    {
+        return [
+            [1, 1],
+            [0, 0],
+            [21, 10],
+            [false, 0],
+            [null, 0],
+            [true, 0],
+            ['true', 0],
+            ['', 0],
+            [[], 0],
+        ];
+    }
+}

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerProductTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerProductTest.php
@@ -18,8 +18,6 @@
 namespace Elcodi\Bundle\CartBundle\Tests\Functional\Services;
 
 use Elcodi\Bundle\CartBundle\Tests\Functional\Services\Abstracts\AbstractCartManagerTest;
-use Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface;
-use Elcodi\Component\Currency\Entity\Money;
 
 /**
  * Tests CartManager class.
@@ -36,8 +34,7 @@ class CartManagerProductTest extends AbstractCartManagerTest
     protected static function loadFixturesBundles()
     {
         return [
-            'ElcodiCurrencyBundle',
-            'ElcodiStoreBundle',
+            'ElcodiProductBundle',
         ];
     }
 
@@ -48,37 +45,7 @@ class CartManagerProductTest extends AbstractCartManagerTest
      */
     protected function createPurchasable()
     {
-        /**
-         * @var CurrencyInterface $currency
-         */
-        $currency = $this
-            ->getRepository('currency')
-            ->findOneBy([
-                'iso' => 'USD',
-            ]);
-
-        $product = $this
-            ->get('elcodi.factory.product')
-            ->create()
-            ->setPrice(Money::create(1000, $currency))
-            ->setName('abc')
-            ->setSlug('abc')
-            ->setWidth(10)
-            ->setHeight(10)
-            ->setDepth(10)
-            ->setWeight(10)
-            ->setEnabled(true)
-            ->setStock(10);
-
-        $this
-            ->getObjectManager('product')
-            ->persist($product);
-
-        $this
-            ->getObjectManager('product')
-            ->flush();
-
-        return $product;
+        return $this->find('product', 1);
     }
 
     /**
@@ -144,9 +111,9 @@ class CartManagerProductTest extends AbstractCartManagerTest
     }
 
     /**
-     * Data for testAddProduct.
+     * Data for testAddPurchasable.
      */
-    public function dataAddProduct()
+    public function dataAddPurchasable()
     {
         return [
             [1, 1],

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Services/CartManagerVariantTest.php
@@ -19,9 +19,6 @@ namespace Elcodi\Bundle\CartBundle\Tests\Functional\Services;
 
 use Elcodi\Bundle\CartBundle\Tests\Functional\Services\Abstracts\AbstractCartManagerTest;
 use Elcodi\Component\Attribute\Entity\Interfaces\ValueInterface;
-use Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface;
-use Elcodi\Component\Currency\Entity\Money;
-use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
 use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
 use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
 
@@ -33,13 +30,6 @@ use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
 class CartManagerVariantTest extends AbstractCartManagerTest
 {
     /**
-     * @var VariantInterface
-     *
-     * Variant
-     */
-    protected $variant;
-
-    /**
      * Load fixtures of these bundles.
      *
      * @return array Bundles name where fixtures should be found
@@ -47,9 +37,7 @@ class CartManagerVariantTest extends AbstractCartManagerTest
     protected static function loadFixturesBundles()
     {
         return [
-            'ElcodiCurrencyBundle',
-            'ElcodiAttributeBundle',
-            'ElcodiStoreBundle',
+            'ElcodiProductBundle',
         ];
     }
 
@@ -60,82 +48,7 @@ class CartManagerVariantTest extends AbstractCartManagerTest
      */
     protected function createPurchasable()
     {
-        /**
-         * @var CurrencyInterface $currency
-         */
-        $currency = $this
-            ->getRepository('currency')
-            ->findOneBy([
-                'iso' => 'USD',
-            ]);
-
-        /**
-         * @var ValueInterface $variantOption
-         */
-        $variantOption = $this->find('attribute_value', 1);
-
-        /**
-         * @var ProductInterface $product
-         */
-        $product = $this
-            ->getFactory('product')
-            ->create()
-            ->setPrice(Money::create(1000, $currency))
-            ->setName('abc')
-            ->setSlug('abc')
-            ->setEnabled(true)
-            ->setWidth(10)
-            ->setHeight(10)
-            ->setDepth(10)
-            ->setWeight(10)
-            ->setStock(10);
-
-        /**
-         * @var VariantInterface $variant
-         */
-        $variant = $this
-            ->getFactory('product_variant')
-            ->create()
-            ->setProduct($product)
-            ->setPrice(Money::create(1200, $currency))
-            ->addOption($variantOption)
-            ->setWidth(10)
-            ->setHeight(10)
-            ->setDepth(10)
-            ->setWeight(10)
-            ->setEnabled(true)
-            ->setStock(20);
-
-        $product->setPrincipalVariant($variant);
-
-        $this
-            ->getObjectManager('product')
-            ->persist($product);
-        $this
-            ->getObjectManager('product_variant')
-            ->persist($variant);
-
-        $this
-            ->getObjectManager('product')
-            ->flush();
-        $this
-            ->getObjectManager('product_variant')
-            ->flush();
-
-        $this->variant = $variant;
-
-        return $variant;
-    }
-
-    /**
-     * Testing that a purchasable is a Variant.
-     */
-    public function testPurchasableIsVariant()
-    {
-        $this->assertInstanceOf(
-            $this->getParameter('elcodi.entity.product_variant.class'),
-            $this->purchasable
-        );
+        return $this->find('product_variant', 1);
     }
 
     /**
@@ -167,7 +80,7 @@ class CartManagerVariantTest extends AbstractCartManagerTest
             [0, 0, 0],
             [1, -1, 0],
             [1, -2, 0],
-            [1, 20, 10],
+            [1, 100, 100],
             [1, false, 1],
             [1, null, 1],
             [1, true, 1],
@@ -187,7 +100,7 @@ class CartManagerVariantTest extends AbstractCartManagerTest
             [1, 0, 1],
             [1, 2, 0],
             [1, -1, 2],
-            [1, -20, 10],
+            [1, -100, 100],
             [1, false, 1],
             [1, null, 1],
             [1, true, 1],
@@ -208,7 +121,7 @@ class CartManagerVariantTest extends AbstractCartManagerTest
             [1, 2, 2],
             [1, -1, 0],
             [1, 10, 10],
-            [1, 21, 10],
+            [1, 101, 100],
             [1, false, 1],
             [1, null, 1],
             [1, true, 1],
@@ -219,14 +132,14 @@ class CartManagerVariantTest extends AbstractCartManagerTest
     }
 
     /**
-     * Data for testAddProduct.
+     * Data for testAddPurchasable.
      */
-    public function dataAddProduct()
+    public function dataAddPurchasable()
     {
         return [
             [1, 1],
             [0, 0],
-            [21, 20],
+            [101, 100],
             [false, 0],
             [null, 0],
             [true, 0],

--- a/src/Elcodi/Bundle/CartBundle/Tests/Functional/Transformer/CartLineOrderLineTransformerTest.php
+++ b/src/Elcodi/Bundle/CartBundle/Tests/Functional/Transformer/CartLineOrderLineTransformerTest.php
@@ -43,8 +43,6 @@ class CartLineOrderLineTransformerTest extends WebTestCase
 
     /**
      * test create orderLine by CartLine.
-     *
-     * @group order
      */
     public function testCreateOrderLineByCartLine()
     {

--- a/src/Elcodi/Bundle/CoreBundle/CompilerPass/Abstracts/AbstractTagCompilerPass.php
+++ b/src/Elcodi/Bundle/CoreBundle/CompilerPass/Abstracts/AbstractTagCompilerPass.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class AbstractTagCompilerPass.
+ */
+abstract class AbstractTagCompilerPass implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has($this->getCollectorServiceName())) {
+            return;
+        }
+
+        $definition = $container->findDefinition(
+            $this->getCollectorServiceName()
+        );
+
+        $taggedServices = $container->findTaggedServiceIds(
+            $this->getTagName()
+        );
+        foreach ($taggedServices as $id => $tags) {
+            $definition->addMethodCall(
+                $this->getCollectorMethodName(),
+                [new Reference($id)]
+            );
+        }
+    }
+
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    abstract public function getCollectorServiceName();
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    abstract public function getCollectorMethodName();
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    abstract public function getTagName();
+}

--- a/src/Elcodi/Bundle/ProductBundle/CompilerPass/MappingCompilerPass.php
+++ b/src/Elcodi/Bundle/ProductBundle/CompilerPass/MappingCompilerPass.php
@@ -41,6 +41,7 @@ class MappingCompilerPass extends AbstractElcodiMappingCompilerPass
                 [
                     'product',
                     'product_variant',
+                    'product_pack',
                     'category',
                     'manufacturer',
                 ]

--- a/src/Elcodi/Bundle/ProductBundle/CompilerPass/PackStockUpdaterCompilerPass.php
+++ b/src/Elcodi/Bundle/ProductBundle/CompilerPass/PackStockUpdaterCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\CompilerPass;
+
+use Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts\AbstractTagCompilerPass;
+
+/**
+ * Class PackStockUpdaterCompilerPass.
+ */
+class PackStockUpdaterCompilerPass extends AbstractTagCompilerPass
+{
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    public function getCollectorServiceName()
+    {
+        return 'elcodi.stock_updater.product_pack';
+    }
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    public function getCollectorMethodName()
+    {
+        return 'addPurchasableStockUpdater';
+    }
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    public function getTagName()
+    {
+        return 'elcodi.simple_purchasable_stock_updater';
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/CompilerPass/PackStockValidatorCompilerPass.php
+++ b/src/Elcodi/Bundle/ProductBundle/CompilerPass/PackStockValidatorCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\CompilerPass;
+
+use Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts\AbstractTagCompilerPass;
+
+/**
+ * Class PackStockValidatorCompilerPass.
+ */
+class PackStockValidatorCompilerPass extends AbstractTagCompilerPass
+{
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    public function getCollectorServiceName()
+    {
+        return 'elcodi.stock_validator.product_pack';
+    }
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    public function getCollectorMethodName()
+    {
+        return 'addPurchasableStockValidator';
+    }
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    public function getTagName()
+    {
+        return 'elcodi.simple_purchasable_stock_validator';
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/CompilerPass/PurchasableNameResolverCompilerPass.php
+++ b/src/Elcodi/Bundle/ProductBundle/CompilerPass/PurchasableNameResolverCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\CompilerPass;
+
+use Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts\AbstractTagCompilerPass;
+
+/**
+ * Class PurchasableNameResolverCompilerPass.
+ */
+class PurchasableNameResolverCompilerPass extends AbstractTagCompilerPass
+{
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    public function getCollectorServiceName()
+    {
+        return 'elcodi.name_resolver.purchasable';
+    }
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    public function getCollectorMethodName()
+    {
+        return 'addPurchasableNameResolver';
+    }
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    public function getTagName()
+    {
+        return 'elcodi.purchasable_name_resolver';
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/CompilerPass/PurchasableStockUpdaterCompilerPass.php
+++ b/src/Elcodi/Bundle/ProductBundle/CompilerPass/PurchasableStockUpdaterCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\CompilerPass;
+
+use Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts\AbstractTagCompilerPass;
+
+/**
+ * Class PurchasableStockUpdaterCompilerPass.
+ */
+class PurchasableStockUpdaterCompilerPass extends AbstractTagCompilerPass
+{
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    public function getCollectorServiceName()
+    {
+        return 'elcodi.stock_updater.purchasable';
+    }
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    public function getCollectorMethodName()
+    {
+        return 'addPurchasableStockUpdater';
+    }
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    public function getTagName()
+    {
+        return 'elcodi.purchasable_stock_updater';
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/CompilerPass/PurchasableStockValidatorCompilerPass.php
+++ b/src/Elcodi/Bundle/ProductBundle/CompilerPass/PurchasableStockValidatorCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\CompilerPass;
+
+use Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts\AbstractTagCompilerPass;
+
+/**
+ * Class PurchasableStockValidatorCompilerPass.
+ */
+class PurchasableStockValidatorCompilerPass extends AbstractTagCompilerPass
+{
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    public function getCollectorServiceName()
+    {
+        return 'elcodi.stock_validator.purchasable';
+    }
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    public function getCollectorMethodName()
+    {
+        return 'addPurchasableStockValidator';
+    }
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    public function getTagName()
+    {
+        return 'elcodi.purchasable_stock_validator';
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/DataFixtures/ORM/PackData.php
+++ b/src/Elcodi/Bundle/ProductBundle/DataFixtures/ORM/PackData.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+use Elcodi\Bundle\CoreBundle\DataFixtures\ORM\Abstracts\AbstractFixture;
+use Elcodi\Component\Core\Services\ObjectDirector;
+use Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface;
+use Elcodi\Component\Currency\Entity\Money;
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\Entity\Interfaces\CategoryInterface;
+use Elcodi\Component\Product\Entity\Interfaces\ManufacturerInterface;
+
+/**
+ * Class PackData.
+ */
+class PackData extends AbstractFixture implements DependentFixtureInterface
+{
+    /**
+     * Load data fixtures with the passed EntityManager.
+     *
+     * @param ObjectManager $manager
+     */
+    public function load(ObjectManager $manager)
+    {
+        /**
+         * Pack.
+         *
+         * @var CategoryInterface     $category
+         * @var ManufacturerInterface $manufacturer
+         * @var CurrencyInterface     $currency
+         * @var ObjectDirector        $productDirector
+         */
+        $category = $this->getReference('category');
+        $manufacturer = $this->getReference('manufacturer');
+        $product = $this->getReference('product');
+        $productReduced = $this->getReference('product-reduced');
+        $variant = $this->getReference('variant-red-small');
+        $currency = $this->getReference('currency-dollar');
+        $packDirector = $this->getDirector('product_pack');
+
+        $pack = $packDirector
+            ->create()
+            ->setName('pack')
+            ->setSlug('pack')
+            ->setDescription('my pack description')
+            ->setShortDescription('my pack short description')
+            ->addCategory($category)
+            ->setPrincipalCategory($category)
+            ->setManufacturer($manufacturer)
+            ->addPurchasable($product)
+            ->addPurchasable($productReduced)
+            ->addPurchasable($variant)
+            ->setStockType(ElcodiProductStock::SPECIFIC_STOCK)
+            ->setStock(10)
+            ->setPrice(Money::create(5000, $currency))
+            ->setSku('pack-sku-code-1')
+            ->setHeight(30)
+            ->setWidth(30)
+            ->setDepth(30)
+            ->setWeight(200)
+            ->setEnabled(true);
+
+        $packDirector->save($pack);
+        $this->addReference('pack', $pack);
+
+        $packInherit = $packDirector
+            ->create()
+            ->setName('pack-inherit')
+            ->setSlug('pack-inherit')
+            ->setDescription('my pack inherit description')
+            ->setShortDescription('my pack inherit short description')
+            ->addCategory($category)
+            ->setPrincipalCategory($category)
+            ->setManufacturer($manufacturer)
+            ->addPurchasable($product)
+            ->addPurchasable($productReduced)
+            ->addPurchasable($variant)
+            ->setStockType(ElcodiProductStock::INHERIT_STOCK)
+            ->setPrice(Money::create(5000, $currency))
+            ->setSku('pack-inherit-sku-code-1')
+            ->setHeight(30)
+            ->setWidth(30)
+            ->setDepth(30)
+            ->setWeight(200)
+            ->setEnabled(true);
+
+        $packDirector->save($packInherit);
+        $this->addReference('pack-inherit', $packInherit);
+    }
+
+    /**
+     * This method must return an array of fixtures classes
+     * on which the implementing class depends on.
+     *
+     * @return array
+     */
+    public function getDependencies()
+    {
+        return [
+            'Elcodi\Bundle\ProductBundle\DataFixtures\ORM\ProductData',
+            'Elcodi\Bundle\ProductBundle\DataFixtures\ORM\VariantData',
+            'Elcodi\Bundle\CurrencyBundle\DataFixtures\ORM\CurrencyData',
+            'Elcodi\Bundle\ProductBundle\DataFixtures\ORM\CategoryData',
+            'Elcodi\Bundle\ProductBundle\DataFixtures\ORM\ManufacturerData',
+            'Elcodi\Bundle\StoreBundle\DataFixtures\ORM\StoreData',
+        ];
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/DataFixtures/ORM/VariantData.php
+++ b/src/Elcodi/Bundle/ProductBundle/DataFixtures/ORM/VariantData.php
@@ -76,7 +76,7 @@ class VariantData extends AbstractFixture implements DependentFixtureInterface
         $productWithVariants->setPrincipalVariant($variantWhiteSmall);
 
         $variantDirector->save($variantWhiteSmall);
-        $this->addReference('variant-white-small', $productWithVariants);
+        $this->addReference('variant-white-small', $variantWhiteSmall);
 
         /**
          * Variant White-Large.
@@ -96,7 +96,7 @@ class VariantData extends AbstractFixture implements DependentFixtureInterface
             ->setEnabled(true);
 
         $variantDirector->save($variantWhiteLarge);
-        $this->addReference('variant-white-large', $productWithVariants);
+        $this->addReference('variant-white-large', $variantWhiteLarge);
 
         /**
          * Variant Red-Small.
@@ -116,7 +116,7 @@ class VariantData extends AbstractFixture implements DependentFixtureInterface
             ->setEnabled(true);
 
         $variantDirector->save($variantRedSmall);
-        $this->addReference('variant-red-small', $productWithVariants);
+        $this->addReference('variant-red-small', $variantRedSmall);
 
         /**
          * Variant Red-Large.
@@ -136,7 +136,7 @@ class VariantData extends AbstractFixture implements DependentFixtureInterface
             ->setEnabled(true);
 
         $variantDirector->save($variantRedLarge);
-        $this->addReference('variant-red-large', $productWithVariants);
+        $this->addReference('variant-red-large', $variantRedLarge);
     }
 
     /**

--- a/src/Elcodi/Bundle/ProductBundle/DependencyInjection/Configuration.php
+++ b/src/Elcodi/Bundle/ProductBundle/DependencyInjection/Configuration.php
@@ -51,6 +51,13 @@ class Configuration extends AbstractConfiguration
                             true
                         ))
                         ->append($this->addMappingNode(
+                            'product_pack',
+                            'Elcodi\Component\Product\Entity\Pack',
+                            '@ElcodiProductBundle/Resources/config/doctrine/Pack.orm.yml',
+                            'default',
+                            true
+                        ))
+                        ->append($this->addMappingNode(
                             'category',
                             'Elcodi\Component\Product\Entity\Category',
                             '@ElcodiProductBundle/Resources/config/doctrine/Category.orm.yml',

--- a/src/Elcodi/Bundle/ProductBundle/DependencyInjection/ElcodiProductExtension.php
+++ b/src/Elcodi/Bundle/ProductBundle/DependencyInjection/ElcodiProductExtension.php
@@ -49,7 +49,7 @@ class ElcodiProductExtension extends AbstractExtension implements EntitiesOverri
      * Return a new Configuration instance.
      *
      * If object returned by this method is an instance of
-     * ConfigurationInterface, extension will use the Configuration to read all
+     * ConfigurationInterface, extension will use the Configuration to read allproduct_pack
      * bundle config definitions.
      *
      * Also will call getParametrizationValues method to load some config values
@@ -88,6 +88,11 @@ class ElcodiProductExtension extends AbstractExtension implements EntitiesOverri
             'elcodi.entity.product_variant.manager' => $config['mapping']['product_variant']['manager'],
             'elcodi.entity.product_variant.enabled' => $config['mapping']['product_variant']['enabled'],
 
+            'elcodi.entity.product_pack.class' => $config['mapping']['product_pack']['class'],
+            'elcodi.entity.product_pack.mapping_file' => $config['mapping']['product_pack']['mapping_file'],
+            'elcodi.entity.product_pack.manager' => $config['mapping']['product_pack']['manager'],
+            'elcodi.entity.product_pack.enabled' => $config['mapping']['product_pack']['enabled'],
+
             'elcodi.entity.category.class' => $config['mapping']['category']['class'],
             'elcodi.entity.category.mapping_file' => $config['mapping']['category']['mapping_file'],
             'elcodi.entity.category.manager' => $config['mapping']['category']['manager'],
@@ -122,6 +127,9 @@ class ElcodiProductExtension extends AbstractExtension implements EntitiesOverri
             'directors',
             'eventListeners',
             'adapters',
+            'nameResolvers',
+            'stockUpdaters',
+            'stockValidators',
         ];
     }
 
@@ -139,6 +147,7 @@ class ElcodiProductExtension extends AbstractExtension implements EntitiesOverri
         return [
             'Elcodi\Component\Product\Entity\Interfaces\ProductInterface' => 'elcodi.entity.product.class',
             'Elcodi\Component\Product\Entity\Interfaces\VariantInterface' => 'elcodi.entity.product_variant.class',
+            'Elcodi\Component\Product\Entity\Interfaces\PackInterface' => 'elcodi.entity.product_pack.class',
             'Elcodi\Component\Product\Entity\Interfaces\ManufacturerInterface' => 'elcodi.entity.manufacturer.class',
             'Elcodi\Component\Product\Entity\Interfaces\CategoryInterface' => 'elcodi.entity.category.class',
         ];

--- a/src/Elcodi/Bundle/ProductBundle/ElcodiProductBundle.php
+++ b/src/Elcodi/Bundle/ProductBundle/ElcodiProductBundle.php
@@ -24,6 +24,11 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
 use Elcodi\Bundle\ProductBundle\CompilerPass\MappingCompilerPass;
+use Elcodi\Bundle\ProductBundle\CompilerPass\PackStockUpdaterCompilerPass;
+use Elcodi\Bundle\ProductBundle\CompilerPass\PackStockValidatorCompilerPass;
+use Elcodi\Bundle\ProductBundle\CompilerPass\PurchasableNameResolverCompilerPass;
+use Elcodi\Bundle\ProductBundle\CompilerPass\PurchasableStockUpdaterCompilerPass;
+use Elcodi\Bundle\ProductBundle\CompilerPass\PurchasableStockValidatorCompilerPass;
 use Elcodi\Bundle\ProductBundle\DependencyInjection\ElcodiProductExtension;
 
 /**
@@ -39,6 +44,11 @@ class ElcodiProductBundle extends AbstractElcodiBundle implements DependentBundl
         parent::build($container);
 
         $container->addCompilerPass(new MappingCompilerPass());
+        $container->addCompilerPass(new PurchasableNameResolverCompilerPass());
+        $container->addCompilerPass(new PurchasableStockValidatorCompilerPass());
+        $container->addCompilerPass(new PurchasableStockUpdaterCompilerPass());
+        $container->addCompilerPass(new PackStockValidatorCompilerPass());
+        $container->addCompilerPass(new PackStockUpdaterCompilerPass());
     }
 
     /**

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/directors.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/directors.yml
@@ -19,6 +19,14 @@ services:
             - '@elcodi.repository.product_variant'
             - '@elcodi.factory.product_variant'
 
+    elcodi.director.product_pack:
+        class: Elcodi\Component\Core\Services\ObjectDirector
+        lazy: true
+        arguments:
+            - '@elcodi.object_manager.product_pack'
+            - '@elcodi.repository.product_pack'
+            - '@elcodi.factory.product_pack'
+
     elcodi.director.category:
         class: Elcodi\Component\Core\Services\ObjectDirector
         lazy: true

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/doctrine/Pack.orm.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/doctrine/Pack.orm.yml
@@ -1,0 +1,185 @@
+Elcodi\Component\Product\Entity\Pack:
+    type: entity
+    repositoryClass: Elcodi\Component\Product\Repository\PackRepository
+    table: pack
+    id:
+        id:
+            type: integer
+            generator:
+                strategy: AUTO
+    fields:
+        name:
+            column: name
+            type: string
+            length: 255
+            nullable: false
+        sku:
+            column: sku
+            type: string
+            length: 255
+            nullable: true
+        slug:
+            column: slug
+            type: string
+            length: 255
+            nullable: false
+        shortDescription:
+            column: short_description
+            type: string
+            length: 255
+            nullable: true
+        description:
+            column: description
+            type: text
+            nullable: true
+        showInHome:
+            column: show_in_home
+            type: boolean
+        dimensions:
+            column: dimensions
+            type: string
+            length: 255
+            nullable: true
+        stock:
+            column: stock
+            type: integer
+            nullable: true
+        stockType:
+            column: stock_type
+            type: integer
+            nullable: false
+        price:
+            column: price
+            type: integer
+            nullable: true
+        reducedPrice:
+            column: reduced_price
+            type: integer
+            nullable: true
+        height:
+            column: height
+            type: integer
+            nullable: false
+        width:
+            column: width
+            type: integer
+            nullable: false
+        depth:
+            column: depth
+            type: integer
+            nullable: false
+        weight:
+            column: weight
+            type: integer
+            nullable: false
+        imagesSort:
+            column: images_sort
+            type: string
+            length: 2048
+            nullable: true
+        metaTitle:
+            column: meta_title
+            type: string
+            length: 255
+            nullable: true
+        metaDescription:
+            column: meta_description
+            type: string
+            length: 255
+            nullable: true
+        metaKeywords:
+            column: meta_keywords
+            type: string
+            length: 255
+            nullable: true
+        createdAt:
+            column: created_at
+            type: datetime
+        updatedAt:
+            column: updated_at
+            type: datetime
+        enabled:
+            column: enabled
+            type: boolean
+
+    manyToOne:
+        manufacturer:
+            targetEntity: Elcodi\Component\Product\Entity\Interfaces\ManufacturerInterface
+            inversedBy: products
+            joinColumn:
+                name: manufacturer_id
+                referencedColumnName: id
+                nullable: true
+                onDelete: "SET NULL"
+        principalCategory:
+            targetEntity: Elcodi\Component\Product\Entity\Interfaces\CategoryInterface
+            joinColumn:
+                name: principal_category_id
+                referencedColumnName: id
+                nullable: true
+                onDelete: "SET NULL"
+        principalImage:
+            targetEntity: Elcodi\Component\Media\Entity\Interfaces\ImageInterface
+            joinColumn:
+                onDelete: SET NULL
+                name: principal_image_id
+                referencedColumnName: id
+                nullable: true
+        priceCurrency:
+            targetEntity: Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface
+            joinColumn:
+                 name: price_currency_iso
+                 referencedColumnName: iso
+                 nullable: true
+        reducedPriceCurrency:
+            targetEntity: Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface
+            joinColumn:
+                 name: reduced_price_currency_iso
+                 referencedColumnName: iso
+                 nullable: true
+
+    manyToMany:
+        categories:
+            targetEntity: Elcodi\Component\Product\Entity\Interfaces\CategoryInterface
+            joinTable:
+                name: pack_category
+                joinColumns:
+                    pack_id:
+                        referencedColumnName: id
+                inverseJoinColumns:
+                    category_id:
+                        referencedColumnName: id
+        images:
+            targetEntity: Elcodi\Component\Media\Entity\Interfaces\ImageInterface
+            joinTable:
+                name: pack_image
+                joinColumns:
+                    pack_id:
+                        referencedColumnName: id
+                inverseJoinColumns:
+                    image_id:
+                        referencedColumnName: id
+        products:
+            targetEntity: Elcodi\Component\Product\Entity\Interfaces\ProductInterface
+            joinTable:
+                name: pack_product
+                joinColumns:
+                    pack_id:
+                        referencedColumnName: id
+                inverseJoinColumns:
+                    product_id:
+                        referencedColumnName: id
+        variants:
+            targetEntity: Elcodi\Component\Product\Entity\Interfaces\VariantInterface
+            joinTable:
+                name: pack_variants
+                joinColumns:
+                    pack_id:
+                        referencedColumnName: id
+                inverseJoinColumns:
+                    variant_id:
+                        referencedColumnName: id
+
+    lifecycleCallbacks:
+        preUpdate: [loadUpdateAt]
+        prePersist: [loadUpdateAt]

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/doctrine/Product.orm.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/doctrine/Product.orm.yml
@@ -35,7 +35,6 @@ Elcodi\Component\Product\Entity\Product:
         showInHome:
             column: show_in_home
             type: boolean
-            nullable: true
         dimensions:
             column: dimensions
             type: string
@@ -72,7 +71,7 @@ Elcodi\Component\Product\Entity\Product:
         imagesSort:
             column: images_sort
             type: string
-            lentgh: 2048
+            length: 2048
             nullable: true
         metaTitle:
             column: meta_title

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/doctrine/Variant.orm.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/doctrine/Variant.orm.yml
@@ -44,7 +44,7 @@ Elcodi\Component\Product\Entity\Variant:
         imagesSort:
             column: images_sort
             type: string
-            lentgh: 2048
+            length: 2048
             nullable: true
         createdAt:
             column: created_at

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/factories.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/factories.yml
@@ -26,6 +26,16 @@ services:
             - [setDateTimeFactory, ["@elcodi.factory.datetime"]]
 
     #
+    # Factory for Pack entities
+    #
+    elcodi.factory.product_pack:
+        class: Elcodi\Component\Product\Factory\PackFactory
+        parent: elcodi.factory.abstract.purchasable
+        calls:
+            - [setEntityNamespace, ["%elcodi.entity.product_pack.class%"]]
+            - [setDateTimeFactory, ["@elcodi.factory.datetime"]]
+
+    #
     # Factory for Manufacturer entities
     #
     elcodi.factory.manufacturer:

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/nameResolvers.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/nameResolvers.yml
@@ -1,0 +1,22 @@
+services:
+
+    #
+    # Name resolvers
+    #
+    elcodi.name_resolver.product:
+        class: Elcodi\Component\Product\NameResolver\ProductNameResolver
+        tags:
+            - { name: elcodi.purchasable_name_resolver }
+
+    elcodi.name_resolver.product_variant:
+        class: Elcodi\Component\Product\NameResolver\VariantNameResolver
+        tags:
+            - { name: elcodi.purchasable_name_resolver }
+
+    elcodi.name_resolver.product_pack:
+        class: Elcodi\Component\Product\NameResolver\PackNameResolver
+        tags:
+            - { name: elcodi.purchasable_name_resolver }
+
+    elcodi.name_resolver.purchasable:
+        class: Elcodi\Component\Product\NameResolver\PurchasableNameResolver

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/objectManagers.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/objectManagers.yml
@@ -13,6 +13,11 @@ services:
         arguments:
             - %elcodi.entity.product_variant.class%
 
+    elcodi.object_manager.product_pack:
+        parent: elcodi.abstract_manager
+        arguments:
+            - %elcodi.entity.product_pack.class%
+
     elcodi.object_manager.category:
         parent: elcodi.abstract_manager
         arguments:

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/repositories.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/repositories.yml
@@ -21,6 +21,14 @@ services:
             - %elcodi.entity.product_variant.class%
 
     #
+    # Repository for Pack entities
+    #
+    elcodi.repository.product_pack:
+        parent: elcodi.abstract_repository
+        arguments:
+            - %elcodi.entity.product_pack.class%
+
+    #
     # Repository for entity category
     #
     elcodi.repository.category:

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/stockUpdaters.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/stockUpdaters.yml
@@ -1,0 +1,30 @@
+services:
+
+    #
+    # Stock updaters
+    #
+    elcodi.stock_updater.product:
+        class: Elcodi\Component\Product\StockUpdater\ProductStockUpdater
+        arguments:
+            - "@elcodi.object_manager.product"
+        tags:
+            - { name: elcodi.purchasable_stock_updater }
+            - { name: elcodi.simple_purchasable_stock_updater }
+
+    elcodi.stock_updater.product_variant:
+        class: Elcodi\Component\Product\StockUpdater\VariantStockUpdater
+        arguments:
+            - "@elcodi.object_manager.product_variant"
+        tags:
+            - { name: elcodi.purchasable_stock_updater }
+            - { name: elcodi.simple_purchasable_stock_updater }
+
+    elcodi.stock_updater.product_pack:
+        class: Elcodi\Component\Product\StockUpdater\PackStockUpdater
+        arguments:
+            - "@elcodi.object_manager.product_pack"
+        tags:
+            - { name: elcodi.purchasable_stock_updater }
+
+    elcodi.stock_updater.purchasable:
+        class: Elcodi\Component\Product\StockUpdater\PurchasableStockUpdater

--- a/src/Elcodi/Bundle/ProductBundle/Resources/config/stockValidators.yml
+++ b/src/Elcodi/Bundle/ProductBundle/Resources/config/stockValidators.yml
@@ -1,0 +1,24 @@
+services:
+
+    #
+    # Validators
+    #
+    elcodi.stock_validator.product:
+        class: Elcodi\Component\Product\StockValidator\ProductStockValidator
+        tags:
+            - { name: elcodi.purchasable_stock_validator }
+            - { name: elcodi.simple_purchasable_stock_validator }
+
+    elcodi.stock_validator.product_variant:
+        class: Elcodi\Component\Product\StockValidator\VariantStockValidator
+        tags:
+            - { name: elcodi.purchasable_stock_validator }
+            - { name: elcodi.simple_purchasable_stock_validator }
+
+    elcodi.stock_validator.product_pack:
+        class: Elcodi\Component\Product\StockValidator\PackStockValidator
+        tags:
+            - { name: elcodi.purchasable_stock_validator }
+
+    elcodi.stock_validator.purchasable:
+        class: Elcodi\Component\Product\StockValidator\PurchasableStockValidator

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Entity/PackTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/Entity/PackTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\Entity;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class PackTest.
+ */
+class PackTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test get stock with specific stock.
+     */
+    public function testGetStockSpecificStock()
+    {
+        $this->assertEquals(10, $this
+            ->find('product_pack', 1)
+            ->getStock()
+        );
+    }
+
+    /**
+     * Test get stock with inherit stock.
+     */
+    public function testGetStockInheritStock()
+    {
+        $this->assertEquals(5, $this
+            ->find('product_pack', 2)
+            ->getStock()
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/NameResolver/PackNameResolverTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/NameResolver/PackNameResolverTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\NameResolver;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class PackNameResolverTest.
+ */
+class PackNameResolverTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test resolve name.
+     */
+    public function testResolveName()
+    {
+        $pack = $this->find('product_pack', 1);
+        $this->assertEquals(
+            'pack',
+            $this
+                ->get('elcodi.name_resolver.product_pack')
+                ->resolveName($pack)
+        );
+        $this->assertEquals(
+            'pack',
+            $this
+                ->get('elcodi.name_resolver.purchasable')
+                ->resolveName($pack)
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/NameResolver/ProductNameResolverTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/NameResolver/ProductNameResolverTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\NameResolver;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class ProductNameResolverTest.
+ */
+class ProductNameResolverTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test resolve name.
+     */
+    public function testResolveName()
+    {
+        $product = $this->find('product', 2);
+        $this->assertEquals(
+            'product-reduced',
+            $this
+                ->get('elcodi.name_resolver.product')
+                ->resolveName($product)
+        );
+        $this->assertEquals(
+            'product-reduced',
+            $this
+                ->get('elcodi.name_resolver.purchasable')
+                ->resolveName($product)
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/NameResolver/VariantNameResolverTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/NameResolver/VariantNameResolverTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\NameResolver;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class VariantNameResolverTest.
+ */
+class VariantNameResolverTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test resolve name.
+     */
+    public function testResolveName()
+    {
+        $variant = $this->find('product_variant', 2);
+        $this->assertEquals(
+            'Product with variants - Size Large - Color White',
+            $this
+                ->get('elcodi.name_resolver.product_variant')
+                ->resolveName($variant)
+        );
+        $this->assertEquals(
+            'Product with variants - Size Large - Color White',
+            $this
+                ->get('elcodi.name_resolver.purchasable')
+                ->resolveName($variant)
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockUpdater/PackStockUpdaterTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockUpdater/PackStockUpdaterTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\StockUpdater;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class PackStockUpdaterTest.
+ */
+class PackStockUpdaterTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test update stock.
+     */
+    public function atestUpdateStockNonInherit()
+    {
+        $pack = $this->find('product_pack', 1);
+        $this->get('elcodi.stock_updater.product_pack')->updateStock(
+            $pack,
+            4
+        );
+        $this->getObjectManager('product_pack')->clear();
+        $pack = $this->find('product_pack', 1);
+        $this->assertEquals(
+            6,
+            $pack->getStock()
+        );
+    }
+
+    /**
+     * Test update stock.
+     */
+    public function testUpdateStockInherit()
+    {
+        $this->reloadScenario();
+
+        $pack = $this->find('product_pack', 2);
+        $this->get('elcodi.stock_updater.product_pack')->updateStock(
+            $pack,
+            3
+        );
+        $this->clear($pack);
+        $pack = $this->find('product_pack', 2);
+        $this->assertEquals(
+            2,
+            $pack->getStock()
+        );
+        $purchasables = $pack->getPurchasables()->toArray();
+
+        $this->assertEquals(
+            7,
+            $purchasables[0]->getStock()
+        );
+
+        $this->assertEquals(
+            2,
+            $purchasables[1]->getStock()
+        );
+
+        $this->assertEquals(
+            97,
+            $purchasables[2]->getStock()
+        );
+    }
+
+    /**
+     * Test update stock.
+     */
+    public function testUpdateStockInheritWithStockFinish()
+    {
+        $this->reloadScenario();
+
+        $pack = $this->find('product_pack', 2);
+        $this->get('elcodi.stock_updater.product_pack')->updateStock(
+            $pack,
+            9
+        );
+        $this->clear($pack);
+        $pack = $this->find('product_pack', 2);
+        $this->assertEquals(
+            0,
+            $pack->getStock()
+        );
+        $purchasables = $pack->getPurchasables()->toArray();
+
+        $this->assertEquals(
+            1,
+            $purchasables[0]->getStock()
+        );
+
+        $this->assertEquals(
+            0,
+            $purchasables[1]->getStock()
+        );
+
+        $this->assertEquals(
+            91,
+            $purchasables[2]->getStock()
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockUpdater/ProductStockUpdaterTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockUpdater/ProductStockUpdaterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\StockUpdater;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class ProductStockUpdaterTest.
+ */
+class ProductStockUpdaterTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test update stock.
+     */
+    public function testUpdateStock()
+    {
+        $product = $this->find('product', 1);
+        $this->get('elcodi.stock_updater.product')->updateStock(
+            $product,
+            2
+        );
+        $this->clear($product);
+        $product = $this->find('product', 1);
+        $this->assertEquals(
+            8,
+            $product->getStock()
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockUpdater/VariantStockUpdaterTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockUpdater/VariantStockUpdaterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\StockUpdater;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class VariantStockUpdaterTest.
+ */
+class VariantStockUpdaterTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test update stock.
+     */
+    public function testUpdateStock()
+    {
+        $variant = $this->find('product_variant', 1);
+        $this->get('elcodi.stock_updater.product_variant')->updateStock(
+            $variant,
+            20
+        );
+        $this->clear($variant);
+        $variant = $this->find('product_variant', 1);
+        $this->assertEquals(
+            80,
+            $variant->getStock()
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockValidator/PackStockValidatorTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockValidator/PackStockValidatorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\StockValidator;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class PackStockValidatorTest.
+ */
+class PackStockValidatorTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test product validator without stock inheritance.
+     */
+    public function testIsStockAvailableNonInheritance()
+    {
+        $pack = $this->find('product_pack', 1);
+        $packStockValidator = $this->get('elcodi.stock_validator.product_pack');
+        $this->assertTrue(
+            $packStockValidator->isStockAvailable(
+                $pack,
+                1,
+                true
+            )
+        );
+
+        $this->assertEquals(
+            10,
+            $packStockValidator->isStockAvailable(
+                $pack,
+                11,
+                true
+            )
+        );
+
+        $purchasableStockValidator = $this->get('elcodi.stock_validator.purchasable');
+
+        $this->assertTrue(
+            $purchasableStockValidator->isStockAvailable(
+                $pack,
+                1,
+                true
+            )
+        );
+
+        $this->assertEquals(
+            10,
+            $purchasableStockValidator->isStockAvailable(
+                $pack,
+                11,
+                true
+            )
+        );
+    }
+
+    /**
+     * Test product validator with stock inheritance.
+     */
+    public function testIsStockAvailableInheritance()
+    {
+        $pack = $this->find('product_pack', 2);
+        $packStockValidator = $this->get('elcodi.stock_validator.product_pack');
+        $this->assertTrue(
+            $packStockValidator->isStockAvailable(
+                $pack,
+                1,
+                true
+            )
+        );
+
+        $this->assertEquals(
+            5,
+            $packStockValidator->isStockAvailable(
+                $pack,
+                10,
+                true
+            )
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockValidator/ProductStockValidatorTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockValidator/ProductStockValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\StockValidator;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class ProductStockValidatorTest.
+ */
+class ProductStockValidatorTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test product validator.
+     */
+    public function testIsStockAvailable()
+    {
+        $product = $this->find('product', 1);
+        $productStockValidator = $this->get('elcodi.stock_validator.product');
+        $this->assertTrue(
+            $productStockValidator->isStockAvailable(
+                $product,
+                1,
+                true
+            )
+        );
+
+        $this->assertEquals(
+            10,
+            $productStockValidator->isStockAvailable(
+                $product,
+                11,
+                true
+            )
+        );
+
+        $purchasableStockValidator = $this->get('elcodi.stock_validator.purchasable');
+
+        $this->assertTrue(
+            $purchasableStockValidator->isStockAvailable(
+                $product,
+                1,
+                true
+            )
+        );
+
+        $this->assertEquals(
+            10,
+            $purchasableStockValidator->isStockAvailable(
+                $product,
+                11,
+                true
+            )
+        );
+    }
+}

--- a/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockValidator/VariantStockValidatorTest.php
+++ b/src/Elcodi/Bundle/ProductBundle/Tests/Functional/StockValidator/VariantStockValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\ProductBundle\Tests\Functional\StockValidator;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class VariantStockValidatorTest.
+ */
+class VariantStockValidatorTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiProductBundle',
+        ];
+    }
+
+    /**
+     * Test product validator.
+     */
+    public function testIsStockAvailable()
+    {
+        $variant = $this->find('product_variant', 1);
+        $variantStockValidator = $this->get('elcodi.stock_validator.product_variant');
+        $this->assertTrue(
+            $variantStockValidator->isStockAvailable(
+                $variant,
+                1,
+                true
+            )
+        );
+
+        $this->assertEquals(
+            100,
+            $variantStockValidator->isStockAvailable(
+                $variant,
+                101,
+                true
+            )
+        );
+
+        $purchasableStockValidator = $this->get('elcodi.stock_validator.purchasable');
+
+        $this->assertTrue(
+            $purchasableStockValidator->isStockAvailable(
+                $variant,
+                1,
+                true
+            )
+        );
+
+        $this->assertEquals(
+            100,
+            $purchasableStockValidator->isStockAvailable(
+                $variant,
+                101,
+                true
+            )
+        );
+    }
+}

--- a/src/Elcodi/Component/Banner/Tests/UnitTest/Entity/BannerTest.php
+++ b/src/Elcodi/Component/Banner/Tests/UnitTest/Entity/BannerTest.php
@@ -17,8 +17,8 @@
 
 namespace Elcodi\Component\Banner\Tests\UnitTest\Entity;
 
-use Elcodi\Component\Core\Tests\UnitTest\Entity\AbstractEntityTest;
 use Elcodi\Component\Banner\Entity\Banner;
+use Elcodi\Component\Core\Tests\UnitTest\Entity\AbstractEntityTest;
 
 /**
  * Class BannerTest.

--- a/src/Elcodi/Component/Banner/Tests/UnitTest/Entity/BannerZoneTest.php
+++ b/src/Elcodi/Component/Banner/Tests/UnitTest/Entity/BannerZoneTest.php
@@ -17,8 +17,8 @@
 
 namespace Elcodi\Component\Banner\Tests\UnitTest\Entity;
 
-use Elcodi\Component\Core\Tests\UnitTest\Entity\AbstractEntityTest;
 use Elcodi\Component\Banner\Entity\BannerZone;
+use Elcodi\Component\Core\Tests\UnitTest\Entity\AbstractEntityTest;
 
 /**
  * Class BannerZoneTest.

--- a/src/Elcodi/Component/Cart/Entity/Interfaces/PurchasableWrapperInterface.php
+++ b/src/Elcodi/Component/Cart/Entity/Interfaces/PurchasableWrapperInterface.php
@@ -46,6 +46,9 @@ interface PurchasableWrapperInterface
     /**
      * Sets the product.
      *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             setPurchasable instead.
+     *
      * @param ProductInterface $product Product
      *
      * @return $this Self object
@@ -55,12 +58,18 @@ interface PurchasableWrapperInterface
     /**
      * Gets the product.
      *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             getPurchasable instead.
+     *
      * @return ProductInterface product attached to this cart line
      */
     public function getProduct();
 
     /**
      * Sets the product variant.
+     *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             setPurchasable instead.
      *
      * @param VariantInterface $variant Variant
      *
@@ -70,6 +79,9 @@ interface PurchasableWrapperInterface
 
     /**
      * Returns the product variant.
+     *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             getPurchasable instead.
      *
      * @return VariantInterface Variant
      */

--- a/src/Elcodi/Component/Cart/Entity/Traits/PurchasableWrapperTrait.php
+++ b/src/Elcodi/Component/Cart/Entity/Traits/PurchasableWrapperTrait.php
@@ -17,6 +17,7 @@
 
 namespace Elcodi\Component\Cart\Entity\Traits;
 
+use Elcodi\Component\Product\Entity\Interfaces\PackInterface;
 use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
 use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
 use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
@@ -41,6 +42,13 @@ trait PurchasableWrapperTrait
     protected $variant;
 
     /**
+     * @var PackInterface
+     *
+     * Pack
+     */
+    protected $pack;
+
+    /**
      * @var int
      *
      * Quantity
@@ -57,17 +65,23 @@ trait PurchasableWrapperTrait
      */
     public function setPurchasable(PurchasableInterface $purchasable)
     {
-        if ($purchasable instanceof VariantInterface) {
-            $this->setVariant($purchasable);
-            $product = $purchasable->getProduct();
-        } else {
-            /**
-             * @var ProductInterface $purchasable
-             */
-            $product = $purchasable;
+        if ($purchasable instanceof ProductInterface) {
+            $this->product = $purchasable;
+
+            return $this;
         }
 
-        $this->setProduct($product);
+        if ($purchasable instanceof VariantInterface) {
+            $this->variant = $purchasable;
+            $product = $purchasable->getProduct();
+            $this->product = $product;
+
+            return $this;
+        }
+
+        if ($purchasable instanceof PackInterface) {
+            $this->pack = $purchasable;
+        }
 
         return $this;
     }
@@ -75,17 +89,28 @@ trait PurchasableWrapperTrait
     /**
      * Gets the purchasable object.
      *
-     * @return PurchasableInterface
+     * @return null|PurchasableInterface Purchasable instance
      */
     public function getPurchasable()
     {
-        return ($this->getVariant() instanceof VariantInterface)
-            ? $this->getVariant()
-            : $this->getProduct();
+        if ($this->variant instanceof VariantInterface) {
+            return $this->variant;
+        }
+
+        if ($this->product instanceof ProductInterface) {
+            return $this->product;
+        }
+
+        if ($this->pack instanceof PackInterface) {
+            return $this->pack;
+        }
     }
 
     /**
      * Sets the product.
+     *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             setPurchasable instead.
      *
      * @param ProductInterface $product Product
      *
@@ -93,6 +118,9 @@ trait PurchasableWrapperTrait
      */
     public function setProduct(ProductInterface $product)
     {
+        @trigger_error('Deprecated since version 1.0.13, to be removed in 2.0.0.
+        Use setPurchasable instead', E_USER_DEPRECATED);
+
         $this->product = $product;
 
         return $this;
@@ -101,15 +129,24 @@ trait PurchasableWrapperTrait
     /**
      * Gets the product.
      *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             getPurchasable instead.
+     *
      * @return ProductInterface product attached to this cart line
      */
     public function getProduct()
     {
+        @trigger_error('Deprecated since version 1.0.13, to be removed in 2.0.0.
+        Use getPurchasable instead', E_USER_DEPRECATED);
+
         return $this->product;
     }
 
     /**
      * Sets the product variant.
+     *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             setPurchasable instead.
      *
      * @param VariantInterface $variant Variant
      *
@@ -117,6 +154,9 @@ trait PurchasableWrapperTrait
      */
     public function setVariant(VariantInterface $variant)
     {
+        @trigger_error('Deprecated since version 1.0.13, to be removed in 2.0.0.
+        Use setPurchasable instead', E_USER_DEPRECATED);
+
         $this->variant = $variant;
 
         return $this;
@@ -125,10 +165,16 @@ trait PurchasableWrapperTrait
     /**
      * Returns the product variant.
      *
+     * @deprecated since version 1.0.13, to be removed in 2.0.0. Use
+     *             getPurchasable instead.
+     *
      * @return VariantInterface Variant
      */
     public function getVariant()
     {
+        @trigger_error('Deprecated since version 1.0.13, to be removed in 2.0.0.
+        Use getPurchasable instead', E_USER_DEPRECATED);
+
         return $this->variant;
     }
 

--- a/src/Elcodi/Component/Product/ElcodiProductStock.php
+++ b/src/Elcodi/Component/Product/ElcodiProductStock.php
@@ -28,4 +28,18 @@ final class ElcodiProductStock
      * Infinite stock
      */
     const INFINITE_STOCK = null;
+
+    /**
+     * @var int
+     *
+     * Inherit stock
+     */
+    const INHERIT_STOCK = 0;
+
+    /**
+     * @var int
+     *
+     * Specific stock
+     */
+    const SPECIFIC_STOCK = 1;
 }

--- a/src/Elcodi/Component/Product/Entity/Interfaces/PackInterface.php
+++ b/src/Elcodi/Component/Product/Entity/Interfaces/PackInterface.php
@@ -1,0 +1,269 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Entity\Interfaces;
+
+use Doctrine\Common\Collections\Collection;
+
+use Elcodi\Component\Core\Entity\Interfaces\DateTimeInterface;
+use Elcodi\Component\Core\Entity\Interfaces\ETaggableInterface;
+use Elcodi\Component\Core\Entity\Interfaces\IdentifiableInterface;
+use Elcodi\Component\Media\Entity\Interfaces\ImagesContainerInterface;
+use Elcodi\Component\Media\Entity\Interfaces\PrincipalImageInterface;
+use Elcodi\Component\MetaData\Entity\Interfaces\MetaDataInterface;
+
+/**
+ * Interface PackInterface.
+ */
+interface PackInterface
+    extends
+    IdentifiableInterface,
+    PurchasableInterface,
+    DateTimeInterface,
+    ETaggableInterface,
+    MetaDataInterface,
+    ImagesContainerInterface,
+    PrincipalImageInterface
+{
+    /**
+     * Set name.
+     *
+     * @param string $name Name
+     *
+     * @return $this Self object
+     */
+    public function setName($name);
+
+    /**
+     * Get name.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Set slug.
+     *
+     * @param string $slug Slug
+     *
+     * @return $this Self object
+     */
+    public function setSlug($slug);
+
+    /**
+     * Get slug.
+     *
+     * @return string slug
+     */
+    public function getSlug();
+
+    /**
+     * Set description.
+     *
+     * @param string $description
+     *
+     * @return $this Self object
+     */
+    public function setDescription($description);
+
+    /**
+     * Get description.
+     *
+     * @return string Description
+     */
+    public function getDescription();
+
+    /**
+     * Set short description.
+     *
+     * @param string $shortDescription Short description
+     *
+     * @return $this Self object
+     */
+    public function setShortDescription($shortDescription);
+
+    /**
+     * Get short description.
+     *
+     * @return string Short description
+     */
+    public function getShortDescription();
+
+    /**
+     * Adds an purchasable if not already in the collection.
+     *
+     * @param PurchasableInterface $purchasable Purchasable
+     *
+     * @return $this Self object;
+     */
+    public function addPurchasable(PurchasableInterface $purchasable);
+
+    /**
+     * Removes an purchasable from the collection.
+     *
+     * @param PurchasableInterface $purchasable Purchasable to be removed
+     *
+     * @return $this Self object
+     */
+    public function removePurchasable(PurchasableInterface $purchasable);
+
+    /**
+     * Returns purchasable purchasables.
+     *
+     * @return Collection Purchasables
+     */
+    public function getPurchasables();
+
+    /**
+     * Sets purchasable purchasables.
+     *
+     * @param Collection $purchasables Purchasables
+     *
+     * @return $this Self object
+     */
+    public function setPurchasables(Collection $purchasables);
+
+    /**
+     * Get Products.
+     *
+     * @return Collection Products
+     */
+    public function getProducts();
+
+    /**
+     * Sets Products.
+     *
+     * @param Collection $products Products
+     *
+     * @return $this Self object
+     */
+    public function setProducts($products);
+
+    /**
+     * Get Variants.
+     *
+     * @return Collection Variants
+     */
+    public function getVariants();
+
+    /**
+     * Sets Variants.
+     *
+     * @param Collection $variants Variants
+     *
+     * @return $this Self object
+     */
+    public function setVariants($variants);
+
+    /**
+     * Set categories.
+     *
+     * @param Collection $categories Categories
+     *
+     * @return $this Self object
+     */
+    public function setCategories(Collection $categories);
+
+    /**
+     * Get categories.
+     *
+     * @return Collection Categories
+     */
+    public function getCategories();
+
+    /**
+     * Add category.
+     *
+     * @param CategoryInterface $category Category
+     *
+     * @return $this Self object
+     */
+    public function addCategory(CategoryInterface $category);
+
+    /**
+     * Remove category.
+     *
+     * @param CategoryInterface $category Category
+     *
+     * @return $this Self object
+     */
+    public function removeCategory(CategoryInterface $category);
+
+    /**
+     * Set the principalCategory.
+     *
+     * @param CategoryInterface $principalCategory Principal category
+     *
+     * @return $this Self object
+     */
+    public function setPrincipalCategory(CategoryInterface $principalCategory = null);
+
+    /**
+     * Get the principalCategory.
+     *
+     * @return CategoryInterface Principal category
+     */
+    public function getPrincipalCategory();
+
+    /**
+     * Set show in home.
+     *
+     * @param bool $showInHome Show in home
+     *
+     * @return $this Self object
+     */
+    public function setShowInHome($showInHome);
+
+    /**
+     * Get show in home.
+     *
+     * @return bool Show in home
+     */
+    public function getShowInHome();
+
+    /**
+     * Set product manufacturer.
+     *
+     * @param ManufacturerInterface $manufacturer Manufacturer
+     *
+     * @return $this Self object
+     */
+    public function setManufacturer(ManufacturerInterface $manufacturer = null);
+
+    /**
+     * Get product manufacturer.
+     *
+     * @return ManufacturerInterface Manufacturer
+     */
+    public function getManufacturer();
+
+    /**
+     * Set stock type.
+     *
+     * @param int $stockType Stock type
+     *
+     * @return $this Self object
+     */
+    public function setStockType($stockType);
+
+    /**
+     * Get stock type.
+     *
+     * @return int Stock type
+     */
+    public function getStockType();
+}

--- a/src/Elcodi/Component/Product/Entity/Interfaces/ProductInterface.php
+++ b/src/Elcodi/Component/Product/Entity/Interfaces/ProductInterface.php
@@ -73,6 +73,8 @@ interface ProductInterface
     public function getSlug();
 
     /**
+     * Set description.
+     *
      * @param string $description
      *
      * @return $this Self object

--- a/src/Elcodi/Component/Product/Entity/Pack.php
+++ b/src/Elcodi/Component/Product/Entity/Pack.php
@@ -1,0 +1,658 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+use Elcodi\Component\Core\Entity\Traits\DateTimeTrait;
+use Elcodi\Component\Core\Entity\Traits\EnabledTrait;
+use Elcodi\Component\Core\Entity\Traits\ETaggableTrait;
+use Elcodi\Component\Core\Entity\Traits\IdentifiableTrait;
+use Elcodi\Component\Media\Entity\Traits\ImagesContainerTrait;
+use Elcodi\Component\Media\Entity\Traits\PrincipalImageTrait;
+use Elcodi\Component\MetaData\Entity\Traits\MetaDataTrait;
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\Entity\Interfaces\CategoryInterface;
+use Elcodi\Component\Product\Entity\Interfaces\ManufacturerInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PackInterface;
+use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
+use Elcodi\Component\Product\Entity\Traits\DimensionsTrait;
+use Elcodi\Component\Product\Entity\Traits\ProductPriceTrait;
+
+/**
+ * Class Pack entity.
+ */
+class Pack implements PackInterface
+{
+    use IdentifiableTrait,
+        ProductPriceTrait,
+        DateTimeTrait,
+        EnabledTrait,
+        ETaggableTrait,
+        MetaDataTrait,
+        ImagesContainerTrait,
+        PrincipalImageTrait,
+        DimensionsTrait;
+
+    /**
+     * @var string
+     *
+     * Name
+     */
+    protected $name;
+
+    /**
+     * @var string
+     *
+     * Pack SKU
+     */
+    protected $sku;
+
+    /**
+     * @var int
+     *
+     * Pack type
+     */
+    protected $type;
+
+    /**
+     * @var int
+     *
+     * Stock Type
+     */
+    protected $stockType;
+
+    /**
+     * @var int
+     *
+     * Stock
+     */
+    protected $stock;
+
+    /**
+     * @var string
+     *
+     * Slug
+     */
+    protected $slug;
+
+    /**
+     * @var string
+     *
+     * Short description
+     */
+    protected $shortDescription;
+
+    /**
+     * @var string
+     *
+     * Description
+     */
+    protected $description;
+
+    /**
+     * @var ManufacturerInterface
+     *
+     * Manufacturer
+     */
+    protected $manufacturer;
+
+    /**
+     * @var Collection
+     *
+     * Many-to-Many association between products and categories.
+     */
+    protected $categories;
+
+    /**
+     * @var CategoryInterface
+     *
+     * Principal category
+     */
+    protected $principalCategory;
+
+    /**
+     * @var bool
+     *
+     * Pack must show in home
+     */
+    protected $showInHome;
+
+    /**
+     * @var string
+     *
+     * Pack dimensions
+     */
+    protected $dimensions;
+
+    /**
+     * @var Collection
+     *
+     * Products
+     */
+    protected $products;
+
+    /**
+     * @var Collection
+     *
+     * Variants
+     */
+    protected $variants;
+
+    /**
+     * Set name.
+     *
+     * @param string $name Name
+     *
+     * @return $this Self object
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get name.
+     *
+     * @return string name
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set slug.
+     *
+     * @param string $slug Slug
+     *
+     * @return $this Self object
+     */
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    /**
+     * Get slug.
+     *
+     * @return string slug
+     */
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+
+    /**
+     * Set description.
+     *
+     * @param string $description Description
+     *
+     * @return $this Self object
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Get description.
+     *
+     * @return string Description
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set short description.
+     *
+     * @param string $shortDescription Short description
+     *
+     * @return $this Self object
+     */
+    public function setShortDescription($shortDescription)
+    {
+        $this->shortDescription = $shortDescription;
+
+        return $this;
+    }
+
+    /**
+     * Get short description.
+     *
+     * @return string Short description
+     */
+    public function getShortDescription()
+    {
+        return $this->shortDescription;
+    }
+
+    /**
+     * Set stock type.
+     *
+     * @param int $stockType Stock type
+     *
+     * @return $this Self object
+     */
+    public function setStockType($stockType)
+    {
+        $this->stockType = $stockType;
+
+        return $this;
+    }
+
+    /**
+     * Get stock type.
+     *
+     * @return int Stock type
+     */
+    public function getStockType()
+    {
+        return $this->stockType;
+    }
+
+    /**
+     * Set stock.
+     *
+     * @param int $stock Stock
+     *
+     * @return $this Self object
+     */
+    public function setStock($stock)
+    {
+        $this->stock = $stock;
+
+        return $this;
+    }
+
+    /**
+     * Get stock.
+     *
+     * @return int Stock
+     */
+    public function getStock()
+    {
+        if ($this->getStockType() !== ElcodiProductStock::INHERIT_STOCK) {
+            return $this->stock;
+        }
+
+        $stock = ElcodiProductStock::INFINITE_STOCK;
+        foreach ($this->getPurchasables() as $purchasable) {
+            $purchasableStock = $purchasable->getStock();
+            if (is_int($purchasableStock) && (
+                    !is_int($stock) ||
+                    $purchasableStock < $stock
+                )) {
+                $stock = $purchasableStock;
+            }
+        }
+
+        return $stock;
+    }
+
+    /**
+     * Set show in home.
+     *
+     * @param bool $showInHome Show in home
+     *
+     * @return $this Self object
+     */
+    public function setShowInHome($showInHome)
+    {
+        $this->showInHome = $showInHome;
+
+        return $this;
+    }
+
+    /**
+     * Get show in home.
+     *
+     * @return bool Show in home
+     */
+    public function getShowInHome()
+    {
+        return $this->showInHome;
+    }
+
+    /**
+     * Sets Dimensions.
+     *
+     * @param string $dimensions Dimensions
+     *
+     * @return $this Self object
+     */
+    public function setDimensions($dimensions)
+    {
+        $this->dimensions = $dimensions;
+
+        return $this;
+    }
+
+    /**
+     * Get Dimensions.
+     *
+     * @return string Dimensions
+     */
+    public function getDimensions()
+    {
+        return $this->dimensions;
+    }
+
+    /**
+     * Gets Pack SKU.
+     *
+     * @return string Pack SKU
+     */
+    public function getSku()
+    {
+        return $this->sku;
+    }
+
+    /**
+     * Sets Pack SKU.
+     *
+     * @param string $sku
+     *
+     * @return $this Self object
+     */
+    public function setSku($sku)
+    {
+        $this->sku = $sku;
+
+        return $this;
+    }
+
+    /**
+     * Sets Type.
+     *
+     * @param int $type Type
+     *
+     * @return $this Self object
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Get Type.
+     *
+     * @return int Type
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Initializes purchasables.
+     *
+     * @return $this Self object
+     */
+    public function initializePurchasable()
+    {
+        $this->products = new ArrayCollection();
+        $this->variants = new ArrayCollection();
+
+        return $this;
+    }
+
+    /**
+     * Adds an purchasable if not already in the collection.
+     *
+     * @param PurchasableInterface $purchasable Purchasable
+     *
+     * @return $this Self object;
+     */
+    public function addPurchasable(PurchasableInterface $purchasable)
+    {
+        if ($purchasable instanceof ProductInterface) {
+            $this->products->add($purchasable);
+        }
+
+        if ($purchasable instanceof VariantInterface) {
+            $this->variants->add($purchasable);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Removes an purchasable from the collection.
+     *
+     * @param PurchasableInterface $purchasable Purchasable to be removed
+     *
+     * @return $this Self object
+     */
+    public function removePurchasable(PurchasableInterface $purchasable)
+    {
+        if ($purchasable instanceof ProductInterface) {
+            $this->products->removeElement($purchasable);
+        }
+
+        if ($purchasable instanceof VariantInterface) {
+            $this->variants->removeElement($purchasable);
+        }
+    }
+
+    /**
+     * Returns purchasable purchasables.
+     *
+     * @param Collection $emptyCollection Empty collection
+     *
+     * @return Collection Purchasables
+     */
+    public function getPurchasables()
+    {
+        return new ArrayCollection(
+            array_merge(
+                $this->products->toArray(),
+                $this->variants->toArray()
+            )
+        );
+    }
+
+    /**
+     * Sets purchasable purchasables.
+     *
+     * @param Collection $purchasables Purchasables
+     *
+     * @return $this Self object
+     */
+    public function setPurchasables(Collection $purchasables)
+    {
+        $this->initializePurchasable();
+
+        foreach ($purchasables as $purchasable) {
+            $this->addPurchasable($purchasable);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get Products.
+     *
+     * @return Collection Products
+     */
+    public function getProducts()
+    {
+        return $this->products;
+    }
+
+    /**
+     * Sets Products.
+     *
+     * @param Collection $products Products
+     *
+     * @return $this Self object
+     */
+    public function setProducts($products)
+    {
+        $this->products = $products;
+
+        return $this;
+    }
+
+    /**
+     * Get Variants.
+     *
+     * @return Collection Variants
+     */
+    public function getVariants()
+    {
+        return $this->variants;
+    }
+
+    /**
+     * Sets Variants.
+     *
+     * @param Collection $variants Variants
+     *
+     * @return $this Self object
+     */
+    public function setVariants($variants)
+    {
+        $this->variants = $variants;
+
+        return $this;
+    }
+
+    /**
+     * Set categories.
+     *
+     * @param Collection $categories Categories
+     *
+     * @return $this Self object
+     */
+    public function setCategories(Collection $categories)
+    {
+        $this->categories = $categories;
+
+        return $this;
+    }
+
+    /**
+     * Get categories.
+     *
+     * @return Collection Categories
+     */
+    public function getCategories()
+    {
+        return $this->categories;
+    }
+
+    /**
+     * Add category.
+     *
+     * @param CategoryInterface $category Category
+     *
+     * @return $this Self object
+     */
+    public function addCategory(CategoryInterface $category)
+    {
+        $this->categories->add($category);
+
+        return $this;
+    }
+
+    /**
+     * Remove category.
+     *
+     * @param CategoryInterface $category Category
+     *
+     * @return $this Self object
+     */
+    public function removeCategory(CategoryInterface $category)
+    {
+        $this->categories->removeElement($category);
+
+        return $this;
+    }
+
+    /**
+     * Set the principalCategory.
+     *
+     * @param CategoryInterface $principalCategory Principal category
+     *
+     * @return $this Self object
+     */
+    public function setPrincipalCategory(CategoryInterface $principalCategory = null)
+    {
+        $this->principalCategory = $principalCategory;
+
+        return $this;
+    }
+
+    /**
+     * Get the principalCategory.
+     *
+     * @return CategoryInterface Principal category
+     */
+    public function getPrincipalCategory()
+    {
+        return $this->principalCategory;
+    }
+
+    /**
+     * Set product manufacturer.
+     *
+     * @param ManufacturerInterface $manufacturer Manufacturer
+     *
+     * @return $this Self object
+     */
+    public function setManufacturer(ManufacturerInterface $manufacturer = null)
+    {
+        $this->manufacturer = $manufacturer;
+
+        return $this;
+    }
+
+    /**
+     * Product manufacturer.
+     *
+     * @return ManufacturerInterface Manufacturer
+     */
+    public function getManufacturer()
+    {
+        return $this->manufacturer;
+    }
+
+    /**
+     * Pack stringified.
+     *
+     * @return string Pack in string mode
+     */
+    public function __toString()
+    {
+        return (string) $this->getName();
+    }
+}

--- a/src/Elcodi/Component/Product/EventListener/ProductCategoryIntegrityEventListener.php
+++ b/src/Elcodi/Component/Product/EventListener/ProductCategoryIntegrityEventListener.php
@@ -38,12 +38,10 @@ class ProductCategoryIntegrityEventListener
     /**
      * Builds a new class.
      *
-     * @param CategoryIntegrityFixer $categoryIntegrityFixer A category
-     *                                                       integrity fixer.
+     * @param CategoryIntegrityFixer $categoryIntegrityFixer Fixer
      */
-    public function __construct(
-        CategoryIntegrityFixer $categoryIntegrityFixer
-    ) {
+    public function __construct(CategoryIntegrityFixer $categoryIntegrityFixer)
+    {
         $this->categoryIntegrityFixer = $categoryIntegrityFixer;
     }
 

--- a/src/Elcodi/Component/Product/Factory/PackFactory.php
+++ b/src/Elcodi/Component/Product/Factory/PackFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Factory;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+use Elcodi\Component\Currency\Factory\Abstracts\AbstractPurchasableFactory;
+use Elcodi\Component\Product\ElcodiProductTypes;
+use Elcodi\Component\Product\Entity\Pack;
+use Elcodi\Component\Product\Entity\Product;
+
+/**
+ * Factory for Pack entities.
+ */
+class PackFactory extends AbstractPurchasableFactory
+{
+    /**
+     * Creates and returns a pristine Product instance.
+     *
+     * Prices are initialized to "zero amount" Money value objects,
+     * using injected CurrencyWrapper default Currency
+     *
+     * @return Product New Product entity
+     */
+    public function create()
+    {
+        $zeroPrice = $this->createZeroAmountMoney();
+
+        /**
+         * @var Pack $product
+         */
+        $classNamespace = $this->getEntityNamespace();
+        $pack = new $classNamespace();
+
+        $pack
+            ->setStock(0)
+            ->setType(ElcodiProductTypes::TYPE_PRODUCT_PHYSICAL)
+            ->setShowInHome(true)
+            ->setPrice($zeroPrice)
+            ->setReducedPrice($zeroPrice)
+            ->initializePurchasable(new ArrayCollection())
+            ->setCategories(new ArrayCollection())
+            ->setImages(new ArrayCollection())
+            ->setWidth(0)
+            ->setHeight(0)
+            ->setDepth(0)
+            ->setWidth(0)
+            ->setWeight(0)
+            ->setImagesSort('')
+            ->setEnabled(true)
+            ->setCreatedAt($this->now());
+
+        return $pack;
+    }
+}

--- a/src/Elcodi/Component/Product/NameResolver/Interfaces/PurchasableNameResolverInterface.php
+++ b/src/Elcodi/Component/Product/NameResolver/Interfaces/PurchasableNameResolverInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\NameResolver\Interfaces;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+
+/**
+ * Interface PurchasableNameResolverInterface.
+ */
+interface PurchasableNameResolverInterface
+{
+    /**
+     * @var string
+     *
+     * Default separator
+     */
+    const DEFAULT_SEPARATOR = ' - ';
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace();
+
+    /**
+     * Given a purchasable, resolve the name.
+     *
+     * @param PurchasableInterface $purchasable Purchasable
+     * @param string               $separator   Separator
+     *
+     * @return false|string Name resolved or false if invalid object
+     */
+    public function resolveName(
+        PurchasableInterface $purchasable,
+        $separator = self::DEFAULT_SEPARATOR
+    );
+}

--- a/src/Elcodi/Component/Product/NameResolver/PackNameResolver.php
+++ b/src/Elcodi/Component/Product/NameResolver/PackNameResolver.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\NameResolver;
+
+use Elcodi\Component\Product\Entity\Interfaces\PackInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\NameResolver\Interfaces\PurchasableNameResolverInterface;
+
+/**
+ * Class PackNameResolver.
+ */
+class PackNameResolver implements PurchasableNameResolverInterface
+{
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\PackInterface';
+    }
+
+    /**
+     * Given a purchasable, resolve the name.
+     *
+     * @param PurchasableInterface $purchasable Purchasable
+     * @param string               $separator   Separator
+     *
+     * @return string Name resolved
+     */
+    public function resolveName(
+        PurchasableInterface $purchasable,
+        $separator = null
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        /**
+         * @var $purchasable PackInterface
+         */
+        return $purchasable->getName();
+    }
+}

--- a/src/Elcodi/Component/Product/NameResolver/ProductNameResolver.php
+++ b/src/Elcodi/Component/Product/NameResolver/ProductNameResolver.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\NameResolver;
+
+use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\NameResolver\Interfaces\PurchasableNameResolverInterface;
+
+/**
+ * Class ProductNameResolver.
+ */
+class ProductNameResolver implements PurchasableNameResolverInterface
+{
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\ProductInterface';
+    }
+
+    /**
+     * Given a purchasable, resolve the name.
+     *
+     * @param PurchasableInterface $purchasable Purchasable
+     * @param string               $separator   Separator
+     *
+     * @return false|string Name resolved or false if invalid object
+     */
+    public function resolveName(
+        PurchasableInterface $purchasable,
+        $separator = null
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        /**
+         * @var $purchasable ProductInterface
+         */
+        return $purchasable->getName();
+    }
+}

--- a/src/Elcodi/Component/Product/NameResolver/PurchasableNameResolver.php
+++ b/src/Elcodi/Component/Product/NameResolver/PurchasableNameResolver.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\NameResolver;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\NameResolver\Interfaces\PurchasableNameResolverInterface;
+
+/**
+ * Class PurchasableNameResolver.
+ */
+class PurchasableNameResolver implements PurchasableNameResolverInterface
+{
+    /**
+     * @var PurchasableNameResolverInterface[]
+     *
+     * Name resolvers
+     */
+    private $nameResolvers = [];
+
+    /**
+     * Add a name resolver.
+     *
+     * @param PurchasableNameResolverInterface $nameResolver Name resolver
+     */
+    public function addPurchasableNameResolver(PurchasableNameResolverInterface $nameResolver)
+    {
+        $this->nameResolvers[] = $nameResolver;
+    }
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface';
+    }
+
+    /**
+     * Given a purchasable, resolve the name.
+     *
+     * @param PurchasableInterface $purchasable Purchasable
+     * @param string               $separator   Separator
+     *
+     * @return false|string Name resolved or false if invalid object
+     */
+    public function resolveName(
+        PurchasableInterface $purchasable,
+        $separator = self::DEFAULT_SEPARATOR
+    ) {
+        foreach ($this->nameResolvers as $nameResolver) {
+            $nameResolverNamespace = $nameResolver->getPurchasableNamespace();
+            if ($purchasable instanceof $nameResolverNamespace) {
+                return $nameResolver->resolveName(
+                    $purchasable,
+                    $separator
+                );
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Elcodi/Component/Product/NameResolver/VariantNameResolver.php
+++ b/src/Elcodi/Component/Product/NameResolver/VariantNameResolver.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\NameResolver;
+
+use Elcodi\Component\Attribute\Entity\Interfaces\ValueInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
+use Elcodi\Component\Product\NameResolver\Interfaces\PurchasableNameResolverInterface;
+
+/**
+ * Class VariantNameResolver.
+ */
+class VariantNameResolver implements PurchasableNameResolverInterface
+{
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\VariantInterface';
+    }
+
+    /**
+     * Given a purchasable, resolve the name.
+     *
+     * @param PurchasableInterface $purchasable Purchasable
+     * @param string               $separator   Separator
+     *
+     * @return string Name resolved
+     */
+    public function resolveName(
+        PurchasableInterface $purchasable,
+        $separator = self::DEFAULT_SEPARATOR
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        /**
+         * @var $purchasable VariantInterface
+         */
+        $variantName = $purchasable->getProduct()->getName();
+
+        foreach ($purchasable->getOptions() as $option) {
+            /**
+             * @var ValueInterface $option
+             */
+            $variantName .= $separator .
+                $option->getAttribute()->getName() .
+                ' ' .
+                $option->getValue();
+        }
+
+        return $variantName;
+    }
+}

--- a/src/Elcodi/Component/Product/Repository/PackRepository.php
+++ b/src/Elcodi/Component/Product/Repository/PackRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Class PackRepository.
+ */
+class PackRepository extends EntityRepository
+{
+}

--- a/src/Elcodi/Component/Product/Services/PurchasableNameResolver.php
+++ b/src/Elcodi/Component/Product/Services/PurchasableNameResolver.php
@@ -18,6 +18,7 @@
 namespace Elcodi\Component\Product\Services;
 
 use Elcodi\Component\Attribute\Entity\Interfaces\ValueInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PackInterface;
 use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
 use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
 use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
@@ -48,25 +49,79 @@ class PurchasableNameResolver
         PurchasableInterface $purchasable,
         $separator = self::DEFAULT_SEPARATOR
     ) {
+        /**
+         * Resolver for product.
+         */
         if ($purchasable instanceof ProductInterface) {
-            return $purchasable->getName();
+            return $this->resolveProductName($purchasable);
         }
 
         /**
-         * @var VariantInterface $purchasable
+         * Resolver for variant.
          */
-        $productName = $purchasable->getProduct()->getName();
+        if ($purchasable instanceof VariantInterface) {
+            return $this->resolveVariantName(
+                $purchasable,
+                $separator
+            );
+        }
 
-        foreach ($purchasable->getOptions() as $option) {
+        /**
+         * Resolver for variant.
+         */
+        if ($purchasable instanceof PackInterface) {
+            return $this->resolvePackName($purchasable);
+        }
+    }
+
+    /**
+     * Resolve name for product.
+     *
+     * @param ProductInterface $product Product
+     *
+     * @return string Resolve product name
+     */
+    private function resolveProductName(ProductInterface $product)
+    {
+        return $product->getName();
+    }
+
+    /**
+     * Resolve name for variant.
+     *
+     * @param VariantInterface $variant   Variant
+     * @param string           $separator Separator string for product variant options
+     *
+     * @return string Resolve product name
+     */
+    private function resolveVariantName(
+        VariantInterface $variant,
+        $separator = self::DEFAULT_SEPARATOR)
+    {
+        $variantName = $variant->getProduct()->getName();
+
+        foreach ($variant->getOptions() as $option) {
             /**
              * @var ValueInterface $option
              */
-            $productName .= $separator .
+            $variantName .= $separator .
                 $option->getAttribute()->getName() .
                 ' ' .
                 $option->getValue();
         }
 
-        return $productName;
+        return $variantName;
+    }
+
+    /**
+     * Resolve name for pack.
+     *
+     * @param PackInterface $pack Pack
+     *
+     * @return string Resolve pack name
+     */
+    private function resolvePackName(PackInterface $pack)
+    {
+        return $pack->getName();
     }
 }

--- a/src/Elcodi/Component/Product/StockUpdater/Interfaces/PurchasableStockUpdaterInterface.php
+++ b/src/Elcodi/Component/Product/StockUpdater/Interfaces/PurchasableStockUpdaterInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockUpdater\Interfaces;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+
+/**
+ * Interface PurchasableStockUpdaterInterface.
+ */
+interface PurchasableStockUpdaterInterface
+{
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace();
+
+    /**
+     * Update stock.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     *
+     * @return false|int Real decreased stock or false if error
+     */
+    public function updateStock(
+        PurchasableInterface $purchasable,
+        $stockToDecrease
+    );
+}

--- a/src/Elcodi/Component/Product/StockUpdater/PackStockUpdater.php
+++ b/src/Elcodi/Component/Product/StockUpdater/PackStockUpdater.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockUpdater;
+
+use Doctrine\Common\Persistence\ObjectManager;
+
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\Entity\Interfaces\PackInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockUpdater\Interfaces\PurchasableStockUpdaterInterface;
+use Elcodi\Component\Product\StockUpdater\Traits\PurchasableStockUpdaterCollectorTrait;
+use Elcodi\Component\Product\StockUpdater\Traits\SimplePurchasableStockUpdaterTrait;
+
+/**
+ * Class PackStockUpdater.
+ */
+class PackStockUpdater implements PurchasableStockUpdaterInterface
+{
+    use PurchasableStockUpdaterCollectorTrait,
+        SimplePurchasableStockUpdaterTrait;
+
+    /**
+     * @var ObjectManager
+     *
+     * ObjectManager for Pack
+     */
+    private $packObjectManager;
+
+    /**
+     * Built method.
+     *
+     * @param ObjectManager $packObjectManager Pack Object Manager
+     */
+    public function __construct(ObjectManager $packObjectManager)
+    {
+        $this->packObjectManager = $packObjectManager;
+    }
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\PackInterface';
+    }
+
+    /**
+     * Update stock.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     *
+     * @return false|int Real decreased stock or false if error
+     */
+    public function updateStock(
+        PurchasableInterface $purchasable,
+        $stockToDecrease
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        /**
+         * @var $purchasable PackInterface
+         */
+        $stockType = $purchasable->getStockType();
+        if ($stockType === ElcodiProductStock::INHERIT_STOCK) {
+            return $this->updateStockOfPurchasablesByLoadedStockUpdaters(
+                $purchasable->getPurchasables(),
+                $stockToDecrease
+            );
+        }
+
+        $decreasedStock = $this->updateSimplePurchasableStock(
+            $purchasable,
+            $stockToDecrease
+        );
+
+        if ($decreasedStock) {
+            $this
+                ->packObjectManager
+                ->flush($purchasable);
+        }
+
+        return $decreasedStock;
+    }
+}

--- a/src/Elcodi/Component/Product/StockUpdater/ProductStockUpdater.php
+++ b/src/Elcodi/Component/Product/StockUpdater/ProductStockUpdater.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockUpdater;
+
+use Doctrine\Common\Persistence\ObjectManager;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockUpdater\Interfaces\PurchasableStockUpdaterInterface;
+use Elcodi\Component\Product\StockUpdater\Traits\SimplePurchasableStockUpdaterTrait;
+
+/**
+ * Class ProductStockUpdater.
+ */
+class ProductStockUpdater implements PurchasableStockUpdaterInterface
+{
+    use SimplePurchasableStockUpdaterTrait;
+
+    /**
+     * @var ObjectManager
+     *
+     * ObjectManager for Product
+     */
+    private $productObjectManager;
+
+    /**
+     * Built method.
+     *
+     * @param ObjectManager $productObjectManager Product Object Manager
+     */
+    public function __construct(ObjectManager $productObjectManager)
+    {
+        $this->productObjectManager = $productObjectManager;
+    }
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\ProductInterface';
+    }
+
+    /**
+     * Update stock.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     *
+     * @return false|int Real decreased stock or false if error
+     */
+    public function updateStock(
+        PurchasableInterface $purchasable,
+        $stockToDecrease
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        $decreasedStock = $this->updateSimplePurchasableStock(
+            $purchasable,
+            $stockToDecrease
+        );
+
+        $this
+            ->productObjectManager
+            ->flush($purchasable);
+
+        return $decreasedStock;
+    }
+}

--- a/src/Elcodi/Component/Product/StockUpdater/PurchasableStockUpdater.php
+++ b/src/Elcodi/Component/Product/StockUpdater/PurchasableStockUpdater.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockUpdater;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockUpdater\Interfaces\PurchasableStockUpdaterInterface;
+use Elcodi\Component\Product\StockUpdater\Traits\PurchasableStockUpdaterCollectorTrait;
+
+/**
+ * Class PurchasableStockUpdater.
+ */
+class PurchasableStockUpdater implements PurchasableStockUpdaterInterface
+{
+    use PurchasableStockUpdaterCollectorTrait;
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface';
+    }
+
+    /**
+     * Update stock.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     *
+     * @return false|int Real decreased stock or false if error
+     */
+    public function updateStock(
+        PurchasableInterface $purchasable,
+        $stockToDecrease
+    ) {
+        return $this->updateStockByLoadedStockUpdaters(
+            $purchasable,
+            $stockToDecrease
+        );
+    }
+}

--- a/src/Elcodi/Component/Product/StockUpdater/Traits/PurchasableStockUpdaterCollectorTrait.php
+++ b/src/Elcodi/Component/Product/StockUpdater/Traits/PurchasableStockUpdaterCollectorTrait.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockUpdater\Traits;
+
+use Traversable;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockUpdater\Interfaces\PurchasableStockUpdaterInterface;
+
+/**
+ * Trait PurchasableStockUpdaterCollectorTrait.
+ */
+trait PurchasableStockUpdaterCollectorTrait
+{
+    /**
+     * @var PurchasableStockUpdaterInterface[]
+     *
+     * Stock update stack
+     */
+    private $stockUpdaters = [];
+
+    /**
+     * Add stock updater.
+     *
+     * @param PurchasableStockUpdaterInterface $stockUpdater Stock updater
+     */
+    public function addPurchasableStockUpdater(PurchasableStockUpdaterInterface $stockUpdater)
+    {
+        $this->stockUpdaters[] = $stockUpdater;
+    }
+
+    /**
+     * Update stock for a set of Purchasable instances given a collection of
+     * stock updaters loaded.
+     *
+     * If all purchasable instances from the collection have been decreased with
+     * same value (initial one), then this method will return this value.
+     * Otherwise, false.
+     *
+     * @param Traversable $purchasables    Purchasable
+     * @param int         $stockToDecrease Stock to decrease
+     *
+     * @return false|int
+     */
+    public function updateStockOfPurchasablesByLoadedStockUpdaters(
+        Traversable $purchasables,
+        $stockToDecrease
+    ) {
+        $valid = true;
+
+        foreach ($purchasables as $purchasable) {
+            $purchasableResult = $this->updateStockByLoadedStockUpdaters(
+                $purchasable,
+                $stockToDecrease
+            );
+
+            $valid &= ($stockToDecrease === $purchasableResult);
+        }
+
+        return $valid
+            ? $stockToDecrease
+            : false;
+    }
+
+    /**
+     * Update stock for a Purchasable instance given a collection of stock
+     * updaters loaded.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     *
+     * @return false|int Real decreased stock or false if error
+     */
+    public function updateStockByLoadedStockUpdaters(
+        PurchasableInterface $purchasable,
+        $stockToDecrease
+    ) {
+        foreach ($this->stockUpdaters as $stockUpdater) {
+            $stockUpdateNamespace = $stockUpdater->getPurchasableNamespace();
+            if ($purchasable instanceof $stockUpdateNamespace) {
+                return $stockUpdater->updateStock(
+                    $purchasable,
+                    $stockToDecrease
+                );
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Elcodi/Component/Product/StockUpdater/Traits/SimplePurchasableStockUpdaterTrait.php
+++ b/src/Elcodi/Component/Product/StockUpdater/Traits/SimplePurchasableStockUpdaterTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockUpdater\Traits;
+
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+
+/**
+ * Trait SimplePurchasableStockUpdaterTrait.
+ */
+trait SimplePurchasableStockUpdaterTrait
+{
+    /**
+     * Update stock.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     *
+     * @return false|int Real decreased stock or false if error
+     */
+    public function updateSimplePurchasableStock(
+        PurchasableInterface $purchasable,
+        $stockToDecrease
+    ) {
+        $stock = $purchasable->getStock();
+        if (
+            $stock === ElcodiProductStock::INFINITE_STOCK ||
+            $stockToDecrease <= 0 ||
+            $stock <= 0
+        ) {
+            return false;
+        }
+
+        $realStockToDecrease = min($stock, $stockToDecrease);
+        $resultingStock = $stock - $realStockToDecrease;
+        $purchasable->setStock($resultingStock);
+
+        return $realStockToDecrease;
+    }
+}

--- a/src/Elcodi/Component/Product/StockUpdater/VariantStockUpdater.php
+++ b/src/Elcodi/Component/Product/StockUpdater/VariantStockUpdater.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockUpdater;
+
+use Doctrine\Common\Persistence\ObjectManager;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockUpdater\Interfaces\PurchasableStockUpdaterInterface;
+use Elcodi\Component\Product\StockUpdater\Traits\SimplePurchasableStockUpdaterTrait;
+
+/**
+ * Class VariantStockUpdater.
+ */
+class VariantStockUpdater implements PurchasableStockUpdaterInterface
+{
+    use SimplePurchasableStockUpdaterTrait;
+
+    /**
+     * @var ObjectManager
+     *
+     * ObjectManager for Variant
+     */
+    private $variantObjectManager;
+
+    /**
+     * Built method.
+     *
+     * @param ObjectManager $variantObjectManager Variant Object Manager
+     */
+    public function __construct(ObjectManager $variantObjectManager)
+    {
+        $this->variantObjectManager = $variantObjectManager;
+    }
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\VariantInterface';
+    }
+
+    /**
+     * Update stock.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     *
+     * @return false|int Real decreased stock or false if error
+     */
+    public function updateStock(
+        PurchasableInterface $purchasable,
+        $stockToDecrease
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        $decreasedStock = $this->updateSimplePurchasableStock(
+            $purchasable,
+            $stockToDecrease
+        );
+
+        $this
+            ->variantObjectManager
+            ->flush($purchasable);
+
+        return $decreasedStock;
+    }
+}

--- a/src/Elcodi/Component/Product/StockValidator/Interfaces/PurchasableStockValidatorInterface.php
+++ b/src/Elcodi/Component/Product/StockValidator/Interfaces/PurchasableStockValidatorInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockValidator\Interfaces;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+
+/**
+ * Interface PurchasableStockValidatorInterface.
+ */
+interface PurchasableStockValidatorInterface
+{
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace();
+
+    /**
+     * Gets purchasable validation.
+     *
+     * @param PurchasableInterface $purchasable   Purchasable
+     * @param int                  $stockRequired Stock required
+     * @param bool                 $useStock      Use stock
+     *
+     * @return bool|int Is valid or the number of elements that can be used
+     */
+    public function isStockAvailable(
+        PurchasableInterface $purchasable,
+        $stockRequired,
+        $useStock
+    );
+}

--- a/src/Elcodi/Component/Product/StockValidator/PackStockValidator.php
+++ b/src/Elcodi/Component/Product/StockValidator/PackStockValidator.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockValidator;
+
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\Entity\Interfaces\PackInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockValidator\Interfaces\PurchasableStockValidatorInterface;
+use Elcodi\Component\Product\StockValidator\Traits\PurchasableStockValidatorCollectorTrait;
+use Elcodi\Component\Product\StockValidator\Traits\SimplePurchasableStockValidatorTrait;
+
+/**
+ * Class PackStockValidator.
+ */
+class PackStockValidator implements PurchasableStockValidatorInterface
+{
+    use PurchasableStockValidatorCollectorTrait,
+        SimplePurchasableStockValidatorTrait;
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\PackInterface';
+    }
+
+    /**
+     * Gets purchasable validation.
+     *
+     * @param PurchasableInterface $purchasable   Purchasable
+     * @param int                  $stockRequired Stock required
+     * @param bool                 $useStock      Use stock
+     *
+     * @return bool|int Is valid or the number of elements that can be used
+     */
+    public function isStockAvailable(
+        PurchasableInterface $purchasable,
+        $stockRequired,
+        $useStock
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        /**
+         * @var PackInterface $purchasable
+         */
+        $isInheritStock = ElcodiProductStock::INHERIT_STOCK === $purchasable->getStockType();
+        $isInheritanceValid = $this->areValidByLoadedValidators(
+            $purchasable->getPurchasables(),
+            $stockRequired,
+            $isInheritStock
+        );
+
+        /**
+         * Happens when their related elements do not allow this pack to be used.
+         */
+        if (false === $isInheritanceValid) {
+            return false;
+        }
+
+        $isPackValid = $this->isValidUsingSimplePurchasableValidation(
+            $purchasable,
+            $stockRequired,
+            !$isInheritStock
+        );
+
+        /**
+         * Happens when the pack itself is not valid.
+         */
+        if (false === $isPackValid) {
+            return false;
+        }
+
+        /**
+         * At this point we need to check both values for determining the result
+         * value of the whole validation. In this case, both results allow the
+         * pack to be used.
+         */
+        if (true === $isInheritanceValid && true === $isPackValid) {
+            return true;
+        }
+
+        /**
+         * Some of them have returned an int value. There is a problem with
+         * stock, so we need to check which one is valid.
+         */
+        return $isInheritStock
+            ? $isInheritanceValid
+            : $isPackValid;
+    }
+}

--- a/src/Elcodi/Component/Product/StockValidator/ProductStockValidator.php
+++ b/src/Elcodi/Component/Product/StockValidator/ProductStockValidator.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockValidator;
+
+use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockValidator\Interfaces\PurchasableStockValidatorInterface;
+use Elcodi\Component\Product\StockValidator\Traits\SimplePurchasableStockValidatorTrait;
+
+/**
+ * Class ProductStockValidator.
+ */
+class ProductStockValidator implements PurchasableStockValidatorInterface
+{
+    use SimplePurchasableStockValidatorTrait;
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\ProductInterface';
+    }
+
+    /**
+     * Gets purchasable validation.
+     *
+     * @param PurchasableInterface $purchasable   Purchasable
+     * @param int                  $stockRequired Stock required
+     * @param bool                 $useStock      Use stock
+     *
+     * @return bool|int Is valid or the number of elements that can be used
+     */
+    public function isStockAvailable(
+        PurchasableInterface $purchasable,
+        $stockRequired,
+        $useStock
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        /**
+         * @var ProductInterface $purchasable
+         */
+        return $this->isValidUsingSimplePurchasableValidation(
+            $purchasable,
+            $stockRequired,
+            $useStock
+        );
+    }
+}

--- a/src/Elcodi/Component/Product/StockValidator/PurchasableStockValidator.php
+++ b/src/Elcodi/Component/Product/StockValidator/PurchasableStockValidator.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockValidator;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockValidator\Interfaces\PurchasableStockValidatorInterface;
+use Elcodi\Component\Product\StockValidator\Traits\PurchasableStockValidatorCollectorTrait;
+
+/**
+ * Class PurchasableValidator.
+ */
+class PurchasableStockValidator implements PurchasableStockValidatorInterface
+{
+    use PurchasableStockValidatorCollectorTrait;
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return null;
+    }
+
+    /**
+     * Update stock.
+     *
+     * @param PurchasableInterface $purchasable     Purchasable
+     * @param int                  $stockToDecrease Stock to decrease
+     * @param bool                 $useStock        Use stock
+     *
+     * @return bool|int Is valid or the number of elements that can be used
+     */
+    public function isStockAvailable(
+        PurchasableInterface $purchasable,
+        $stockToDecrease,
+        $useStock
+    ) {
+        return $this->isValidByLoadedValidators(
+            $purchasable,
+            $stockToDecrease,
+            $useStock
+        );
+    }
+}

--- a/src/Elcodi/Component/Product/StockValidator/Traits/PurchasableStockValidatorCollectorTrait.php
+++ b/src/Elcodi/Component/Product/StockValidator/Traits/PurchasableStockValidatorCollectorTrait.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockValidator\Traits;
+
+use Traversable;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\StockValidator\Interfaces\PurchasableStockValidatorInterface;
+
+/**
+ * Trait PurchasableStockValidatorCollectorTrait.
+ */
+trait PurchasableStockValidatorCollectorTrait
+{
+    /**
+     * @var PurchasableStockValidatorInterface[]
+     *
+     * Stock validator stack
+     */
+    private $validators = [];
+
+    /**
+     * Add stock validator.
+     *
+     * @param PurchasableStockValidatorInterface $validator Stock updater
+     */
+    public function addPurchasableStockValidator(PurchasableStockValidatorInterface $validator)
+    {
+        $this->validators[] = $validator;
+    }
+
+    /**
+     * Update stock for a set of Purchasable instances given a collection of
+     * stock updaters loaded.
+     *
+     * * If all elements are valid, then the whole collection is valid
+     * * If one of them is invalid, then the whole collection is invalid
+     * * Otherwise, will return the minimum of available stocks
+     *
+     * @param Traversable $purchasables    Purchasable
+     * @param int         $stockToDecrease Stock to decrease
+     * @param bool        $useStock        Use stock
+     *
+     * @return bool Are valid
+     */
+    protected function areValidByLoadedValidators(
+        Traversable $purchasables,
+        $stockToDecrease,
+        $useStock
+    ) {
+        $maximumStockAvailable = null;
+
+        foreach ($purchasables as $purchasable) {
+            $purchasableIsValid = $this->isValidByLoadedValidators(
+                $purchasable,
+                $stockToDecrease,
+                $useStock
+            );
+
+            if (false === $purchasableIsValid) {
+                return false;
+            }
+
+            if (is_int($purchasableIsValid)) {
+                $maximumStockAvailable = is_null($maximumStockAvailable)
+                    ? $purchasableIsValid
+                    : min($maximumStockAvailable, $purchasableIsValid);
+            }
+        }
+
+        if (is_null($maximumStockAvailable)) {
+            return true;
+        }
+
+        return $maximumStockAvailable > 0
+            ? $maximumStockAvailable
+            : false;
+    }
+
+    /**
+     * Gets purchasable validation.
+     *
+     * @param PurchasableInterface $purchasable   Purchasable
+     * @param int                  $stockRequired Stock required
+     * @param bool                 $useStock      Use stock
+     *
+     * @return bool Is valid
+     */
+    protected function isValidByLoadedValidators(
+        PurchasableInterface $purchasable,
+        $stockRequired,
+        $useStock
+    ) {
+        foreach ($this->validators as $validator) {
+            $stockUpdateNamespace = $validator->getPurchasableNamespace();
+            if ($purchasable instanceof $stockUpdateNamespace) {
+                return $validator->isStockAvailable(
+                    $purchasable,
+                    $stockRequired,
+                    $useStock
+                );
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Elcodi/Component/Product/StockValidator/Traits/SimplePurchasableStockValidatorTrait.php
+++ b/src/Elcodi/Component/Product/StockValidator/Traits/SimplePurchasableStockValidatorTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockValidator\Traits;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+
+/**
+ * Trait SimplePurchasableStockValidatorTrait.
+ */
+trait SimplePurchasableStockValidatorTrait
+{
+    /**
+     * Make a simple validation of a Purchasable instance.
+     *
+     * @param PurchasableInterface $purchasable   Purchasable
+     * @param int                  $stockRequired Stock required
+     * @param bool                 $useStock      Use stock
+     *
+     * @return bool|int Is valid or the number of elements that can be used
+     */
+    public function isValidUsingSimplePurchasableValidation(
+        PurchasableInterface $purchasable,
+        $stockRequired,
+        $useStock
+    ) {
+        if (
+            !$purchasable->isEnabled() ||
+            $stockRequired <= 0 ||
+            (
+                $useStock &&
+                $purchasable->getStock() <= 0
+            )
+        ) {
+            return false;
+        }
+
+        if ($purchasable->getStock() < $stockRequired) {
+            return $purchasable->getStock();
+        }
+
+        return true;
+    }
+}

--- a/src/Elcodi/Component/Product/StockValidator/VariantStockValidator.php
+++ b/src/Elcodi/Component/Product/StockValidator/VariantStockValidator.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\StockValidator;
+
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
+use Elcodi\Component\Product\StockValidator\Interfaces\PurchasableStockValidatorInterface;
+use Elcodi\Component\Product\StockValidator\Traits\SimplePurchasableStockValidatorTrait;
+
+/**
+ * Class VariantStockValidator.
+ */
+class VariantStockValidator implements PurchasableStockValidatorInterface
+{
+    use SimplePurchasableStockValidatorTrait;
+
+    /**
+     * Get the entity interface.
+     *
+     * @return string Namespace
+     */
+    public function getPurchasableNamespace()
+    {
+        return 'Elcodi\Component\Product\Entity\Interfaces\VariantInterface';
+    }
+
+    /**
+     * Gets purchasable validation.
+     *
+     * @param PurchasableInterface $purchasable   Purchasable
+     * @param int                  $stockRequired Stock required
+     * @param bool                 $useStock      Use stock
+     *
+     * @return bool|int Is valid or the number of elements that can be used
+     */
+    public function isStockAvailable(
+        PurchasableInterface $purchasable,
+        $stockRequired,
+        $useStock
+    ) {
+        $namespace = $this->getPurchasableNamespace();
+        if (!$purchasable instanceof $namespace) {
+            return false;
+        }
+
+        /**
+         * @var VariantInterface $purchasable
+         */
+        return $this->isValidUsingSimplePurchasableValidation(
+            $purchasable,
+            $stockRequired,
+            $useStock
+        );
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/NameResolver/PackNameResolverTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/NameResolver/PackNameResolverTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\NameResolver;
+
+use PHPUnit_Framework_TestCase;
+
+use Elcodi\Component\Product\NameResolver\Interfaces\PurchasableNameResolverInterface;
+use Elcodi\Component\Product\NameResolver\PackNameResolver;
+use Elcodi\Component\Product\NameResolver\PurchasableNameResolver;
+
+/**
+ * Class PackNameResolverTest.
+ */
+class PackNameResolverTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test resolve name.
+     *
+     * @dataProvider dataResolveName
+     */
+    public function testResolveName(PurchasableNameResolverInterface $resolver)
+    {
+        $pack = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\PackInterface');
+        $pack
+            ->getName()
+            ->willReturn('My Pack');
+
+        $this->assertEquals(
+            'My Pack',
+            $resolver->resolveName(
+                $pack->reveal()
+            )
+        );
+    }
+
+    /**
+     * Data for testResolveName.
+     */
+    public function dataResolveName()
+    {
+        $packNameResolver = new PackNameResolver();
+        $purchasableNameResolver = new PurchasableNameResolver();
+        $purchasableNameResolver->addPurchasableNameResolver($packNameResolver);
+
+        return [
+            [$purchasableNameResolver],
+            [$packNameResolver],
+        ];
+    }
+
+    /**
+     * Test resolve name with bad purchasable instance.
+     */
+    public function testResolveNameBadInstance()
+    {
+        $purchasable = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface');
+        $packNameResolver = new PackNameResolver();
+        $this->assertFalse(
+            $packNameResolver->resolveName(
+                $purchasable->reveal()
+            )
+        );
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/NameResolver/ProductNameResolverTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/NameResolver/ProductNameResolverTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\NameResolver;
+
+use PHPUnit_Framework_TestCase;
+
+use Elcodi\Component\Product\NameResolver\Interfaces\PurchasableNameResolverInterface;
+use Elcodi\Component\Product\NameResolver\ProductNameResolver;
+use Elcodi\Component\Product\NameResolver\PurchasableNameResolver;
+
+/**
+ * Class ProductNameResolverTest.
+ */
+class ProductNameResolverTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test resolve name.
+     *
+     * @dataProvider dataResolveName
+     */
+    public function testResolveName(PurchasableNameResolverInterface $resolver)
+    {
+        $product = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\ProductInterface');
+        $product
+            ->getName()
+            ->willReturn('My Product');
+
+        $this->assertEquals(
+            'My Product',
+            $resolver->resolveName(
+                $product->reveal()
+            )
+        );
+    }
+
+    /**
+     * Data for testResolveName.
+     */
+    public function dataResolveName()
+    {
+        $productNameResolver = new ProductNameResolver();
+        $purchasableNameResolver = new PurchasableNameResolver();
+        $purchasableNameResolver->addPurchasableNameResolver($productNameResolver);
+
+        return [
+            [$purchasableNameResolver],
+            [$productNameResolver],
+        ];
+    }
+
+    /**
+     * Test resolve name with bad purchasable instance.
+     */
+    public function testResolveNameBadInstance()
+    {
+        $purchasable = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface');
+        $productNameResolver = new ProductNameResolver();
+        $this->assertFalse(
+            $productNameResolver->resolveName(
+                $purchasable->reveal()
+            )
+        );
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/NameResolver/VariantNameResolverTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/NameResolver/VariantNameResolverTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\NameResolver;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit_Framework_TestCase;
+
+use Elcodi\Component\Product\NameResolver\Interfaces\PurchasableNameResolverInterface;
+use Elcodi\Component\Product\NameResolver\ProductNameResolver;
+use Elcodi\Component\Product\NameResolver\PurchasableNameResolver;
+use Elcodi\Component\Product\NameResolver\VariantNameResolver;
+
+/**
+ * Class VariantNameResolverTest.
+ */
+class VariantNameResolverTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test resolve name.
+     *
+     * @dataProvider dataResolveName
+     */
+    public function testResolveName(PurchasableNameResolverInterface $resolver)
+    {
+        $product = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\ProductInterface');
+        $variant = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface');
+        $product
+            ->getName()
+            ->willReturn('Product Name');
+
+        $variant
+            ->getProduct()
+            ->willReturn($product->reveal());
+
+        $attribute1 = $this->prophesize('Elcodi\Component\Attribute\Entity\Interfaces\AttributeInterface');
+        $attribute1->getName()->willReturn('attribute1');
+        $value1 = $this->prophesize('Elcodi\Component\Attribute\Entity\Interfaces\ValueInterface');
+        $value1->getAttribute()->willReturn($attribute1->reveal());
+        $value1->getValue()->willReturn('value1');
+
+        $attribute2 = $this->prophesize('Elcodi\Component\Attribute\Entity\Interfaces\AttributeInterface');
+        $attribute2->getName()->willReturn('attribute2');
+        $value2 = $this->prophesize('Elcodi\Component\Attribute\Entity\Interfaces\ValueInterface');
+        $value2->getAttribute()->willReturn($attribute2->reveal());
+        $value2->getValue()->willReturn('value2');
+
+        $variant
+            ->getOptions()
+            ->willReturn(new ArrayCollection([
+                $value1->reveal(),
+                $value2->reveal(),
+            ]));
+        $variant = $variant->reveal();
+
+        $this->assertEquals(
+            'Product Name - attribute1 value1 - attribute2 value2',
+            $resolver->resolveName(
+                $variant
+            )
+        );
+
+        $this->assertEquals(
+            'Product Name # attribute1 value1 # attribute2 value2',
+            $resolver->resolveName(
+                $variant,
+                ' # '
+            )
+        );
+    }
+
+    /**
+     * Data for testResolveName.
+     */
+    public function dataResolveName()
+    {
+        $variantNameResolver = new VariantNameResolver();
+        $purchasableNameResolver = new PurchasableNameResolver();
+        $purchasableNameResolver->addPurchasableNameResolver($variantNameResolver);
+
+        return [
+            [$purchasableNameResolver],
+            [$variantNameResolver],
+        ];
+    }
+
+    /**
+     * Test resolve name with bad purchasable instance.
+     */
+    public function testResolveNameBadInstance()
+    {
+        $purchasable = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface');
+        $productNameResolver = new ProductNameResolver();
+        $this->assertFalse(
+            $productNameResolver->resolveName(
+                $purchasable->reveal()
+            )
+        );
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/StockUpdater/PackStockUpdaterTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/StockUpdater/PackStockUpdaterTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\StockUpdater;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit_Framework_TestCase;
+use Prophecy\Argument;
+
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\StockUpdater\PackStockUpdater;
+use Elcodi\Component\Product\StockUpdater\ProductStockUpdater;
+use Elcodi\Component\Product\StockUpdater\VariantStockUpdater;
+
+/**
+ * Class PackStockUpdaterTest.
+ */
+class PackStockUpdaterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test update stock with a no product.
+     */
+    public function testUpdateStockNoProduct()
+    {
+        $objectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        $productStockUpdater = new ProductStockUpdater($objectManager->reveal());
+        $this->assertFalse(
+            $productStockUpdater->updateStock(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+
+        $this->assertFalse(
+            $productStockUpdater->updateStock(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+    }
+
+    /**
+     * Test update stock.
+     *
+     * @dataProvider dataUpdateStock
+     */
+    public function testUpdateStock(
+        $stockToDecrease,
+        $packStockType,
+        $packStock,
+        $packNewStock,
+        $packFlush,
+        $productStock,
+        $productNewStock,
+        $productFlush,
+        $variantStock,
+        $variantNewStock,
+        $variantFlush,
+        $result
+    ) {
+        $product = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\ProductInterface');
+        $product
+            ->getStock()
+            ->willReturn($productStock);
+        if (!is_null($productNewStock)) {
+            $product->setStock($productNewStock)->shouldBeCalled();
+        }
+        $product = $product->reveal();
+        $productObjectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        if ($productFlush) {
+            $productObjectManager
+                ->flush(Argument::any())
+                ->shouldBeCalled();
+        }
+
+        $variant = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface');
+        $variant
+            ->getStock()
+            ->willReturn($variantStock);
+        if (!is_null($variantNewStock)) {
+            $variant->setStock($variantNewStock)->shouldBeCalled();
+        }
+        $variant = $variant->reveal();
+        $variantObjectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        if ($variantFlush) {
+            $variantObjectManager
+                ->flush(Argument::any())
+                ->shouldBeCalled();
+        }
+
+        $pack = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\PackInterface');
+        $pack
+            ->getStockType()
+            ->willReturn($packStockType);
+        $pack
+            ->getStock()
+            ->willReturn($packStock);
+        $pack
+            ->getPurchasables()
+            ->willReturn(new ArrayCollection([
+                $product,
+                $variant,
+            ]));
+        if (!is_null($packNewStock)) {
+            $pack->setStock($packNewStock)->shouldBeCalled();
+        }
+        $pack = $pack->reveal();
+        $packObjectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        if ($packFlush) {
+            $packObjectManager
+                ->flush(Argument::any())
+                ->shouldBeCalled();
+        }
+
+        $productStockUpdater = new ProductStockUpdater($productObjectManager->reveal());
+        $variantStockUpdater = new VariantStockUpdater($variantObjectManager->reveal());
+        $packStockUpdater = new PackStockUpdater($packObjectManager->reveal());
+        $packStockUpdater->addPurchasableStockUpdater($productStockUpdater);
+        $packStockUpdater->addPurchasableStockUpdater($variantStockUpdater);
+        $this->assertEquals(
+            $result,
+            $packStockUpdater->updateStock(
+                $pack,
+                $stockToDecrease
+            )
+        );
+    }
+
+    /**
+     * Data for testUpdateStock.
+     */
+    public function dataUpdateStock()
+    {
+        $infStock = ElcodiProductStock::INFINITE_STOCK;
+        $inhStock = ElcodiProductStock::INHERIT_STOCK;
+        $spcStock = ElcodiProductStock::SPECIFIC_STOCK;
+
+        return [
+            // Without inheritance stock
+            'Without inh: All ok' => [1, $spcStock, 2, 1, true, null, null, false, null, null, false, 1],
+            'Without inh: We decrease more than existing elements' => [2, $spcStock, 1, 0, true, null, null, false, null, null, false, 1],
+            'Without inh: We decrease 0' => [0, $spcStock, 2, null, false, null, null, false, null, null, false, false],
+            'Without inh: Negative stock' => [2, $spcStock, -2, null, false, null, null, false, null, null, false, false],
+            'Without inh: 0 stock' => [2, $spcStock, 0, null, false, null, null, false, null, null, false, false],
+
+            // With inheritance stock
+            'Inh: All ok' => [1, $inhStock, null, null, false, 2, 1, true, 3, 2, true, 1],
+            'Inh: One with less stock than needed' => [2, $inhStock, null, null, false, 1, 0, true, 3, 1, true, false],
+            'Inh: One with infinite stock' => [2, $inhStock, null, null, false, $infStock, null, true, 3, 1, true, false],
+            'Inh: One with 0 stock' => [2, $inhStock, null, null, false, 0, null, true, 3, 1, true, false],
+            'Inh: One with negative stock' => [2, $inhStock, null, null, false, -2, null, true, 3, 1, true, false],
+        ];
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/StockUpdater/ProductStockUpdaterTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/StockUpdater/ProductStockUpdaterTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\StockUpdater;
+
+use PHPUnit_Framework_TestCase;
+use Prophecy\Argument;
+
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\StockUpdater\ProductStockUpdater;
+use Elcodi\Component\Product\StockUpdater\PurchasableStockUpdater;
+
+/**
+ * Class ProductStockUpdaterTest.
+ */
+class ProductStockUpdaterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test update stock with a no product.
+     */
+    public function testUpdateStockNoProduct()
+    {
+        $objectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        $productStockUpdater = new ProductStockUpdater($objectManager->reveal());
+        $this->assertFalse(
+            $productStockUpdater->updateStock(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+
+        $this->assertFalse(
+            $productStockUpdater->updateStock(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+    }
+
+    /**
+     * Test update stock.
+     *
+     * @dataProvider dataUpdateStock
+     */
+    public function testUpdateStock(
+        $actualStock,
+        $stockToDecrease,
+        $newStock,
+        $flush,
+        $result
+    ) {
+        $product = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\ProductInterface');
+        $product
+            ->getStock()
+            ->willReturn($actualStock);
+        if (!is_null($newStock)) {
+            $product->setStock($newStock)->shouldBeCalled();
+        }
+        $product = $product->reveal();
+
+        $objectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        if ($flush) {
+            $objectManager->flush(Argument::any());
+        }
+
+        $productStockUpdater = new ProductStockUpdater($objectManager->reveal());
+        $this->assertEquals(
+            $result,
+            $productStockUpdater->updateStock(
+                $product,
+                $stockToDecrease
+            )
+        );
+
+        $purchasableStockUpdater = new PurchasableStockUpdater();
+        $purchasableStockUpdater->addPurchasableStockUpdater($productStockUpdater);
+        $this->assertEquals(
+            $result,
+            $purchasableStockUpdater->updateStock(
+                $product,
+                $stockToDecrease
+            )
+        );
+    }
+
+    /**
+     * Data for testUpdateStock.
+     */
+    public function dataUpdateStock()
+    {
+        $infStock = ElcodiProductStock::INFINITE_STOCK;
+
+        return [
+            'All ok' => [3, 1, 2, true, 1],
+            'infinite stock' => [$infStock, 1, null, false, false],
+            'We decrease more than existing elements' => [2, 3, 0, true, 2],
+        ];
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/StockUpdater/VariantStockUpdaterTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/StockUpdater/VariantStockUpdaterTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\StockUpdater;
+
+use PHPUnit_Framework_TestCase;
+use Prophecy\Argument;
+
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\StockUpdater\PurchasableStockUpdater;
+use Elcodi\Component\Product\StockUpdater\VariantStockUpdater;
+
+/**
+ * Class VariantStockUpdaterTest.
+ */
+class VariantStockUpdaterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test update stock with a no variant.
+     */
+    public function testUpdateStockNoProduct()
+    {
+        $objectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        $variantStockUpdater = new VariantStockUpdater($objectManager->reveal());
+        $this->assertFalse(
+            $variantStockUpdater->updateStock(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+
+        $this->assertFalse(
+            $variantStockUpdater->updateStock(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+    }
+
+    /**
+     * Test update stock.
+     *
+     * @dataProvider dataUpdateStock
+     */
+    public function testUpdateStock(
+        $actualStock,
+        $stockToDecrease,
+        $newStock,
+        $flush,
+        $result
+    ) {
+        $variant = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface');
+        $variant
+            ->getStock()
+            ->willReturn($actualStock);
+        if (!is_null($newStock)) {
+            $variant->setStock($newStock)->shouldBeCalled();
+        }
+        $variant = $variant->reveal();
+
+        $objectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        if ($flush) {
+            $objectManager->flush(Argument::any());
+        }
+
+        $variantStockUpdater = new VariantStockUpdater($objectManager->reveal());
+        $this->assertEquals(
+            $result,
+            $variantStockUpdater->updateStock(
+                $variant,
+                $stockToDecrease
+            )
+        );
+
+        $purchasableStockUpdater = new PurchasableStockUpdater();
+        $purchasableStockUpdater->addPurchasableStockUpdater($variantStockUpdater);
+        $this->assertEquals(
+            $result,
+            $purchasableStockUpdater->updateStock(
+                $variant,
+                $stockToDecrease
+            )
+        );
+    }
+
+    /**
+     * Data for testUpdateStock.
+     */
+    public function dataUpdateStock()
+    {
+        $infStock = ElcodiProductStock::INFINITE_STOCK;
+
+        return [
+            'All ok' => [3, 1, 2, true, 1],
+            'infinite stock' => [$infStock, 1, null, false, false],
+            'We decrease more than existing elements' => [2, 3, 0, true, 2],
+        ];
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/StockValidator/PackStockValidatorTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/StockValidator/PackStockValidatorTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\StockValidator;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit_Framework_TestCase;
+
+use Elcodi\Component\Product\ElcodiProductStock;
+use Elcodi\Component\Product\StockValidator\PackStockValidator;
+use Elcodi\Component\Product\StockValidator\ProductStockValidator;
+use Elcodi\Component\Product\StockValidator\PurchasableStockValidator;
+use Elcodi\Component\Product\StockValidator\VariantStockValidator;
+
+/**
+ * Class PackStockValidatorTest.
+ */
+class PackStockValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test isStockAvailable() with a purchasable non pack.
+     */
+    public function testIsValidNonPack()
+    {
+        $packValidator = new PackStockValidator();
+        $this->assertFalse(
+            $packValidator->isStockAvailable(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+
+        $this->assertFalse(
+            $packValidator->isStockAvailable(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+    }
+
+    /**
+     * Test isStockAvailable() with a purchasable non pack.
+     *
+     * @dataProvider dataIsValidPack
+     */
+    public function testIsValidPack(
+        $packIsEnabled,
+        $packType,
+        $packStock,
+        $productIsEnabled,
+        $productStock,
+        $variantIsEnabled,
+        $variantStock,
+        $stockRequired,
+        $useStock,
+        $isValid
+    ) {
+        $product = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\ProductInterface');
+        $product
+            ->isEnabled()
+            ->willReturn($productIsEnabled);
+        $product
+            ->getStock()
+            ->willReturn($productStock);
+
+        $variant = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface');
+        $variant
+            ->isEnabled()
+            ->willReturn($variantIsEnabled);
+        $variant
+            ->getStock()
+            ->willReturn($variantStock);
+
+        $pack = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\PackInterface');
+        $pack
+            ->isEnabled()
+            ->willReturn($packIsEnabled);
+
+        $pack
+            ->getStockType()
+            ->willReturn($packType);
+        $pack
+            ->getStock()
+            ->willReturn($packStock);
+        $pack
+            ->getPurchasables()
+            ->willReturn(new ArrayCollection([
+                $product->reveal(),
+                $variant->reveal(),
+            ]));
+
+        $pack = $pack->reveal();
+        $packValidator = new PackStockValidator();
+        $packValidator->addPurchasableStockValidator(new ProductStockValidator());
+        $packValidator->addPurchasableStockValidator(new VariantStockValidator());
+
+        $this->assertEquals(
+            $isValid,
+            $packValidator->isStockAvailable(
+                $pack,
+                $stockRequired,
+                $useStock
+            )
+        );
+
+        $purchasableValidator = new PurchasableStockValidator();
+        $purchasableValidator->addPurchasableStockValidator(new ProductStockValidator());
+        $purchasableValidator->addPurchasableStockValidator(new VariantStockValidator());
+        $purchasableValidator->addPurchasableStockValidator($packValidator);
+        $this->assertEquals(
+            $isValid,
+            $purchasableValidator->isStockAvailable(
+                $pack,
+                $stockRequired,
+                $useStock
+            )
+        );
+    }
+
+    /**
+     * data for testIsValidPack.
+     */
+    public function dataIsValidPack()
+    {
+        $inhStock = ElcodiProductStock::INHERIT_STOCK;
+        $spcStock = ElcodiProductStock::SPECIFIC_STOCK;
+
+        return [
+            'Pack disabled' => [false, $spcStock, 3, true, 3, true, 3, 2, false, false],
+
+            // Without inheritance stock
+            'Non inh: one of them disabled' => [true, $spcStock, 3, false, 3, true, 3, 2, true, false],
+            'Non inh: both of them disabled' => [true, $spcStock, 3, false, 3, false, 3, 2, true, false],
+            'Non inh: Available stock with stock usage' => [true, $spcStock, 3, true, 3, true, 3, 2, true, true],
+            'Non inh: Same stock elements than required' => [true, $spcStock, 3, true, 3, true, 3, 3, true, true],
+            'Non inh: Required more elements than stock' => [true, $spcStock, 2, true, 3, true, 3, 3, true, 2],
+            'Non inh: Pack without stock' => [true, $spcStock, 0, true, 3, true, 3, 3, true, false],
+            'Non inh: Required 0 elements' => [true, $spcStock, 3, true, 3, true, 3, 0, true, false],
+            'Non inh: Required more elements that existent with no stock usage' => [true, $spcStock, 2, true, 3, true, 3, 3, false, true],
+            'Non inh: Required 0 elements with no stock usage' => [true, $spcStock, 2, true, 3, true, 3, 0, false, false],
+
+            // With inheritance stock + Variant enabled and stock 3
+            // Changes only product
+            'Prod: Product disabled' => [true, $inhStock, null, false, 3, true, 3, 2, true, false],
+            'Prod: Available stock with stock usage' => [true, $inhStock, null, true, 3, true, 3, 2, true, true],
+            'Prod: Same stock elements than required' => [true, $inhStock, null, true, 3, true, 3, 3, true, true],
+            'Prod: Required more elements than stock' => [true, $inhStock, null, true, 2, true, 3, 3, true, 2],
+            'Prod: Required much more elements than stock' => [true, $inhStock, null, true, 2, true, 4, 3, true, 2],
+            'Prod: Product without stock' => [true, $inhStock, null, true, 0, true, 3, 3, true, false],
+            'Prod: Required 0 elements' => [true, $inhStock, null, true, 0, true, 3, 0, true, false],
+            'Prod: Required more elements that existent with no stock usage' => [true, $inhStock, null, true, 2, true, 3, 3, false, true],
+            'Prod: Required 0 elements with no stock usage' => [true, $inhStock, null, true, 0, true, 3, 0, false, false],
+
+            // With inheritance stock + Product enabled and stock 3
+            // Changes only variant
+            'Var: Variant disabled' => [true, $inhStock, null, true, 3, false, 3, 2, true, false],
+            'Var: Available stock with stock usage' => [true, $inhStock, null, true, 3, true, 3, 2, true, true],
+            'Var: Same stock elements than required' => [true, $inhStock, null, true, 3, true, 3, 3, true, true],
+            'Var: Required more elements than stock' => [true, $inhStock, null, true, 3, true, 2, 3, true, 2],
+            'Var: Variant without stock' => [true, $inhStock, null, true, 3, true, 0, 3, true, false],
+            'Var: Required 0 elements' => [true, $inhStock, null, true, 3, true, 0, 0, true, false],
+            'Var: Required more elements that existent with no stock usage' => [true, $inhStock, null, true, 3, true, 2, 3, false, true],
+            'Var: Required 0 elements with no stock usage' => [true, $inhStock, null, true, 3, true, 0, 0, false, false],
+        ];
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/StockValidator/ProductStockValidatorTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/StockValidator/ProductStockValidatorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\Validator;
+
+use PHPUnit_Framework_TestCase;
+
+use Elcodi\Component\Product\StockValidator\ProductStockValidator;
+use Elcodi\Component\Product\StockValidator\PurchasableStockValidator;
+
+/**
+ * Class ProductStockValidatorTest.
+ */
+class ProductStockValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test isStockAvailable() with a purchasable non product.
+     */
+    public function testIsValidNonProduct()
+    {
+        $productValidator = new ProductStockValidator();
+        $this->assertFalse(
+            $productValidator->isStockAvailable(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+
+        $this->assertFalse(
+            $productValidator->isStockAvailable(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+    }
+
+    /**
+     * Test isStockAvailable() with a purchasable non product.
+     *
+     * @dataProvider dataIsValidProduct
+     */
+    public function testIsValidProduct(
+        $productIsEnabled,
+        $productStock,
+        $stockRequired,
+        $useStock,
+        $isValid
+    ) {
+        $product = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\ProductInterface');
+        $product
+            ->isEnabled()
+            ->willReturn($productIsEnabled);
+        $product
+            ->getStock()
+            ->willReturn($productStock);
+        $product = $product->reveal();
+
+        $productValidator = new ProductStockValidator();
+        $this->assertEquals(
+            $isValid,
+            $productValidator->isStockAvailable(
+                $product,
+                $stockRequired,
+                $useStock
+            )
+        );
+
+        $purchasableValidator = new PurchasableStockValidator();
+        $purchasableValidator->addPurchasableStockValidator($productValidator);
+        $this->assertEquals(
+            $isValid,
+            $purchasableValidator->isStockAvailable(
+                $product,
+                $stockRequired,
+                $useStock
+            )
+        );
+    }
+
+    /**
+     * data for testIsValidProduct.
+     */
+    public function dataIsValidProduct()
+    {
+        return [
+            'Product disabled' => [false, 3, 2, true, false],
+            'Available stock with stock usage' => [true, 3, 2, true, true],
+            'Same stock elements than required' => [true, 3, 3, true, true],
+            'Required more elements than stock' => [true, 2, 3, true, 2],
+            'Product without stock' => [true, 0, 3, true, false],
+            'Required 0 elements' => [true, 0, 0, true, false],
+            'Required more elements that existent with no stock usage' => [true, 2, 3, false, true],
+            'Required 0 elements with no stock usage' => [true, 0, 0, false, false],
+        ];
+    }
+}

--- a/src/Elcodi/Component/Product/Tests/UnitTest/StockValidator/VariantStockValidatorTest.php
+++ b/src/Elcodi/Component/Product/Tests/UnitTest/StockValidator/VariantStockValidatorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Product\Tests\UnitTest\Validator;
+
+use PHPUnit_Framework_TestCase;
+
+use Elcodi\Component\Product\StockValidator\PurchasableStockValidator;
+use Elcodi\Component\Product\StockValidator\VariantStockValidator;
+
+/**
+ * Class VariantStockValidatorTest.
+ */
+class VariantStockValidatorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test isStockAvailable() with a purchasable non variant.
+     */
+    public function testIsValidNonVariant()
+    {
+        $variantValidator = new VariantStockValidator();
+        $this->assertFalse(
+            $variantValidator->isStockAvailable(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+
+        $this->assertFalse(
+            $variantValidator->isStockAvailable(
+                $this
+                    ->prophesize('Elcodi\Component\Product\Entity\Interfaces\ProductInterface')
+                    ->reveal(),
+                0,
+                false
+            )
+        );
+    }
+
+    /**
+     * Test isStockAvailable() with a purchasable non variant.
+     *
+     * @dataProvider dataIsValidVariant
+     */
+    public function testIsValidVariant(
+        $variantIsEnabled,
+        $variantStock,
+        $stockRequired,
+        $useStock,
+        $isValid
+    ) {
+        $variant = $this->prophesize('Elcodi\Component\Product\Entity\Interfaces\VariantInterface');
+        $variant
+            ->isEnabled()
+            ->willReturn($variantIsEnabled);
+        $variant
+            ->getStock()
+            ->willReturn($variantStock);
+        $variant = $variant->reveal();
+
+        $variantValidator = new VariantStockValidator();
+        $this->assertEquals(
+            $isValid,
+            $variantValidator->isStockAvailable(
+                $variant,
+                $stockRequired,
+                $useStock
+            )
+        );
+
+        $purchasableValidator = new PurchasableStockValidator();
+        $purchasableValidator->addPurchasableStockValidator($variantValidator);
+        $this->assertEquals(
+            $isValid,
+            $purchasableValidator->isStockAvailable(
+                $variant,
+                $stockRequired,
+                $useStock
+            )
+        );
+    }
+
+    /**
+     * data for testIsValidVariant.
+     */
+    public function dataIsValidVariant()
+    {
+        return [
+            'Variant disabled' => [false, 3, 2, true, false],
+            'Available stock with stock usage' => [true, 3, 2, true, true],
+            'Same stock elements than required' => [true, 3, 3, true, true],
+            'Required more elements than stock' => [true, 2, 3, true, 2],
+            'Variant without stock' => [true, 0, 3, true, false],
+            'Required 0 elements' => [true, 0, 0, true, false],
+            'Required more elements that existent with no stock usage' => [true, 2, 3, false, true],
+            'Required 0 elements with no stock usage' => [true, 0, 0, false, false],
+        ];
+    }
+}


### PR DESCRIPTION
* This PR adds the Product Pack entity
    * Entity + Interface + ORM Mapping Information
    * Associated basic services (Factory, Repository, ObjectManager, Director)

* This PR has led to refactor part of the code, introducing a small BC Break (explained here)
    * Some cart services were managing the stock processes for Purchasable entries
    * Because PackInterface is as well a PurchasableInterface, adding new logic meant to change
      as well these Cart services. Bad idea
    * Some services have been created in Product, designed to solve these problems
        - Purchasable name resolvers
        - Stock validation
        - Stock update
    * Using tags, we can split to different services (implementing interfaces) all PurchasableInterface
      implementations, collecting them all in a main service for each purpose.
    * We have changed the construction for 2 services, but I really think we should now bring construct
      method BC (composition over inheritance)

* These features have been developed using a strict TDD philosophy (first tests, then implementation)