### PR TITLE
Coupons Query Language (CQL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
       env: $SYMFONY_VERSION="^3.0.0"
   allow_failures:
     - php: nightly
-    - env: $SYMFONY_VERSION="^3.0.0"
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "mmoreram/symfony-bundle-dependencies": "^1.1.1",
 
         "sebastian/money": "^1.5",
-        "knplabs/knp-gaufrette-bundle": "^0.1.7",
+        "knplabs/knp-gaufrette-bundle": "^0.3.0",
         "predis/predis": "^1.0.1",
         "ircmaxell/password-compat": "^1.0",
         "guzzlehttp/guzzle": "^5.2",

--- a/src/Elcodi/Bundle/CartCouponBundle/CompilerPass/CartCouponApplicatorCompilerPass.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/CompilerPass/CartCouponApplicatorCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CartCouponBundle\CompilerPass;
+
+use Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts\AbstractTagCompilerPass;
+
+/**
+ * Class CartCouponApplicatorCompilerPass.
+ */
+class CartCouponApplicatorCompilerPass extends AbstractTagCompilerPass
+{
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    public function getCollectorServiceName()
+    {
+        return 'elcodi.cart_coupon_applicator_collector';
+    }
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    public function getCollectorMethodName()
+    {
+        return 'addCartCouponApplicator';
+    }
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    public function getTagName()
+    {
+        return 'elcodi.cart_coupon_applicator';
+    }
+}

--- a/src/Elcodi/Bundle/CartCouponBundle/CompilerPass/CartCouponApplicatorFunctionCompilerPass.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/CompilerPass/CartCouponApplicatorFunctionCompilerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CartCouponBundle\CompilerPass;
+
+use Elcodi\Bundle\CoreBundle\CompilerPass\Abstracts\AbstractTagCompilerPass;
+
+/**
+ * Class CartCouponApplicatorFunctionCompilerPass.
+ */
+class CartCouponApplicatorFunctionCompilerPass extends AbstractTagCompilerPass
+{
+    /**
+     * Get collector service name.
+     *
+     * @return string Collector service name
+     */
+    public function getCollectorServiceName()
+    {
+        return 'elcodi.cart_coupon_applicator_function_collector';
+    }
+
+    /**
+     * Get collector method name.
+     *
+     * @return string Collector method name
+     */
+    public function getCollectorMethodName()
+    {
+        return 'addExpressionLanguageFunction';
+    }
+
+    /**
+     * Get tag name.
+     *
+     * @return string Tag name
+     */
+    public function getTagName()
+    {
+        return 'elcodi.cart_coupon_applicator_function';
+    }
+}

--- a/src/Elcodi/Bundle/CartCouponBundle/DependencyInjection/ElcodiCartCouponExtension.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/DependencyInjection/ElcodiCartCouponExtension.php
@@ -114,6 +114,7 @@ class ElcodiCartCouponExtension extends AbstractExtension implements EntitiesOve
             'eventDispatchers',
             'objectManagers',
             'directors',
+            'applicators',
         ];
     }
 

--- a/src/Elcodi/Bundle/CartCouponBundle/ElcodiCartCouponBundle.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/ElcodiCartCouponBundle.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+use Elcodi\Bundle\CartCouponBundle\CompilerPass\CartCouponApplicatorCompilerPass;
+use Elcodi\Bundle\CartCouponBundle\CompilerPass\CartCouponApplicatorFunctionCompilerPass;
 use Elcodi\Bundle\CartCouponBundle\CompilerPass\MappingCompilerPass;
 use Elcodi\Bundle\CartCouponBundle\DependencyInjection\ElcodiCartCouponExtension;
 use Elcodi\Bundle\CoreBundle\Abstracts\AbstractElcodiBundle;
@@ -39,6 +41,8 @@ class ElcodiCartCouponBundle extends AbstractElcodiBundle implements DependentBu
         parent::build($container);
 
         $container->addCompilerPass(new MappingCompilerPass());
