### PR TITLE
Avoid saving translation if form is invalid

### DIFF
--- a/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
+++ b/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
@@ -199,8 +199,12 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
      */
     public function postSubmit(FormEvent $event)
     {
-        $entity = $event->getData();
         $form = $event->getForm();
+        if (!$form->isValid()) {
+            return;
+        }
+
+        $entity = $event->getData();
         $formHash = $this->getFormHash($form);
         $entityConfiguration = $this->getTranslatableEntityConfiguration($entity);
 


### PR DESCRIPTION
When invalid data is entered in a form with `EntityTranslatorFormEventListener`, translations should not be saved. But they are.
This can lead to Doctrine exceptions about the entity being not saved (id is `null`) or other types of unexpected behaviour.