### PR TITLE
CI scripts improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,33 +4,28 @@ sudo: false
 
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
-    - /tmp/Elcodi/
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
-  - 7.0
-
-env:
-  global:
-    - secure: b4fh7VMvVktVPsMY9Z8/YOHXWoSGrl/caETmnYsuF3dTV3eOLIQxtP9eW58JBpH14CBLxzbs8D7l2bcvHShsU946Pgxn58xAWO4QLSiZtEJGOB/bVu2s7V/ckEmzbCc83TRiDb4EBaMWLoFWRQn87m00zky4URtDjMGjGgdAfOA=
+matrix:
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: hhvm
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 before_install:
-  - 'if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TRAVIS_PHP_VERSION != "7.0" ]]; then phpenv config-rm xdebug.ini; fi;'
   - composer self-update
   - composer config preferred-install source
   - 'if [[ -n "$GH_TOKEN" ]]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;'
   - 'if [[ -n "$GH_TOKEN" ]]; then composer config preferred-install dist; fi;'
 
-install:
-  - composer install --no-interaction --no-progress
+install: composer install --no-interaction --no-progress
 
-script:
-  - vendor/bin/phpunit
+script: vendor/bin/phpunit -v
 
 after_success:
   - 'if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $TRAVIS_PHP_VERSION == "5.6" ]]; then sh generate-api.sh; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,12 @@ env:
 before_install:
   - 'if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TRAVIS_PHP_VERSION != "7.0" ]]; then phpenv config-rm xdebug.ini; fi;'
   - composer self-update
+  - composer config preferred-install source
   - 'if [[ -n "$GH_TOKEN" ]]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;'
+  - 'if [[ -n "$GH_TOKEN" ]]; then composer config preferred-install dist; fi;'
 
 install:
-  - composer install --prefer-dist --no-interaction --no-progress
+  - composer install --no-interaction --no-progress
 
 script:
   - vendor/bin/phpunit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,4 @@
 build: false
-platform: x86
-clone_folder: c:\projects\elcodi
-
-matrix:
-  fast_finish: true
 
 cache:
   - '%LOCALAPPDATA%\Composer\files'
@@ -25,13 +20,14 @@ install:
   - echo extension=php_gd2.dll >> php.ini
   - echo extension=php_fileinfo.dll >> php.ini
   - echo extension=php_pdo_sqlite.dll >> php.ini
+
+before_test:
   - cd %APPVEYOR_BUILD_FOLDER%
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar config preferred-install source
-  - IF %GH_TOKEN% php composer.phar config github-oauth.github.com %GH_TOKEN%
-  - IF %GH_TOKEN% php composer.phar config preferred-install dist
+  - IF DEFINED %GH_TOKEN% php composer.phar config github-oauth.github.com %GH_TOKEN%
+  - IF DEFINED %GH_TOKEN% php composer.phar config preferred-install dist
   - php composer.phar install --no-interaction --no-progress
 
 test_script:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - vendor\bin\phpunit.bat --verbose
+  - vendor\bin\phpunit.bat -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,10 @@ install:
   - echo extension=php_pdo_sqlite.dll >> php.ini
   - cd %APPVEYOR_BUILD_FOLDER%
   - php -r "readfile('http://getcomposer.org/installer');" | php
-  - php composer.phar install --prefer-dist --no-interaction --no-progress
+  - php composer.phar config preferred-install source
+  - IF %GH_TOKEN% php composer.phar config github-oauth.github.com %GH_TOKEN%
+  - IF %GH_TOKEN% php composer.phar config preferred-install dist
+  - php composer.phar install --no-interaction --no-progress
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%


### PR DESCRIPTION
* a switch for the `preferred-install` option based on the `GH_TOKEN` env variable
* removed vendor and /tmp/Elcodi directories from travis cache (the first to avoid invalidating the cache because of Packagist metadata and the second to prevent old stored data)
* added nightly to the testing matrix (under the `allowed_failures` section)
* removed appveyor settings: clone_folder, platform and matrix because don't improve anything