+        $container->addCompilerPass(new CartCouponApplicatorCompilerPass());
+        $container->addCompilerPass(new CartCouponApplicatorFunctionCompilerPass());
     }
 
     /**

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/applicators.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/applicators.yml
@@ -1,0 +1,67 @@
+services:
+
+    #
+    # Applicators
+    #
+    elcodi.cart_coupon_applicator.absolute:
+        class: Elcodi\Component\CartCoupon\Applicator\AbsoluteCartCouponApplicator
+        arguments:
+            - '@elcodi.wrapper.currency'
+            - '@elcodi.converter.currency'
+        tags:
+            - { name: elcodi.cart_coupon_applicator }
+
+    elcodi.cart_coupon_applicator.mxn_abstract:
+        class: Elcodi\Component\CartCoupon\Applicator\Abstracts\AbstractMxNCartCouponApplicator
+        abstract: true
+        arguments:
+            - '@elcodi.wrapper.currency'
+            - '@elcodi.converter.currency'
+            - '@elcodi.cart_coupon_applicator_function_collector'
+
+    elcodi.cart_coupon_applicator.mxn_group:
+        class: Elcodi\Component\CartCoupon\Applicator\MxNGroupCartCouponApplicator
+        parent: elcodi.cart_coupon_applicator.mxn_abstract
+        tags:
+            - { name: elcodi.cart_coupon_applicator }
+
+    elcodi.cart_coupon_applicator.mxn_specific:
+        class: Elcodi\Component\CartCoupon\Applicator\MxNSpecificCartCouponApplicator
+        parent: elcodi.cart_coupon_applicator.mxn_abstract
+        tags:
+            - { name: elcodi.cart_coupon_applicator }
+
+    elcodi.cart_coupon_applicator.percent:
+        class: Elcodi\Component\CartCoupon\Applicator\PercentCartCouponApplicator
+        tags:
+            - { name: elcodi.cart_coupon_applicator }
+
+
+    elcodi.cart_coupon_applicator_collector:
+        class: Elcodi\Component\CartCoupon\Applicator\CartCouponApplicatorCollector
+        arguments:
+            - '@elcodi.wrapper.currency'
+
+    #
+    # Expression Language functions
+    #
+    elcodi.cart_coupon_applicator_function.category:
+        class: Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage\CategoryFunction
+        public: false
+        tags:
+            - { name: elcodi.cart_coupon_applicator_function }
+
+    elcodi.cart_coupon_applicator_function.manufacturer:
+        class: Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage\ManufacturerFunction
+        public: false
+        tags:
+            - { name: elcodi.cart_coupon_applicator_function }
+
+    elcodi.cart_coupon_applicator_function.product:
+        class: Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage\ProductFunction
+        public: false
+        tags:
+            - { name: elcodi.cart_coupon_applicator_function }
+
+    elcodi.cart_coupon_applicator_function_collector:
+        class: Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage\ExpressionLanguageFunctionCollector

--- a/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
+++ b/src/Elcodi/Bundle/CartCouponBundle/Resources/config/services.yml
@@ -34,7 +34,7 @@ services:
         arguments:
             - '@elcodi.manager.cart_coupon'
             - '@elcodi.wrapper.currency'
-            - '@elcodi.converter.currency'
+            - '@elcodi.cart_coupon_applicator_collector'
 
     #
     # Validator

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Applicator/AbsoluteCartCouponApplicatorTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Applicator/AbsoluteCartCouponApplicatorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CartCouponBundle\Tests\Functional\Applicator;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class AbsoluteCartCouponApplicatorTest.
+ */
+class AbsoluteCartCouponApplicatorTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCartBundle',
+            'ElcodiCouponBundle',
+            'ElcodiProductBundle',
+            'ElcodiCurrencyBundle',
+        ];
+    }
+
+    /**
+     * Test getCouponAbsoluteValue.
+     *
+     * @dataProvider dataGetCouponAbsoluteValue
+     */
+    public function testGetCouponAbsoluteValue(
+        $value,
+        $result
+    ) {
+        $this->reloadScenario();
+
+        $cart = $this->find('cart', 2);
+        $this
+            ->get('elcodi.event_dispatcher.cart')
+            ->dispatchCartLoadEvents($cart);
+
+        $this
+            ->get('elcodi.manager.cart')
+            ->addPurchasable(
+                $cart,
+                $this->find('product', 3),
+                4
+            );
+
+        $this
+            ->get('elcodi.manager.cart')
+            ->addPurchasable(
+                $cart,
+                $this->find('product_variant', 3),
+                2
+            );
+
+        $this
+            ->get('elcodi.manager.cart')
+            ->addPurchasable(
+                $cart,
+                $this->find('product_pack', 1),
+                3
+            );
+
+        $coupon = $this
+            ->getRepository('coupon')
+            ->findOneBy(
+                ['code' => '2x1category1']
+            );
+
+        $coupon->setValue($value);
+        $this
+            ->get('elcodi.manager.cart_coupon')
+            ->addCoupon(
+                $cart,
+                $coupon
+            );
+
+        $this->assertEquals(
+            $result,
+            $cart->getAmount()->getAmount()
+        );
+    }
+
+    /**
+     * Data for testGetCouponAbsoluteValue.
+     */
+    public function dataGetCouponAbsoluteValue()
+    {
+        return [
+
+            // Specific scenarios
+            ['2x1', 15000],
+            ['2x1:m(1)&c(2)&p(3)', 21500],
+            ['2x1:m(1)&c(2)&p(3):P', 23000],
+            ['2x1:m(1)&c(2)&p(3):V', 23500],
+            ['2x1:m(1)&c(2)&p(3):K', 25000],
+            ['2x1:p(1):P', 24000],
+            ['2x1:p(1):K', 20000],
+            ['2x1:c(1)', 25000],
+            ['2x1:c(2)', 15500],
+            ['3x2:c(2)', 19000],
+            ['10x1:c(2)', 9500],
+            ['4x3:c(2)', 24000],
+            ['2x1::V', 23500],
+
+            // Group scenarios (with G modifier)
+            ['2x1:m(1)&c(2)&p(3):G', 22000],
+            ['2x1:m(1)&c(2)&p(3):PG', 23000],
+            ['2x1:m(1)&c(2)&p(3):VG', 23500],
+            ['2x1:m(1)&c(2)&p(3):KG', 25000],
+            ['2x1:p(1):PG', 24000],
+            ['2x1:p(1):KG', 20000],
+            ['2x1:c(1):G', 25000],
+            ['2x1:c(2):G', 20000],
+            ['3x2:c(2):G', 22000],
+            ['10x1:c(2):G', 11000],
+            ['10x2:c(2):G', 16000],
+            ['10x2:c(2):VG', 23500],
+            ['2x1::VG', 23500],
+        ];
+    }
+}

