### PR TITLE
Make country option mandatory for all command scripts

### DIFF
--- a/src/Elcodi/Component/Geo/Command/LocationPopulateCommand.php
+++ b/src/Elcodi/Component/Geo/Command/LocationPopulateCommand.php
@@ -76,6 +76,8 @@ class LocationPopulateCommand extends AbstractLocationCommand
     {
         $this->startCommand($output, true);
         $countries = $input->getOption('country');
+        if (!$countries)
+            throw new \InvalidArgumentException("Specify country as argument eg: --country=FR" );        
 
         foreach ($countries as $countryCode) {
             $countryCode = strtoupper($countryCode);


### PR DESCRIPTION
1. Issue when command is executed "php app/console elcodi:locations:populate"
2. Made changes so that the above command throws an exception when --country  option is not specified...