--- a/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Applicator/MxNCartCouponApplicatorTest.php
+++ b/src/Elcodi/Bundle/CartCouponBundle/Tests/Functional/Applicator/MxNCartCouponApplicatorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Bundle\CartCouponBundle\Tests\Functional\Applicator;
+
+use Elcodi\Bundle\TestCommonBundle\Functional\WebTestCase;
+
+/**
+ * Class MxNCartCouponApplicatorTest.
+ */
+class MxNCartCouponApplicatorTest extends WebTestCase
+{
+    /**
+     * Load fixtures of these bundles.
+     *
+     * @return array Bundles name where fixtures should be found
+     */
+    protected static function loadFixturesBundles()
+    {
+        return [
+            'ElcodiCartBundle',
+            'ElcodiCouponBundle',
+            'ElcodiProductBundle',
+            'ElcodiCurrencyBundle',
+        ];
+    }
+
+    /**
+     * Test getCouponAbsoluteValue.
+     *
+     * @dataProvider dataGetCouponAbsoluteValue
+     */
+    public function testGetCouponAbsoluteValue(
+        $value,
+        $result
+    ) {
+        $this->reloadScenario();
+
+        $cart = $this->find('cart', 2);
+        $this
+            ->get('elcodi.event_dispatcher.cart')
+            ->dispatchCartLoadEvents($cart);
+
+        $this
+            ->get('elcodi.manager.cart')
+            ->addPurchasable(
+                $cart,
+                $this->find('product', 3),
+                4
+            );
+
+        $this
+            ->get('elcodi.manager.cart')
+            ->addPurchasable(
+                $cart,
+                $this->find('product_variant', 3),
+                2
+            );
+
+        $this
+            ->get('elcodi.manager.cart')
+            ->addPurchasable(
+                $cart,
+                $this->find('product_pack', 1),
+                3
+            );
+
+        $coupon = $this
+            ->getRepository('coupon')
+            ->findOneBy(
+                ['code' => '2x1category1']
+            );
+
+        $coupon->setValue($value);
+        $this
+            ->get('elcodi.manager.cart_coupon')
+            ->addCoupon(
+                $cart,
+                $coupon
+            );
+
+        $this->assertEquals(
+            $result,
+            $cart->getAmount()->getAmount()
+        );
+    }
+
+    /**
+     * Data for testGetCouponAbsoluteValue.
+     */
+    public function dataGetCouponAbsoluteValue()
+    {
+        return [
+
+            // Specific scenarios
+            ['2x1', 15000],
+            ['2x1:m(1)&c(2)&p(3)', 21500],
+            ['2x1:m(1)&c(2)&p(3):P', 23000],
+            ['2x1:m(1)&c(2)&p(3):V', 23500],
+            ['2x1:m(1)&c(2)&p(3):K', 25000],
+            ['2x1:p(1):P', 24000],
+            ['2x1:p(1):K', 20000],
+            ['2x1:c(1)', 25000],
+            ['2x1:c(2)', 15500],
+            ['3x2:c(2)', 19000],
+            ['10x1:c(2)', 9500],
+            ['4x3:c(2)', 24000],
+            ['2x1::V', 23500],
+
+            // Group scenarios (with G modifier)
+            ['2x1:m(1)&c(2)&p(3):G', 22000],
+            ['2x1:m(1)&c(2)&p(3):PG', 23000],
+            ['2x1:m(1)&c(2)&p(3):VG', 23500],
+            ['2x1:m(1)&c(2)&p(3):KG', 25000],
+            ['2x1:p(1):PG', 24000],
+            ['2x1:p(1):KG', 20000],
+            ['2x1:c(1):G', 25000],
+            ['2x1:c(2):G', 20000],
+            ['3x2:c(2):G', 22000],
+            ['10x1:c(2):G', 11000],
+            ['10x2:c(2):G', 16000],
+            ['10x2:c(2):VG', 23500],
+            ['2x1::VG', 23500],
+        ];
+    }
+}

--- a/src/Elcodi/Bundle/CouponBundle/DataFixtures/ORM/CouponData.php
+++ b/src/Elcodi/Bundle/CouponBundle/DataFixtures/ORM/CouponData.php
@@ -22,8 +22,10 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
 use Elcodi\Bundle\CoreBundle\DataFixtures\ORM\Abstracts\AbstractFixture;
+use Elcodi\Component\CartCoupon\Applicator\AbsoluteCartCouponApplicator;
+use Elcodi\Component\CartCoupon\Applicator\Abstracts\AbstractMxNCartCouponApplicator;
+use Elcodi\Component\CartCoupon\Applicator\PercentCartCouponApplicator;
 use Elcodi\Component\Core\Services\ObjectDirector;
-use Elcodi\Component\Coupon\ElcodiCouponTypes;
 use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
 use Elcodi\Component\Currency\Entity\Interfaces\CurrencyInterface;
 use Elcodi\Component\Currency\Entity\Money;
@@ -60,7 +62,7 @@ class CouponData extends AbstractFixture implements DependentFixtureInterface
             ->create()
             ->setCode('percent')
             ->setName('10 percent discount')
-            ->setType(ElcodiCouponTypes::TYPE_PERCENT)
+            ->setType(PercentCartCouponApplicator::id())
             ->setDiscount(12)
             ->setCount(100)
             ->setValidFrom(new DateTime())
@@ -86,7 +88,7 @@ class CouponData extends AbstractFixture implements DependentFixtureInterface
             ->create()
             ->setCode('amount')
             ->setName('5 USD discount')
-            ->setType(ElcodiCouponTypes::TYPE_AMOUNT)
+            ->setType(AbsoluteCartCouponApplicator::id())
             ->setPrice(Money::create(500, $currency))
             ->setCount(20)
             ->setValidFrom(new DateTime());
@@ -108,7 +110,7 @@ class CouponData extends AbstractFixture implements DependentFixtureInterface
             ->create()
             ->setCode('stackable-percent')
             ->setName('12 percent discount - stackable')
-            ->setType(ElcodiCouponTypes::TYPE_PERCENT)
+            ->setType(PercentCartCouponApplicator::id())
             ->setDiscount(12)
             ->setCount(100)
             ->setStackable(true)
@@ -134,13 +136,38 @@ class CouponData extends AbstractFixture implements DependentFixtureInterface
             ->create()
             ->setCode('stackable-amount')
             ->setName('2 USD discount - stackable')
-            ->setType(ElcodiCouponTypes::TYPE_AMOUNT)
+            ->setType(AbsoluteCartCouponApplicator::id())
             ->setPrice(Money::create(200, $currency))
             ->setCount(20)
             ->setStackable(true)
             ->setValidFrom(new DateTime());
         $couponDirector->save($stackableCouponAmount);
         $this->addReference('stackable-coupon-amount', $stackableCouponAmount);
+
+        /**
+         * Coupon MxN. Valid for products with category 1.
+         *
+         * Valid from now without expire time
+         *
+         * Customer only can redeem it n times in all life
+         *
+         * Only 20 available
+         *
+         * Prices are stored in cents. @see \Elcodi\Component\Currency\Entity\Money
+         *
+         * @var CouponInterface $couponAmount
+         */
+        $coupon2x1Category1 = $couponDirector
+            ->create()
+            ->setCode('2x1category1')
+            ->setEnabled(true)
+            ->setName('2x1 in products from category1')
+            ->setType(AbstractMxNCartCouponApplicator::id())
+            ->setValue('2x1:cat(1):P')
+            ->setCount(20)
+            ->setValidFrom(new DateTime());
+        $couponDirector->save($coupon2x1Category1);
+        $this->addReference('coupon-2x1-category1', $coupon2x1Category1);
     }
 
     /**

--- a/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
+++ b/src/Elcodi/Bundle/CouponBundle/Resources/config/doctrine/Coupon.orm.yml
@@ -33,6 +33,11 @@ Elcodi\Component\Coupon\Entity\Coupon:
         discount:
             column: discount
             type: integer
+        value:
+            column: value
+            type: string
+            length: 255
+            nullable: true
         count:
             column: count
             type: integer

--- a/src/Elcodi/Component/CartCoupon/Applicator/AbsoluteCartCouponApplicator.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/AbsoluteCartCouponApplicator.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator;
+
+use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
+use Elcodi\Component\CartCoupon\Applicator\Interfaces\CartCouponApplicatorInterface;
+use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
+use Elcodi\Component\Currency\Services\CurrencyConverter;
+use Elcodi\Component\Currency\Wrapper\CurrencyWrapper;
+
+/**
+ * Class AbsoluteCartCouponApplicator.
+ */
+class AbsoluteCartCouponApplicator implements CartCouponApplicatorInterface
+{
+    /**
+     * @var CurrencyWrapper
+     *
+     * Currency Wrapper
+     */
+    private $currencyWrapper;
+
+    /**
+     * @var CurrencyConverter
+     *
+     * Currency converter
+     */
+    private $currencyConverter;
+
+    /**
+     * Construct method.
+     *
+     * @param CurrencyWrapper   $currencyWrapper   Currency wrapper
+     * @param CurrencyConverter $currencyConverter Currency converter
+     */
+    public function __construct(
+        CurrencyWrapper $currencyWrapper,
+        CurrencyConverter $currencyConverter
+    ) {
+        $this->currencyWrapper = $currencyWrapper;
+        $this->currencyConverter = $currencyConverter;
+    }
+
+    /**
+     * Get the id of the Applicator.
+     *
+     * @return string Applicator id
+     */
+    public static function id()
+    {
+        return 1;
+    }
+
+    /**
+     * Can be applied.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return bool Can be applied
+     */
+    public function canBeApplied(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        return $coupon->getType() === self::id();
+    }
+
+    /**
+     * Calculate coupon absolute value.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return MoneyInterface|false Absolute value for this coupon in this cart
+     */
+    public function getCouponAbsoluteValue(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        $currency = $this
+            ->currencyWrapper
+            ->get();
+
+        $amount = $coupon->getPrice();
+
+        return $this
+            ->currencyConverter
+            ->convertMoney(
+                $amount,
+                $currency
+            );
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/Abstracts/AbstractMxNCartCouponApplicator.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/Abstracts/AbstractMxNCartCouponApplicator.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator\Abstracts;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
+use Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage\ExpressionLanguageFunctionCollector;
+use Elcodi\Component\CartCoupon\Applicator\Interfaces\CartCouponApplicatorInterface;
+use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Services\CurrencyConverter;
+use Elcodi\Component\Currency\Wrapper\CurrencyWrapper;
+use Elcodi\Component\Product\Entity\Interfaces\PackInterface;
+use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
+use Elcodi\Component\Product\Entity\Interfaces\PurchasableInterface;
+use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
+
+/**
+ * Class AbstractMxNCartCouponApplicator.
+ */
+abstract class AbstractMxNCartCouponApplicator implements CartCouponApplicatorInterface
+{
+    /**
+     * @var CurrencyWrapper
+     *
+     * Currency Wrapper
+     */
+    protected $currencyWrapper;
+
+    /**
+     * @var CurrencyConverter
+     *
+     * Currency converter
+     */
+    protected $currencyConverter;
+
+    /**
+     * @var ExpressionLanguageFunctionCollector
+     *
+     * ExpressionLanguageFunction collector
+     */
+    protected $expressionLanguageFunctionCollector;
+
+    /**
+     * Construct method.
+     *
+     * @param CurrencyWrapper                     $currencyWrapper                     Currency wrapper
+     * @param CurrencyConverter                   $currencyConverter                   Currency converter
+     * @param ExpressionLanguageFunctionCollector $expressionLanguageFunctionCollector ExpressionLanguageFunction collector
+     */
+    public function __construct(
+        CurrencyWrapper $currencyWrapper,
+        CurrencyConverter $currencyConverter,
+        ExpressionLanguageFunctionCollector $expressionLanguageFunctionCollector
+    ) {
+        $this->currencyWrapper = $currencyWrapper;
+        $this->currencyConverter = $currencyConverter;
+        $this->expressionLanguageFunctionCollector = $expressionLanguageFunctionCollector;
+    }
+
+    /**
+     * Get the id of the Applicator.
+     *
+     * @return string Applicator id
+     */
+    public static function id()
+    {
+        return 3;
+    }
+
+    /**
+     * Can be applied.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return bool Can be applied
+     */
+    public function canBeApplied(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        return
+            $coupon->getType() === self::id() &&
+            1 === preg_match($this->regexp(), $coupon->getValue());
+    }
+
+    /**
+     * Get the regular expression.
+     *
+     * @return string Regular Expression
+     */
+    abstract public function regexp();
+
+    /**
+     * Get expression language instance.
+     *
+     * @return ExpressionLanguage
+     */
+    protected function getExpressionLanguageInstance()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+
+        $this
+            ->expressionLanguageFunctionCollector
+            ->registerFunction($expressionLanguage);
+
+        return $expressionLanguage;
+    }
+
+    /**
+     * Evaluate purchasables.
+     */
+    protected function evaluatePurchasableType(
+        PurchasableInterface $purchasable,
+        $modifiers
+    ) {
+        if (empty($modifiers)) {
+            return true;
+        }
+
+        if (
+            false === strpos($modifiers, 'P') &&
+            false === strpos($modifiers, 'V') &&
+            false === strpos($modifiers, 'K')
+        ) {
+            return true;
+        }
+
+        if (
+            $purchasable instanceof ProductInterface &&
+            false !== strpos($modifiers, 'P')
+        ) {
+            return true;
+        }
+
+        if (
+            $purchasable instanceof VariantInterface &&
+            false !== strpos($modifiers, 'V')
+        ) {
+            return true;
+        }
+
+        if (
+            $purchasable instanceof PackInterface &&
+            false !== strpos($modifiers, 'K')
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/CartCouponApplicatorCollector.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/CartCouponApplicatorCollector.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator;
+
+use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
+use Elcodi\Component\CartCoupon\Applicator\Interfaces\CartCouponApplicatorInterface;
+use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
+use Elcodi\Component\Currency\Entity\Money;
+use Elcodi\Component\Currency\Wrapper\CurrencyWrapper;
+
+/**
+ * Class CartCouponApplicatorCollector.
+ */
+class CartCouponApplicatorCollector
+{
+    /**
+     * @var CartCouponApplicatorInterface[]
+     *
+     * Cart Coupon Applicators
+     */
+    private $cartCouponApplicators = [];
+
+    /**
+     * @var CurrencyWrapper
+     *
+     * Currency Wrapper
+     */
+    private $currencyWrapper;
+
+    /**
+     * Construct method.
+     *
+     * @param CurrencyWrapper $currencyWrapper Currency wrapper
+     */
+    public function __construct(CurrencyWrapper $currencyWrapper)
+    {
+        $this->currencyWrapper = $currencyWrapper;
+    }
+
+    /**
+     * Add Cart Coupon Applicator.
+     *
+     * @param CartCouponApplicatorInterface $cartCouponApplicator Cart Coupon Applicator
+     */
+    public function addCartCouponApplicator(CartCouponApplicatorInterface $cartCouponApplicator)
+    {
+        $this->cartCouponApplicators[] = $cartCouponApplicator;
+    }
+
+    /**
+     * Calculate coupon absolute value.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return MoneyInterface Absolute value for this coupon in this cart
+     */
+    public function getCouponAbsoluteValue(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        $currency = $this
+            ->currencyWrapper
+            ->get();
+
+        $couponPrice = Money::create(
+            0,
+            $currency
+        );
+
+        foreach ($this->cartCouponApplicators as $cartCouponApplicator) {
+            if ($cartCouponApplicator->canBeApplied(
+                $cart,
+                $coupon
+            )) {
+                return $cartCouponApplicator->getCouponAbsoluteValue(
+                    $cart,
+                    $coupon
+                );
+            }
+        }
+
+        return $couponPrice;
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/CategoryFunction.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/CategoryFunction.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+use Elcodi\Component\Product\Entity\Interfaces\CategoryInterface;
+
+/**
+ * Class CategoryFunction.
+ */
+class CategoryFunction implements ExpressionLanguageFunctionInterface
+{
+    /**
+     * Register function.
+     *
+     * @param ExpressionLanguage $expressionLanguage Expression language
+     */
+    public function registerFunction(ExpressionLanguage $expressionLanguage)
+    {
+        $expressionLanguage->register('c', function ($ids) {
+            return sprintf('(c(%1$s))', $ids);
+        }, function ($arguments, $ids) {
+            $ids = explode(',', $ids);
+            $purchasable = $arguments['purchasable'];
+
+            $categoryIds = $purchasable
+                ->getCategories()
+                ->map(function (CategoryInterface $category) {
+                    return $category->getId();
+                })
+                ->toArray();
+
+            $intersection = array_intersect(
+                $categoryIds,
+                $ids
+            );
+
+            return !empty($intersection);
+        });
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ExpressionLanguageFunctionCollector.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ExpressionLanguageFunctionCollector.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * Class ExpressionLanguageFunctionCollector.
+ */
+class ExpressionLanguageFunctionCollector
+{
+    /**
+     * @var ExpressionLanguageFunctionInterface[]
+     *
+     * Expression Language functions
+     */
+    private $expressionLanguageFunctions = [];
+
+    /**
+     * Add a new ExpressionLanguageFunctionInterface.
+     *
+     * @param ExpressionLanguageFunctionInterface $expressionLanguageFunction Expression Language functions
+     */
+    public function addExpressionLanguageFunction(ExpressionLanguageFunctionInterface $expressionLanguageFunction)
+    {
+        $this->expressionLanguageFunctions[] = $expressionLanguageFunction;
+    }
+
+    /**
+     * Register function.
+     *
+     * @param ExpressionLanguage $expressionLanguage Expression language
+     */
+    public function registerFunction(ExpressionLanguage $expressionLanguage)
+    {
+        foreach ($this->expressionLanguageFunctions as $expressionLanguageFunction) {
+            $expressionLanguageFunction->registerFunction($expressionLanguage);
+        }
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ExpressionLanguageFunctionInterface.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ExpressionLanguageFunctionInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * Interface ExpressionLanguageFunctionInterface.
+ */
+interface ExpressionLanguageFunctionInterface
+{
+    /**
+     * Register function.
+     *
+     * @param ExpressionLanguage $expressionLanguage Expression language
+     */
+    public function registerFunction(ExpressionLanguage $expressionLanguage);
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ManufacturerFunction.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ManufacturerFunction.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+use Elcodi\Component\Product\Entity\Interfaces\ManufacturerInterface;
+
+/**
+ * Class ManufacturerFunction.
+ */
+class ManufacturerFunction implements ExpressionLanguageFunctionInterface
+{
+    /**
+     * Register function.
+     *
+     * @param ExpressionLanguage $expressionLanguage Expression language
+     */
+    public function registerFunction(ExpressionLanguage $expressionLanguage)
+    {
+        $expressionLanguage->register('m', function ($ids) {
+            return sprintf('(purchasable.manufacturer.id in [%1$s])', $ids);
+        }, function ($arguments, $ids) {
+            $ids = explode(',', $ids);
+            $purchasable = $arguments['purchasable'];
+            $manufacturer = $purchasable->getManufacturer();
+
+            if (!$manufacturer instanceof ManufacturerInterface) {
+                return false;
+            }
+
+            return in_array(
+                $manufacturer->getId(),
+                $ids
+            );
+        });
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ProductFunction.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/ExpressionLanguage/ProductFunction.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * Class ProductFunction.
+ */
+class ProductFunction implements ExpressionLanguageFunctionInterface
+{
+    /**
+     * Register function.
+     *
+     * @param ExpressionLanguage $expressionLanguage Expression language
+     */
+    public function registerFunction(ExpressionLanguage $expressionLanguage)
+    {
+        $expressionLanguage->register('p', function ($ids) {
+            return sprintf('(purchasable.id in [%1$s])', $ids);
+        }, function ($arguments, $ids) {
+            $ids = explode(',', $ids);
+            $purchasable = $arguments['purchasable'];
+
+            return in_array(
+                $purchasable->getId(),
+                $ids
+            );
+        });
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/Interfaces/CartCouponApplicatorInterface.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/Interfaces/CartCouponApplicatorInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator\Interfaces;
+
+use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
+use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
+
+/**
+ * Interface CartCouponApplicatorInterface.
+ */
+interface CartCouponApplicatorInterface
+{
+    /**
+     * Get the id of the Applicator.
+     *
+     * @return string Applicator id
+     */
+    public static function id();
+
+    /**
+     * Can be applied.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return bool Can be applied
+     */
+    public function canBeApplied(
+        CartInterface $cart,
+        CouponInterface $coupon
+    );
+
+    /**
+     * Calculate coupon absolute value.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return MoneyInterface|false Absolute value for this coupon in this cart.
+     */
+    public function getCouponAbsoluteValue(
+        CartInterface $cart,
+        CouponInterface $coupon
+    );
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/MxNGroupCartCouponApplicator.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/MxNGroupCartCouponApplicator.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator;
+
+use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
+use Elcodi\Component\CartCoupon\Applicator\Abstracts\AbstractMxNCartCouponApplicator;
+use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
+use Elcodi\Component\Currency\Entity\Money;
+
+/**
+ * Class MxNGroupCartCouponApplicator.
+ */
+class MxNGroupCartCouponApplicator extends AbstractMxNCartCouponApplicator
+{
+    /**
+     * Get the regular expression.
+     *
+     * @return string Regular Expression
+     */
+    public function regexp()
+    {
+        return '~^(?:([1-9]\d*)x([1-9]\d*))(?::([^:]*))?(?::((?=.*[G])[A-Z]+))$~';
+    }
+
+    /**
+     * Calculate coupon absolute value.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return MoneyInterface|false Absolute value for this coupon in this cart
+     */
+    public function getCouponAbsoluteValue(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        $currency = $this
+            ->currencyWrapper
+            ->get();
+
+        $couponPrice = Money::create(
+            0,
+            $currency
+        );
+
+        $value = $coupon->getValue();
+        preg_match($this->regexp(), $value, $match);
+        $m = (int) $match[1];
+        $n = (int) $match[2];
+        $expressionValue = isset($match[3]) ? $match[3] : '';
+        $modifiers = isset($match[4]) ? $match[4] : '';
+
+        $totalElements = 0;
+        $moneys = [];
+        $freePerGroup = $m - $n;
+        $freePerGroup = max($freePerGroup, 0);
+
+        foreach ($cart->getCartLines() as $cartLine) {
+            $purchasable = $cartLine->getPurchasable();
+            $expressionEvaluator = $this->getExpressionLanguageInstance();
+            $expressionResult =
+                (
+                    empty($expressionValue) ||
+                    $expressionEvaluator->evaluate($expressionValue, [
+                        'purchasable' => $purchasable,
+                    ])
+                ) &&
+                $this->evaluatePurchasableType($purchasable, $modifiers);
+
+            if (true === $expressionResult) {
+                $partialElements = $cartLine->getQuantity();
+                $totalElements += $partialElements;
+                for ($i = 0; $i < $partialElements; ++$i) {
+                    $partialPurchasable = $cartLine->getPurchasable();
+                    $moneys[] = $partialPurchasable->getReducedPrice()->getAmount() > 0
+                        ? $partialPurchasable->getReducedPrice()
+                        : $partialPurchasable->getPrice();
+                }
+            }
+        }
+
+        usort($moneys, function (MoneyInterface $a, MoneyInterface $b) {
+            $aCurrency = $a->getCurrency();
+            $bPriceInACurrency = $this
+                ->currencyConverter
+                ->convertMoney(
+                    $b,
+                    $aCurrency
+                );
+
+            return $a->isGreaterThan($bPriceInACurrency)
+                ? 1
+                : -1;
+        });
+
+        $groups = $totalElements / $m;
+        if ($groups > 0) {
+            $nbMoneys = $groups * $freePerGroup;
+            $moneysToDiscount = array_slice($moneys, 0, $nbMoneys);
+
+            foreach ($moneysToDiscount as $moneyToDiscount) {
+                $couponPrice = $couponPrice->add(
+                    $this
+                        ->currencyConverter
+                        ->convertMoney(
+                            $moneyToDiscount,
+                            $currency
+                        )
+                );
+            }
+        }
+
+        return $couponPrice;
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/MxNSpecificCartCouponApplicator.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/MxNSpecificCartCouponApplicator.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator;
+
+use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
+use Elcodi\Component\CartCoupon\Applicator\Abstracts\AbstractMxNCartCouponApplicator;
+use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
+use Elcodi\Component\Currency\Entity\Money;
+
+/**
+ * Class MxNSpecificCartCouponApplicator.
+ */
+class MxNSpecificCartCouponApplicator extends AbstractMxNCartCouponApplicator
+{
+    /**
+     * Get the regular expression.
+     *
+     * @return string Regular Expression
+     */
+    public function regexp()
+    {
+        return '~^(?:([1-9]\d*)x([1-9]\d*))(?::([^:]*))?(?::((?!.*[G])[A-Z]+))?$~';
+    }
+
+    /**
+     * Calculate coupon absolute value.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return MoneyInterface|false Absolute value for this coupon in this cart
+     */
+    public function getCouponAbsoluteValue(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        $currency = $this
+            ->currencyWrapper
+            ->get();
+
+        $couponPrice = Money::create(
+            0,
+            $currency
+        );
+
+        $value = $coupon->getValue();
+        preg_match($this->regexp(), $value, $match);
+        $m = (int) $match[1];
+        $n = (int) $match[2];
+        $expressionValue = isset($match[3]) ? $match[3] : '';
+        $modifiers = isset($match[4]) ? $match[4] : '';
+
+        $freePerGroup = $m - $n;
+        $freePerGroup = max($freePerGroup, 0);
+
+        foreach ($cart->getCartLines() as $cartLine) {
+            $moneys = [];
+            $purchasable = $cartLine->getPurchasable();
+            $expressionEvaluator = $this->getExpressionLanguageInstance();
+            $expressionResult =
+                (
+                    empty($expressionValue) ||
+                    $expressionEvaluator->evaluate($expressionValue, [
+                        'purchasable' => $purchasable,
+                    ])
+                ) &&
+                $this->evaluatePurchasableType($purchasable, $modifiers);
+
+            if (true === $expressionResult) {
+                $partialElements = $cartLine->getQuantity();
+                for ($i = 0; $i < $partialElements; ++$i) {
+                    $partialPurchasable = $cartLine->getPurchasable();
+                    $moneys[] = $partialPurchasable->getReducedPrice()->getAmount() > 0
+                        ? $partialPurchasable->getReducedPrice()
+                        : $partialPurchasable->getPrice();
+                }
+
+                $groups = $partialElements / $m;
+                if ($groups > 0) {
+                    $nbMoneys = $groups * $freePerGroup;
+                    $moneysToDiscount = array_slice($moneys, 0, $nbMoneys);
+
+                    foreach ($moneysToDiscount as $moneyToDiscount) {
+                        $couponPrice = $couponPrice->add(
+                            $this
+                                ->currencyConverter
+                                ->convertMoney(
+                                    $moneyToDiscount,
+                                    $currency
+                                )
+                        );
+                    }
+                }
+            }
+        }
+
+        return $couponPrice;
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/Applicator/PercentCartCouponApplicator.php
+++ b/src/Elcodi/Component/CartCoupon/Applicator/PercentCartCouponApplicator.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2016 Elcodi Networks S.L.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\CartCoupon\Applicator;
+
+use Elcodi\Component\Cart\Entity\Interfaces\CartInterface;
+use Elcodi\Component\CartCoupon\Applicator\Interfaces\CartCouponApplicatorInterface;
+use Elcodi\Component\Coupon\Entity\Interfaces\CouponInterface;
+use Elcodi\Component\Currency\Entity\Interfaces\MoneyInterface;
+
+/**
+ * Class PercentCartCouponApplicator.
+ */
+class PercentCartCouponApplicator implements CartCouponApplicatorInterface
+{
+    /**
+     * Get the id of the Applicator.
+     *
+     * @return string Applicator id
+     */
+    public static function id()
+    {
+        return 2;
+    }
+
+    /**
+     * Can be applied.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return bool Can be applied
+     */
+    public function canBeApplied(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        return $coupon->getType() === self::id();
+    }
+
+    /**
+     * Calculate coupon absolute value.
+     *
+     * @param CartInterface   $cart   Cart
+     * @param CouponInterface $coupon Coupon
+     *
+     * @return MoneyInterface|false Absolute value for this coupon in this cart.
+     */
+    public function getCouponAbsoluteValue(
+        CartInterface $cart,
+        CouponInterface $coupon
+    ) {
+        $couponPercent = $coupon->getDiscount();
+
+        return $cart
+            ->getProductAmount()
+            ->multiply($couponPercent / 100);
+    }
+}

--- a/src/Elcodi/Component/CartCoupon/composer.json
+++ b/src/Elcodi/Component/CartCoupon/composer.json
@@ -36,6 +36,7 @@
         "doctrine/common": "^2.5",
         "doctrine/orm": "^2.5",
         "symfony/event-dispatcher": "^2.7|^3.0",
+        "symfony/expression-language": "^2.7|^3.0",
 
         "elcodi/core": "^1.0",
         "elcodi/cart": "^1.0",

--- a/src/Elcodi/Component/Coupon/Entity/Coupon.php
+++ b/src/Elcodi/Component/Coupon/Entity/Coupon.php
@@ -101,6 +101,13 @@ class Coupon implements CouponInterface
     protected $absolutePriceCurrency;
 
     /**
+     * @var string
+     *
+     * Plain value
+     */
+    protected $value;
+
+    /**
      * @var int
      *
      * Count
@@ -323,6 +330,30 @@ class Coupon implements CouponInterface
             $this->absolutePriceAmount,
             $this->absolutePriceCurrency
         );
+    }
+
+    /**
+     * Get Value.
+     *
+     * @return string Value
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets Value.
+     *
+     * @param string $value Value
+     *
+     * @return $this Self object
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
     }
 
     /**

--- a/src/Elcodi/Component/Coupon/Entity/Interfaces/CouponInterface.php
+++ b/src/Elcodi/Component/Coupon/Entity/Interfaces/CouponInterface.php
@@ -153,6 +153,22 @@ interface CouponInterface
     public function getAbsolutePrice();
 
     /**
+     * Get Value.
+     *
+     * @return string Value
+     */
+    public function getValue();
+
+    /**
+     * Sets Value.
+     *
+     * @param string $value Value
+     *
+     * @return $this Self object
+     */
+    public function setValue($value);
+
+    /**
      * Set count.
      *
      * @param int $count

--- a/src/Elcodi/Component/Coupon/Services/CouponManager.php
+++ b/src/Elcodi/Component/Coupon/Services/CouponManager.php
@@ -131,6 +131,7 @@ class CouponManager
             ->setMinimumPurchase($coupon->getMinimumPurchase())
             ->setValidFrom($dateFrom)
             ->setValidTo($dateTo)
+            ->setValue($coupon->getValue())
             ->setRule($coupon->getRule())
             ->setEnforcement($coupon->getEnforcement())
             ->setEnabled(true);

--- a/src/Elcodi/Component/Product/Entity/Interfaces/VariantInterface.php
+++ b/src/Elcodi/Component/Product/Entity/Interfaces/VariantInterface.php
@@ -86,4 +86,25 @@ interface VariantInterface
      * @return $this Self object
      */
     public function removeOption(ValueInterface $option);
+
+    /**
+     * Get categories.
+     *
+     * @return Collection Categories
+     */
+    public function getCategories();
+
+    /**
+     * Get the principalCategory.
+     *
+     * @return CategoryInterface Principal category
+     */
+    public function getPrincipalCategory();
+
+    /**
+     * Product manufacturer.
+     *
+     * @return ManufacturerInterface Manufacturer
+     */
+    public function getManufacturer();
 }

--- a/src/Elcodi/Component/Product/Entity/Variant.php
+++ b/src/Elcodi/Component/Product/Entity/Variant.php
@@ -25,6 +25,8 @@ use Elcodi\Component\Core\Entity\Traits\EnabledTrait;
 use Elcodi\Component\Core\Entity\Traits\IdentifiableTrait;
 use Elcodi\Component\Media\Entity\Traits\ImagesContainerTrait;
 use Elcodi\Component\Media\Entity\Traits\PrincipalImageTrait;
+use Elcodi\Component\Product\Entity\Interfaces\CategoryInterface;
+use Elcodi\Component\Product\Entity\Interfaces\ManufacturerInterface;
 use Elcodi\Component\Product\Entity\Interfaces\ProductInterface;
 use Elcodi\Component\Product\Entity\Interfaces\VariantInterface;
 use Elcodi\Component\Product\Entity\Traits\DimensionsTrait;
@@ -240,5 +242,41 @@ class Variant implements VariantInterface
         $this->product = $product;
 
         return $this;
+    }
+
+    /**
+     * Get categories.
+     *
+     * @return Collection Categories
+     */
+    public function getCategories()
+    {
+        return $this
+            ->product
+            ->getCategories();
+    }
+
+    /**
+     * Get the principalCategory.
+     *
+     * @return CategoryInterface Principal category
+     */
+    public function getPrincipalCategory()
+    {
+        return $this
+            ->product
+            ->getPrincipalCategory();
+    }
+
+    /**
+     * Product manufacturer.
+     *
+     * @return ManufacturerInterface Manufacturer
+     */
+    public function getManufacturer()
+    {
+        return $this
+            ->product
+            ->getManufacturer();
     }
 }


### PR DESCRIPTION
We have developed a coupons query language, a special query language for coupons design.
At the moment, only *NxM* coupons have been applied, and the query language only contains logic for
products, categories and manufacturers.

For example:

**3x2:p(13,34)|m(3)**

This means: buy 3, pay only 2, including all products of manufacturer 3 or products with id 13 and 34.
Here we have some extra examples

**2x1** - buy 2, pay 1, to all products
**4x3:c(13)** - buy 4, pay 3, to all products of category 13

This PR introduces as well modifiers. At the moment we have only 5 modifiers.
They can be combined.

**2x1:c(13):G**

*P* - Only products - When exists, only Products are applied
*V* - Only variants - When exists, only Variants are applied
*K* - Only packs - When exists, only Packs are applied
*G* - Group elements - When exists, coupons are applied to all elements matching the expression. This means that they are threated as the same
    element before applying the coupon. for example, if **2x1** for category 13 is applied with G modifier (**2x1:c(13):G**), all products, variants and packs with category 13 will match, they will be ordered from less expensive to more expensive, and the first half will be discounted. If the modifier is not introduced, all elements will be grouped by type and id and after this, **2x1** will be applied for each one.

If type modifiers are combined, then you can mix types

**2x1:c(13):PVG** - buy 2, pay 1, to all products with category 13 that are products, variants, grouping them all as one before applying.

This implementation is explicitely done for extension, with adapters and tags in Symfony DIC.

Documentation PR - https://github.com/elcodi/docs/pull/123
Documentation Web - http://elcodi.io/docs/book/coupon-architecture/#coupon-types